### PR TITLE
Convert onboarding page to client component

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,12 +1,22 @@
+'use client';
+
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import Button from '../components/ui/Button';
 
 export default function OnboardingPage() {
+  const router = useRouter();
+
   return (
     <div className="h-screen flex flex-col items-center justify-center text-center bg-black text-white">
       <h1 className="text-4xl font-bold mb-4">URAI</h1>
       <p className="text-lg mb-8">Your Emotional Media OS</p>
-      <Button variant="primary" onClick={() => window.location.href='/home'}>
+      <Button
+        variant="primary"
+        onClick={() => {
+          router.push('/home');
+        }}
+      >
         Get Started
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- mark the onboarding page as a client component to enable event handling
- switch the onboarding button to use Next.js router navigation instead of window.location

## Testing
- `npm run lint` *(fails: ESLint v9 requires eslint.config.js in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d602c5d014832583066a6bf802f35f