### PR TITLE
Load journal entries dynamically

### DIFF
--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -1,8 +1,27 @@
+import { promises as fs } from 'fs';
+import path from 'path';
 import React from 'react';
 import Card from '../../components/ui/Card';
-import journalEntries from '../../../data/journal-entries.json';
 
-export default function JournalPage() {
+type JournalEntry = {
+  timestamp: string;
+  transcription: string;
+};
+
+export const dynamic = 'force-dynamic';
+
+async function getJournalEntries(): Promise<JournalEntry[]> {
+  const filePath = path.join(process.cwd(), 'data', 'journal-entries.json');
+  const fileContents = await fs.readFile(filePath, 'utf-8');
+
+  const entries: JournalEntry[] = JSON.parse(fileContents);
+
+  return entries;
+}
+
+export default async function JournalPage() {
+  const journalEntries = await getJournalEntries();
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Journal</h1>


### PR DESCRIPTION
## Summary
- read journal entries from the data file at request time using the filesystem API
- force the journal page to render dynamically so fresh data is shown on each request

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d602495a888325b663a6860b2e1292