### PR TITLE
feat: proxy export requests to cloud run

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,31 +1,45 @@
-import { NextResponse } from 'next/server';
-import { withApiAuth, type AuthenticatedRequest } from '@/lib/api-auth';
-import { db } from '@/lib/firebase-admin';
+import { NextResponse } from "next/server";
+import { withApiAuth, type AuthenticatedRequest } from "@/lib/api-auth";
 
-// This API route queues a new export job in Firestore.
-// The `exportWorker` Cloud Function will then pick it up.
+// Proxy POST requests to the Cloud Run exporter service. This allows local scripts
+// to simply call `/api/export` instead of talking to the exporter directly and
+// keeps Cloud Run credentials on the server.
+
+const EXPORTER_URL =
+  process.env.CLOUD_RUN_EXPORTER_URL || "http://localhost:8787/export";
+
 export const POST = withApiAuth(async (req: AuthenticatedRequest) => {
   try {
-    // 1. Get UID from the verified token, not the request body
-    const uid = req.user.uid;
+    const body = await req.json().catch(() => ({}));
 
-    // 2. Get the payload from the request
-    const payload = await req.json();
-    if (!payload.skyUrl || !payload.groundUrl) {
-      return NextResponse.json({ error: 'Missing required asset URLs' }, { status: 400 });
-    }
-
-    // 3. Write job to the 'exportQueue' collection
-    const jobRef = await db.collection('exportQueue').add({
-      uid, // Use the verified UID
-      status: 'queued',
-      createdAt: new Date(),
-      payload, // Contains skyUrl, groundUrl, overlayUrl, etc.
+    const response = await fetch(EXPORTER_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
     });
 
-    return NextResponse.json({ ok: true, jobId: jobRef.id });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      return NextResponse.json(
+        { ok: false, error: `Exporter error: ${response.status} ${text}` },
+        { status: response.status }
+      );
+    }
+
+    // Stream the MP4 (or other binary) result back to the client
+    const arrayBuffer = await response.arrayBuffer();
+    return new NextResponse(arrayBuffer, {
+      headers: {
+        "content-type":
+          response.headers.get("content-type") || "application/octet-stream",
+      },
+    });
   } catch (error: any) {
-    console.error('Error queuing export job:', error);
-    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: error?.message ?? "Unknown error" },
+      { status: 500 }
+    );
   }
 });


### PR DESCRIPTION
## Summary
- proxy `/api/export` to Cloud Run exporter service, returning the binary response

## Testing
- ⚠️ `npm test` *(failed: command not found: npm)*
- ⚠️ `apt-get update` *(failed: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be4fae04d88325a4fb7d404bce78ad