### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy to Firebase Hosting on merge
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/LifeLoggerAI/UrAi/security/code-scanning/1](https://github.com/LifeLoggerAI/UrAi/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or to the specific job. The best way is to add it at the job level (under `build_and_deploy:`) or at the root of the workflow (before `jobs:`), specifying the least privileges required. For most deploy workflows, `contents: read` is sufficient unless the deploy action needs to write to the repository (e.g., updating deployment status, creating tags, etc.). Since the Firebase deploy action typically only needs to read the repository contents, start with `contents: read`. If you later encounter permission errors, you can adjust as needed.

Edit `.github/workflows/firebase-hosting-merge.yml` to add:

```yaml
permissions:
  contents: read
```

at the top level (after `name:` and before `on:`), or under the job if you want to scope it more tightly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
