### PR TITLE
Ensure onboarding page uses client-side navigation

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,12 +1,18 @@
+"use client";
+
 import React from 'react';
-import Button from '../components/ui/Button';
+import { useRouter } from 'next/navigation';
+
+import Button from '@/components/ui/Button';
 
 export default function OnboardingPage() {
+  const router = useRouter();
+
   return (
     <div className="h-screen flex flex-col items-center justify-center text-center bg-black text-white">
       <h1 className="text-4xl font-bold mb-4">URAI</h1>
       <p className="text-lg mb-8">Your Emotional Media OS</p>
-      <Button variant="primary" onClick={() => window.location.href='/home'}>
+      <Button variant="primary" onClick={() => router.push('/home')}>
         Get Started
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- mark the onboarding page as a client component so it can use browser APIs
- correct the Button import to use the shared UI component path
- switch the CTA to use the Next.js router for client-side navigation to /home

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d602169ed8832588e637b1719f60b7