### PR TITLE
Protect audio uploads

### DIFF
--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -4,7 +4,24 @@ import { NextResponse } from 'next/server';
 
 const transcriptionsPath = path.resolve(process.cwd(), 'data/transcriptions.json');
 const journalEntriesPath = path.resolve(process.cwd(), 'data/journal-entries.json');
-const audioUploadPath = path.resolve(process.cwd(), 'public/audio');
+const audioUploadPath = path.resolve(process.cwd(), '.uploads/audio');
+
+function isAuthorized(request: Request) {
+    const apiKey = process.env.TRANSCRIBE_API_KEY;
+    const authHeader = request.headers.get('authorization');
+
+    if (!apiKey) {
+        console.warn('TRANSCRIBE_API_KEY env var is not set; denying access to transcription endpoint.');
+        return false;
+    }
+
+    if (!authHeader?.startsWith('Bearer ')) {
+        return false;
+    }
+
+    const token = authHeader.slice('Bearer '.length).trim();
+    return token === apiKey;
+}
 
 async function saveTranscription(transcription: string) {
     let transcriptions = [];
@@ -39,6 +56,10 @@ async function saveJournalEntry(transcription: string) {
 }
 
 export async function POST(request: Request) {
+    if (!isAuthorized(request)) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     const formData = await request.formData();
     const audio = formData.get('audio') as File;
 
@@ -46,24 +67,39 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'No audio file provided' }, { status: 400 });
     }
 
-    // Create the upload directory if it doesn't exist
+    let audioFilePath: string | null = null;
+
     try {
-        await fs.mkdir(audioUploadPath, { recursive: true });
+        // Create the upload directory if it doesn't exist
+        try {
+            await fs.mkdir(audioUploadPath, { recursive: true });
+        } catch (error) {
+            console.error('Error creating upload directory:', error);
+            throw error;
+        }
+
+        const audioBuffer = Buffer.from(await audio.arrayBuffer());
+        const audioFileName = `${new Date().toISOString()}-${audio.name}`;
+        audioFilePath = path.join(audioUploadPath, audioFileName);
+
+        await fs.writeFile(audioFilePath, audioBuffer);
+
+        const dummyTranscription = "This is a dummy transcription of your audio recording.";
+
+        await saveTranscription(dummyTranscription);
+        await saveJournalEntry(dummyTranscription);
+
+        return NextResponse.json({ transcription: dummyTranscription });
     } catch (error) {
-        console.error('Error creating upload directory:', error);
+        console.error('Error processing transcription request:', error);
+        return NextResponse.json({ error: 'Failed to process audio upload' }, { status: 500 });
+    } finally {
+        if (audioFilePath) {
+            try {
+                await fs.unlink(audioFilePath);
+            } catch (cleanupError) {
+                console.error('Failed to clean up audio upload:', cleanupError);
+            }
+        }
     }
-    
-    const audioBuffer = Buffer.from(await audio.arrayBuffer());
-    const audioFileName = `${new Date().toISOString()}-${audio.name}`;
-    const audioFilePath = path.join(audioUploadPath, audioFileName);
-
-    await fs.writeFile(audioFilePath, audioBuffer);
-
-
-    const dummyTranscription = "This is a dummy transcription of your audio recording.";
-
-    await saveTranscription(dummyTranscription);
-    await saveJournalEntry(dummyTranscription);
-
-    return NextResponse.json({ transcription: dummyTranscription });
 }


### PR DESCRIPTION
## Summary
- store uploaded audio in a private .uploads directory instead of the public folder
- require a bearer token that matches TRANSCRIBE_API_KEY before processing audio uploads
- clean up transient audio files after transcription completes to avoid lingering private data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6020edc28832584466eba5ba8058e