### PR TITLE
Adjust onboarding layout rendering

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,13 +6,11 @@ export const metadata = {
   description: 'Your Emotional Media OS',
 };
 
-export default function RootLayout({ children, ...props }) {
-  const isOnboarding = props.router?.pathname === '/onboarding';
-
+export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body>
-        {isOnboarding ? children : <MainLayout>{children}</MainLayout>}
+        <MainLayout>{children}</MainLayout>
       </body>
     </html>
   );

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -2,11 +2,18 @@
 
 import Link from "next/link";
 import React from "react";
+import { usePathname } from "next/navigation";
 import BugReportButton from "@/components/BugReportButton";
 import FeedbackBox from "@/components/FeedbackBox";
 import BottomNav from "@/components/layout/BottomNav";
 
 const MainLayout = ({ children }) => {
+  const pathname = usePathname();
+
+  if (pathname === "/onboarding") {
+    return <>{children}</>;
+  }
+
   return (
     <div className="min-h-screen bg-black text-white">
       <main className="pb-24">{children}</main>


### PR DESCRIPTION
## Summary
- always mount the root layout with `MainLayout`
- let `MainLayout` detect the onboarding route via `usePathname` and skip the chrome for it

## Testing
- npm run lint *(fails: ESLint config missing after v9 migration)*

------
https://chatgpt.com/codex/tasks/task_e_68d60247769083258e89454a6c343223