### PR TITLE
Remove redundant layout wrapper from home page

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,33 +1,30 @@
 "use client";
 import React from 'react';
-import MainLayout from '@/components/layout/MainLayout';
 import Button from '@/components/ui/Button';
 import Chip from '@/components/ui/Chip';
 
 export default function HomePage() {
   return (
-    <MainLayout>
-      <div className="relative h-screen flex flex-col items-center justify-center text-center">
-        <div className="absolute top-0 left-0 right-0 p-4 flex justify-between items-center">
-          <span className="text-sm">Listening locally</span>
-          <Button variant="secondary">Local-Only</Button>
-        </div>
-
-        <div className="flex-grow flex flex-col items-center justify-center">
-          <div className="w-40 h-60 bg-white/10 rounded-full mb-4"></div>
-          <div className="w-16 h-16 bg-blue-500 rounded-full shadow-lg mb-8"></div>
-
-          <Button variant="primary" onClick={() => window.location.href='/life-map'}>
-            Tap the sky
-          </Button>
-        </div>
-
-        <div className="flex space-x-4 mb-24">
-          <Chip>Mirror</Chip>
-          <Chip>Narrator</Chip>
-          <Chip>Rituals</Chip>
-        </div>
+    <div className="relative flex min-h-screen flex-col items-center justify-center text-center">
+      <div className="absolute left-0 right-0 top-0 flex items-center justify-between p-4">
+        <span className="text-sm">Listening locally</span>
+        <Button variant="secondary">Local-Only</Button>
       </div>
-    </MainLayout>
+
+      <div className="flex flex-1 flex-col items-center justify-center">
+        <div className="mb-4 h-60 w-40 rounded-full bg-white/10"></div>
+        <div className="mb-8 h-16 w-16 rounded-full bg-blue-500 shadow-lg"></div>
+
+        <Button variant="primary" onClick={() => (window.location.href = '/life-map')}>
+          Tap the sky
+        </Button>
+      </div>
+
+      <div className="mb-24 flex space-x-4">
+        <Chip>Mirror</Chip>
+        <Chip>Narrator</Chip>
+        <Chip>Rituals</Chip>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the MainLayout wrapper from the home page so it relies on the shared layout
- adjust the home content container to maintain full-height flex behavior inside the shared shell

## Testing
- npm run dev *(fails: `next` binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d602bb86048325a2f6207f2c41f093