### PR TITLE
Add client directive and refine types for record page

### DIFF
--- a/src/app/record/page.tsx
+++ b/src/app/record/page.tsx
@@ -1,10 +1,12 @@
+'use client';
+
 import React from 'react';
 import Button from '../../components/ui/Button';
 
 export default function RecordPage() {
   const [isRecording, setIsRecording] = React.useState(false);
-  const [audioBlob, setAudioBlob] = React.useState(null);
-  const mediaRecorderRef = React.useRef(null);
+  const [audioBlob, setAudioBlob] = React.useState<Blob | null>(null);
+  const mediaRecorderRef = React.useRef<MediaRecorder | null>(null);
   const [transcription, setTranscription] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
 
@@ -14,9 +16,9 @@ export default function RecordPage() {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     const mediaRecorder = new MediaRecorder(stream);
     mediaRecorderRef.current = mediaRecorder;
-    const audioChunks = [];
+    const audioChunks: BlobPart[] = [];
 
-    mediaRecorder.ondataavailable = (event) => {
+    mediaRecorder.ondataavailable = (event: BlobEvent) => {
       audioChunks.push(event.data);
     };
 
@@ -30,7 +32,7 @@ export default function RecordPage() {
   };
 
   const handleStopRecording = () => {
-    mediaRecorderRef.current.stop();
+    mediaRecorderRef.current?.stop();
     setIsRecording(false);
   };
 


### PR DESCRIPTION
## Summary
- mark the record page as a client component to allow browser APIs
- tighten media recorder and audio blob typings for TypeScript safety

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d60209e1cc832590bb30adb4271599