### PR TITLE
Add localized marketing email templates and subject catalogs

### DIFF
--- a/data/email_subjects/beta-invite.csv
+++ b/data/email_subjects/beta-invite.csv
@@ -1,0 +1,19 @@
+flow,language,tone,subject_line
+beta-invite,en,exclusivity,{{first_name}}, you’re on the list for {{beta_feature_name}}
+beta-invite,en,clarity,Instructions for your {{beta_feature_name}} early access
+beta-invite,en,urgency,Activate {{beta_feature_name}} before the window closes {{access_window}}
+beta-invite,es,exclusivity,{{first_name}}, estás en la lista para {{beta_feature_name}}
+beta-invite,es,clarity,Instrucciones para tu acceso anticipado a {{beta_feature_name}}
+beta-invite,es,urgency,Activa {{beta_feature_name}} antes de que cierre {{access_window}}
+beta-invite,pt,exclusivity,{{first_name}}, você está na lista do {{beta_feature_name}}
+beta-invite,pt,clarity,Passo a passo para acessar antes o {{beta_feature_name}}
+beta-invite,pt,urgency,Ative o {{beta_feature_name}} antes do fim de {{access_window}}
+beta-invite,fr,exclusivity,{{first_name}}, vous êtes sélectionné·e pour {{beta_feature_name}}
+beta-invite,fr,clarity,Mode d’emploi pour accéder en avant-première à {{beta_feature_name}}
+beta-invite,fr,urgency,Activez {{beta_feature_name}} avant la fin de {{access_window}}
+beta-invite,hi,exclusivity,{{first_name}}, आपको {{beta_feature_name}} की विशेष पहुँच मिली है
+beta-invite,hi,clarity,{{beta_feature_name}} अर्ली एक्सेस के निर्देश
+beta-invite,hi,urgency,{{access_window}} से पहले {{beta_feature_name}} सक्रिय करें
+beta-invite,zh,exclusivity,{{first_name}}，你已获选体验 {{beta_feature_name}}
+beta-invite,zh,clarity,{{beta_feature_name}} 早鸟体验指南
+beta-invite,zh,urgency,请在 {{access_window}} 前激活 {{beta_feature_name}}

--- a/data/email_subjects/beta-invite.json
+++ b/data/email_subjects/beta-invite.json
@@ -1,0 +1,20 @@
+[
+  {"flow": "beta-invite", "language": "en", "tone": "exclusivity", "subject_line": "{{first_name}}, you’re on the list for {{beta_feature_name}}"},
+  {"flow": "beta-invite", "language": "en", "tone": "clarity", "subject_line": "Instructions for your {{beta_feature_name}} early access"},
+  {"flow": "beta-invite", "language": "en", "tone": "urgency", "subject_line": "Activate {{beta_feature_name}} before the window closes {{access_window}}"},
+  {"flow": "beta-invite", "language": "es", "tone": "exclusivity", "subject_line": "{{first_name}}, estás en la lista para {{beta_feature_name}}"},
+  {"flow": "beta-invite", "language": "es", "tone": "clarity", "subject_line": "Instrucciones para tu acceso anticipado a {{beta_feature_name}}"},
+  {"flow": "beta-invite", "language": "es", "tone": "urgency", "subject_line": "Activa {{beta_feature_name}} antes de que cierre {{access_window}}"},
+  {"flow": "beta-invite", "language": "pt", "tone": "exclusivity", "subject_line": "{{first_name}}, você está na lista do {{beta_feature_name}}"},
+  {"flow": "beta-invite", "language": "pt", "tone": "clarity", "subject_line": "Passo a passo para acessar antes o {{beta_feature_name}}"},
+  {"flow": "beta-invite", "language": "pt", "tone": "urgency", "subject_line": "Ative o {{beta_feature_name}} antes do fim de {{access_window}}"},
+  {"flow": "beta-invite", "language": "fr", "tone": "exclusivity", "subject_line": "{{first_name}}, vous êtes sélectionné·e pour {{beta_feature_name}}"},
+  {"flow": "beta-invite", "language": "fr", "tone": "clarity", "subject_line": "Mode d’emploi pour accéder en avant-première à {{beta_feature_name}}"},
+  {"flow": "beta-invite", "language": "fr", "tone": "urgency", "subject_line": "Activez {{beta_feature_name}} avant la fin de {{access_window}}"},
+  {"flow": "beta-invite", "language": "hi", "tone": "exclusivity", "subject_line": "{{first_name}}, आपको {{beta_feature_name}} की विशेष पहुँच मिली है"},
+  {"flow": "beta-invite", "language": "hi", "tone": "clarity", "subject_line": "{{beta_feature_name}} अर्ली एक्सेस के निर्देश"},
+  {"flow": "beta-invite", "language": "hi", "tone": "urgency", "subject_line": "{{access_window}} से पहले {{beta_feature_name}} सक्रिय करें"},
+  {"flow": "beta-invite", "language": "zh", "tone": "exclusivity", "subject_line": "{{first_name}}，你已获选体验 {{beta_feature_name}}"},
+  {"flow": "beta-invite", "language": "zh", "tone": "clarity", "subject_line": "{{beta_feature_name}} 早鸟体验指南"},
+  {"flow": "beta-invite", "language": "zh", "tone": "urgency", "subject_line": "请在 {{access_window}} 前激活 {{beta_feature_name}}"}
+]

--- a/data/email_subjects/creator-call.csv
+++ b/data/email_subjects/creator-call.csv
@@ -1,0 +1,19 @@
+flow,language,tone,subject_line
+creator-call,en,anticipation,Creators circle: reserve your seat for {{call_date}}
+creator-call,en,clarity,Agenda and prep for our upcoming creator call
+creator-call,en,urgency,Last spots for the UrAi creator session on {{call_date}}
+creator-call,es,anticipation,Círculo de creadores: reserva tu lugar para {{call_date}}
+creator-call,es,clarity,Agenda y preparación para la próxima llamada de creadores
+creator-call,es,urgency,Últimos lugares para la sesión de creadores de UrAi en {{call_date}}
+creator-call,pt,anticipation,Círculo de criadores: garanta sua vaga em {{call_date}}
+creator-call,pt,clarity,Agenda e preparos para nossa próxima call de criadores
+creator-call,pt,urgency,Últimas vagas para a sessão de criadores UrAi em {{call_date}}
+creator-call,fr,anticipation,Cercle des créateur·rices : réservez pour le {{call_date}}
+creator-call,fr,clarity,Agenda et préparation pour notre prochain appel créateur·rices
+creator-call,fr,urgency,Dernières places pour la session créateur·rices UrAi du {{call_date}}
+creator-call,hi,anticipation,क्रिएटर सर्कल: {{call_date}} सत्र के लिए स्थान सुरक्षित करें
+creator-call,hi,clarity,हमारी अगली क्रिएटर कॉल की एजेंडा और तैयारी
+creator-call,hi,urgency,{{call_date}} की UrAi क्रिएटर सत्र में सीमित स्थान शेष हैं
+creator-call,zh,anticipation,创作者圈：立即预留 {{call_date}} 的席位
+creator-call,zh,clarity,UrAi 创作者会议议程与准备清单
+creator-call,zh,urgency,{{call_date}} UrAi 创作者会仅剩少量席位

--- a/data/email_subjects/creator-call.json
+++ b/data/email_subjects/creator-call.json
@@ -1,0 +1,20 @@
+[
+  {"flow": "creator-call", "language": "en", "tone": "anticipation", "subject_line": "Creators circle: reserve your seat for {{call_date}}"},
+  {"flow": "creator-call", "language": "en", "tone": "clarity", "subject_line": "Agenda and prep for our upcoming creator call"},
+  {"flow": "creator-call", "language": "en", "tone": "urgency", "subject_line": "Last spots for the UrAi creator session on {{call_date}}"},
+  {"flow": "creator-call", "language": "es", "tone": "anticipation", "subject_line": "Círculo de creadores: reserva tu lugar para {{call_date}}"},
+  {"flow": "creator-call", "language": "es", "tone": "clarity", "subject_line": "Agenda y preparación para la próxima llamada de creadores"},
+  {"flow": "creator-call", "language": "es", "tone": "urgency", "subject_line": "Últimos lugares para la sesión de creadores de UrAi en {{call_date}}"},
+  {"flow": "creator-call", "language": "pt", "tone": "anticipation", "subject_line": "Círculo de criadores: garanta sua vaga em {{call_date}}"},
+  {"flow": "creator-call", "language": "pt", "tone": "clarity", "subject_line": "Agenda e preparos para nossa próxima call de criadores"},
+  {"flow": "creator-call", "language": "pt", "tone": "urgency", "subject_line": "Últimas vagas para a sessão de criadores UrAi em {{call_date}}"},
+  {"flow": "creator-call", "language": "fr", "tone": "anticipation", "subject_line": "Cercle des créateur·rices : réservez pour le {{call_date}}"},
+  {"flow": "creator-call", "language": "fr", "tone": "clarity", "subject_line": "Agenda et préparation pour notre prochain appel créateur·rices"},
+  {"flow": "creator-call", "language": "fr", "tone": "urgency", "subject_line": "Dernières places pour la session créateur·rices UrAi du {{call_date}}"},
+  {"flow": "creator-call", "language": "hi", "tone": "anticipation", "subject_line": "क्रिएटर सर्कल: {{call_date}} सत्र के लिए स्थान सुरक्षित करें"},
+  {"flow": "creator-call", "language": "hi", "tone": "clarity", "subject_line": "हमारी अगली क्रिएटर कॉल की एजेंडा और तैयारी"},
+  {"flow": "creator-call", "language": "hi", "tone": "urgency", "subject_line": "{{call_date}} की UrAi क्रिएटर सत्र में सीमित स्थान शेष हैं"},
+  {"flow": "creator-call", "language": "zh", "tone": "anticipation", "subject_line": "创作者圈：立即预留 {{call_date}} 的席位"},
+  {"flow": "creator-call", "language": "zh", "tone": "clarity", "subject_line": "UrAi 创作者会议议程与准备清单"},
+  {"flow": "creator-call", "language": "zh", "tone": "urgency", "subject_line": "{{call_date}} UrAi 创作者会仅剩少量席位"}
+]

--- a/data/email_subjects/donor-thank-you.csv
+++ b/data/email_subjects/donor-thank-you.csv
@@ -1,0 +1,19 @@
+flow,language,tone,subject_line
+donor-thank-you,en,gratitude,Your gift is already in motion, {{first_name}}
+donor-thank-you,en,clarity,Receipt and impact path for your UrAi donation
+donor-thank-you,en,celebration,You unlocked the next UrAi experiment!
+donor-thank-you,es,gratitude,Tu contribución ya está en marcha, {{first_name}}
+donor-thank-you,es,clarity,Recibo e impacto de tu donación a UrAi
+donor-thank-you,es,celebration,¡Activaste el próximo experimento de UrAi!
+donor-thank-you,pt,gratitude,Sua contribuição já está gerando impacto, {{first_name}}
+donor-thank-you,pt,clarity,Recibo e plano de impacto da sua doação UrAi
+donor-thank-you,pt,celebration,Você habilitou o próximo experimento UrAi!
+donor-thank-you,fr,gratitude,Votre contribution agit déjà, {{first_name}}
+donor-thank-you,fr,clarity,Reçu et feuille de route d’impact pour votre don UrAi
+donor-thank-you,fr,celebration,Vous avez déclenché la prochaine expérimentation UrAi !
+donor-thank-you,hi,gratitude,आपका सहयोग अभी असर ला रहा है, {{first_name}}
+donor-thank-you,hi,clarity,UrAi दान की रसीद और प्रभाव योजना
+donor-thank-you,hi,celebration,आपने अगला UrAi प्रयोग शुरू कर दिया!
+donor-thank-you,zh,gratitude,你的支持正在发挥作用，{{first_name}}
+donor-thank-you,zh,clarity,UrAi 捐赠回执与影响路径
+donor-thank-you,zh,celebration,你点亮了下一场 UrAi 实验！

--- a/data/email_subjects/donor-thank-you.json
+++ b/data/email_subjects/donor-thank-you.json
@@ -1,0 +1,20 @@
+[
+  {"flow": "donor-thank-you", "language": "en", "tone": "gratitude", "subject_line": "Your gift is already in motion, {{first_name}}"},
+  {"flow": "donor-thank-you", "language": "en", "tone": "clarity", "subject_line": "Receipt and impact path for your UrAi donation"},
+  {"flow": "donor-thank-you", "language": "en", "tone": "celebration", "subject_line": "You unlocked the next UrAi experiment!"},
+  {"flow": "donor-thank-you", "language": "es", "tone": "gratitude", "subject_line": "Tu contribución ya está en marcha, {{first_name}}"},
+  {"flow": "donor-thank-you", "language": "es", "tone": "clarity", "subject_line": "Recibo e impacto de tu donación a UrAi"},
+  {"flow": "donor-thank-you", "language": "es", "tone": "celebration", "subject_line": "¡Activaste el próximo experimento de UrAi!"},
+  {"flow": "donor-thank-you", "language": "pt", "tone": "gratitude", "subject_line": "Sua contribuição já está gerando impacto, {{first_name}}"},
+  {"flow": "donor-thank-you", "language": "pt", "tone": "clarity", "subject_line": "Recibo e plano de impacto da sua doação UrAi"},
+  {"flow": "donor-thank-you", "language": "pt", "tone": "celebration", "subject_line": "Você habilitou o próximo experimento UrAi!"},
+  {"flow": "donor-thank-you", "language": "fr", "tone": "gratitude", "subject_line": "Votre contribution agit déjà, {{first_name}}"},
+  {"flow": "donor-thank-you", "language": "fr", "tone": "clarity", "subject_line": "Reçu et feuille de route d’impact pour votre don UrAi"},
+  {"flow": "donor-thank-you", "language": "fr", "tone": "celebration", "subject_line": "Vous avez déclenché la prochaine expérimentation UrAi !"},
+  {"flow": "donor-thank-you", "language": "hi", "tone": "gratitude", "subject_line": "आपका सहयोग अभी असर ला रहा है, {{first_name}}"},
+  {"flow": "donor-thank-you", "language": "hi", "tone": "clarity", "subject_line": "UrAi दान की रसीद और प्रभाव योजना"},
+  {"flow": "donor-thank-you", "language": "hi", "tone": "celebration", "subject_line": "आपने अगला UrAi प्रयोग शुरू कर दिया!"},
+  {"flow": "donor-thank-you", "language": "zh", "tone": "gratitude", "subject_line": "你的支持正在发挥作用，{{first_name}}"},
+  {"flow": "donor-thank-you", "language": "zh", "tone": "clarity", "subject_line": "UrAi 捐赠回执与影响路径"},
+  {"flow": "donor-thank-you", "language": "zh", "tone": "celebration", "subject_line": "你点亮了下一场 UrAi 实验！"}
+]

--- a/data/email_subjects/privacy-proof.csv
+++ b/data/email_subjects/privacy-proof.csv
@@ -1,0 +1,19 @@
+flow,language,tone,subject_line
+privacy-proof,en,curiosity,See the latest proof of how UrAi guards your data
+privacy-proof,en,clarity,Your privacy dashboard updates are ready
+privacy-proof,en,urgency,Review today’s UrAi security audit highlights
+privacy-proof,es,curiosity,Conoce cómo UrAi protege tus datos hoy
+privacy-proof,es,clarity,Tus paneles de privacidad ya tienen novedades
+privacy-proof,es,urgency,Revisa los puntos clave de seguridad de UrAi hoy
+privacy-proof,pt,curiosity,Descubra como a UrAi protege seus dados agora
+privacy-proof,pt,clarity,Seus painéis de privacidade foram atualizados
+privacy-proof,pt,urgency,Veja os destaques da auditoria de segurança UrAi hoje
+privacy-proof,fr,curiosity,Découvrez comment UrAi protège vos données
+privacy-proof,fr,clarity,Votre tableau de bord confidentialité est à jour
+privacy-proof,fr,urgency,Consultez dès aujourd’hui les points clés de l’audit UrAi
+privacy-proof,hi,curiosity,आज जानें UrAi आपके डेटा को कैसे सुरक्षित रखता है
+privacy-proof,hi,clarity,आपका प्राइवेसी डैशबोर्ड अपडेट हो गया है
+privacy-proof,hi,urgency,UrAi सुरक्षा ऑडिट की मुख्य बातें अभी देखें
+privacy-proof,zh,curiosity,看看 UrAi 今天如何守护你的数据
+privacy-proof,zh,clarity,你的隐私面板已有最新更新
+privacy-proof,zh,urgency,立即查看 UrAi 安全审计要点

--- a/data/email_subjects/privacy-proof.json
+++ b/data/email_subjects/privacy-proof.json
@@ -1,0 +1,20 @@
+[
+  {"flow": "privacy-proof", "language": "en", "tone": "curiosity", "subject_line": "See the latest proof of how UrAi guards your data"},
+  {"flow": "privacy-proof", "language": "en", "tone": "clarity", "subject_line": "Your privacy dashboard updates are ready"},
+  {"flow": "privacy-proof", "language": "en", "tone": "urgency", "subject_line": "Review today’s UrAi security audit highlights"},
+  {"flow": "privacy-proof", "language": "es", "tone": "curiosity", "subject_line": "Conoce cómo UrAi protege tus datos hoy"},
+  {"flow": "privacy-proof", "language": "es", "tone": "clarity", "subject_line": "Tus paneles de privacidad ya tienen novedades"},
+  {"flow": "privacy-proof", "language": "es", "tone": "urgency", "subject_line": "Revisa los puntos clave de seguridad de UrAi hoy"},
+  {"flow": "privacy-proof", "language": "pt", "tone": "curiosity", "subject_line": "Descubra como a UrAi protege seus dados agora"},
+  {"flow": "privacy-proof", "language": "pt", "tone": "clarity", "subject_line": "Seus painéis de privacidade foram atualizados"},
+  {"flow": "privacy-proof", "language": "pt", "tone": "urgency", "subject_line": "Veja os destaques da auditoria de segurança UrAi hoje"},
+  {"flow": "privacy-proof", "language": "fr", "tone": "curiosity", "subject_line": "Découvrez comment UrAi protège vos données"},
+  {"flow": "privacy-proof", "language": "fr", "tone": "clarity", "subject_line": "Votre tableau de bord confidentialité est à jour"},
+  {"flow": "privacy-proof", "language": "fr", "tone": "urgency", "subject_line": "Consultez dès aujourd’hui les points clés de l’audit UrAi"},
+  {"flow": "privacy-proof", "language": "hi", "tone": "curiosity", "subject_line": "आज जानें UrAi आपके डेटा को कैसे सुरक्षित रखता है"},
+  {"flow": "privacy-proof", "language": "hi", "tone": "clarity", "subject_line": "आपका प्राइवेसी डैशबोर्ड अपडेट हो गया है"},
+  {"flow": "privacy-proof", "language": "hi", "tone": "urgency", "subject_line": "UrAi सुरक्षा ऑडिट की मुख्य बातें अभी देखें"},
+  {"flow": "privacy-proof", "language": "zh", "tone": "curiosity", "subject_line": "看看 UrAi 今天如何守护你的数据"},
+  {"flow": "privacy-proof", "language": "zh", "tone": "clarity", "subject_line": "你的隐私面板已有最新更新"},
+  {"flow": "privacy-proof", "language": "zh", "tone": "urgency", "subject_line": "立即查看 UrAi 安全审计要点"}
+]

--- a/data/email_subjects/weekly-scroll.csv
+++ b/data/email_subjects/weekly-scroll.csv
@@ -1,0 +1,19 @@
+flow,language,tone,subject_line
+weekly-scroll,en,curiosity,What the UrAi community discovered this week
+weekly-scroll,en,clarity,Your UrAi Weekly Scroll for {{week_range}}
+weekly-scroll,en,urgency,Don’t miss this week’s UrAi experiments
+weekly-scroll,es,curiosity,Lo que descubrió la comunidad UrAi esta semana
+weekly-scroll,es,clarity,Tu Scroll semanal de UrAi: {{week_range}}
+weekly-scroll,es,urgency,No te pierdas los experimentos UrAi de esta semana
+weekly-scroll,pt,curiosity,O que a comunidade UrAi descobriu nesta semana
+weekly-scroll,pt,clarity,Seu Scroll semanal UrAi: {{week_range}}
+weekly-scroll,pt,urgency,Não perca os experimentos UrAi desta semana
+weekly-scroll,fr,curiosity,Ce que la communauté UrAi a révélé cette semaine
+weekly-scroll,fr,clarity,Votre Scroll hebdomadaire UrAi — {{week_range}}
+weekly-scroll,fr,urgency,Ne manquez pas les expériences UrAi de la semaine
+weekly-scroll,hi,curiosity,इस सप्ताह UrAi समुदाय ने क्या खोजा
+weekly-scroll,hi,clarity,आपका UrAi साप्ताहिक Scroll — {{week_range}}
+weekly-scroll,hi,urgency,इस सप्ताह के UrAi प्रयोग न चूकें
+weekly-scroll,zh,curiosity,本周 UrAi 社区的新发现
+weekly-scroll,zh,clarity,你的 UrAi 每周速览 — {{week_range}}
+weekly-scroll,zh,urgency,别错过本周的 UrAi 实验

--- a/data/email_subjects/weekly-scroll.json
+++ b/data/email_subjects/weekly-scroll.json
@@ -1,0 +1,20 @@
+[
+  {"flow": "weekly-scroll", "language": "en", "tone": "curiosity", "subject_line": "What the UrAi community discovered this week"},
+  {"flow": "weekly-scroll", "language": "en", "tone": "clarity", "subject_line": "Your UrAi Weekly Scroll for {{week_range}}"},
+  {"flow": "weekly-scroll", "language": "en", "tone": "urgency", "subject_line": "Don’t miss this week’s UrAi experiments"},
+  {"flow": "weekly-scroll", "language": "es", "tone": "curiosity", "subject_line": "Lo que descubrió la comunidad UrAi esta semana"},
+  {"flow": "weekly-scroll", "language": "es", "tone": "clarity", "subject_line": "Tu Scroll semanal de UrAi: {{week_range}}"},
+  {"flow": "weekly-scroll", "language": "es", "tone": "urgency", "subject_line": "No te pierdas los experimentos UrAi de esta semana"},
+  {"flow": "weekly-scroll", "language": "pt", "tone": "curiosity", "subject_line": "O que a comunidade UrAi descobriu nesta semana"},
+  {"flow": "weekly-scroll", "language": "pt", "tone": "clarity", "subject_line": "Seu Scroll semanal UrAi: {{week_range}}"},
+  {"flow": "weekly-scroll", "language": "pt", "tone": "urgency", "subject_line": "Não perca os experimentos UrAi desta semana"},
+  {"flow": "weekly-scroll", "language": "fr", "tone": "curiosity", "subject_line": "Ce que la communauté UrAi a révélé cette semaine"},
+  {"flow": "weekly-scroll", "language": "fr", "tone": "clarity", "subject_line": "Votre Scroll hebdomadaire UrAi — {{week_range}}"},
+  {"flow": "weekly-scroll", "language": "fr", "tone": "urgency", "subject_line": "Ne manquez pas les expériences UrAi de la semaine"},
+  {"flow": "weekly-scroll", "language": "hi", "tone": "curiosity", "subject_line": "इस सप्ताह UrAi समुदाय ने क्या खोजा"},
+  {"flow": "weekly-scroll", "language": "hi", "tone": "clarity", "subject_line": "आपका UrAi साप्ताहिक Scroll — {{week_range}}"},
+  {"flow": "weekly-scroll", "language": "hi", "tone": "urgency", "subject_line": "इस सप्ताह के UrAi प्रयोग न चूकें"},
+  {"flow": "weekly-scroll", "language": "zh", "tone": "curiosity", "subject_line": "本周 UrAi 社区的新发现"},
+  {"flow": "weekly-scroll", "language": "zh", "tone": "clarity", "subject_line": "你的 UrAi 每周速览 — {{week_range}}"},
+  {"flow": "weekly-scroll", "language": "zh", "tone": "urgency", "subject_line": "别错过本周的 UrAi 实验"}
+]

--- a/data/email_subjects/welcome.csv
+++ b/data/email_subjects/welcome.csv
@@ -1,0 +1,19 @@
+flow,language,tone,subject_line
+welcome,en,curiosity,Welcome inside UrAi — see what’s waiting, {{first_name}}
+welcome,en,clarity,Your UrAi tools are ready to explore
+welcome,en,urgency,Start your UrAi journey today, {{first_name}}
+welcome,es,curiosity,Descubre lo que UrAi preparó para ti, {{first_name}}
+welcome,es,clarity,Tus herramientas de UrAi ya están listas
+welcome,es,urgency,Empieza hoy tu recorrido UrAi, {{first_name}}
+welcome,pt,curiosity,Veja o que a UrAi reservou para você, {{first_name}}
+welcome,pt,clarity,Suas ferramentas UrAi estão prontas para uso
+welcome,pt,urgency,Comece sua jornada UrAi hoje, {{first_name}}
+welcome,fr,curiosity,Explorez ce qu’UrAi vous réserve, {{first_name}}
+welcome,fr,clarity,Vos outils UrAi sont prêts à l’emploi
+welcome,fr,urgency,Lancez votre parcours UrAi dès aujourd’hui, {{first_name}}
+welcome,hi,curiosity,जानें UrAi ने आपके लिए क्या तैयार किया है, {{first_name}}
+welcome,hi,clarity,आपके UrAi टूल अब तैयार हैं
+welcome,hi,urgency,आज ही अपना UrAi सफ़र शुरू करें, {{first_name}}
+welcome,zh,curiosity,来看看 UrAi 为你准备了什么，{{first_name}}
+welcome,zh,clarity,你的 UrAi 工具已就绪
+welcome,zh,urgency,立即开启你的 UrAi 旅程，{{first_name}}

--- a/data/email_subjects/welcome.json
+++ b/data/email_subjects/welcome.json
@@ -1,0 +1,20 @@
+[
+  {"flow": "welcome", "language": "en", "tone": "curiosity", "subject_line": "Welcome inside UrAi — see what’s waiting, {{first_name}}"},
+  {"flow": "welcome", "language": "en", "tone": "clarity", "subject_line": "Your UrAi tools are ready to explore"},
+  {"flow": "welcome", "language": "en", "tone": "urgency", "subject_line": "Start your UrAi journey today, {{first_name}}"},
+  {"flow": "welcome", "language": "es", "tone": "curiosity", "subject_line": "Descubre lo que UrAi preparó para ti, {{first_name}}"},
+  {"flow": "welcome", "language": "es", "tone": "clarity", "subject_line": "Tus herramientas de UrAi ya están listas"},
+  {"flow": "welcome", "language": "es", "tone": "urgency", "subject_line": "Empieza hoy tu recorrido UrAi, {{first_name}}"},
+  {"flow": "welcome", "language": "pt", "tone": "curiosity", "subject_line": "Veja o que a UrAi reservou para você, {{first_name}}"},
+  {"flow": "welcome", "language": "pt", "tone": "clarity", "subject_line": "Suas ferramentas UrAi estão prontas para uso"},
+  {"flow": "welcome", "language": "pt", "tone": "urgency", "subject_line": "Comece sua jornada UrAi hoje, {{first_name}}"},
+  {"flow": "welcome", "language": "fr", "tone": "curiosity", "subject_line": "Explorez ce qu’UrAi vous réserve, {{first_name}}"},
+  {"flow": "welcome", "language": "fr", "tone": "clarity", "subject_line": "Vos outils UrAi sont prêts à l’emploi"},
+  {"flow": "welcome", "language": "fr", "tone": "urgency", "subject_line": "Lancez votre parcours UrAi dès aujourd’hui, {{first_name}}"},
+  {"flow": "welcome", "language": "hi", "tone": "curiosity", "subject_line": "जानें UrAi ने आपके लिए क्या तैयार किया है, {{first_name}}"},
+  {"flow": "welcome", "language": "hi", "tone": "clarity", "subject_line": "आपके UrAi टूल अब तैयार हैं"},
+  {"flow": "welcome", "language": "hi", "tone": "urgency", "subject_line": "आज ही अपना UrAi सफ़र शुरू करें, {{first_name}}"},
+  {"flow": "welcome", "language": "zh", "tone": "curiosity", "subject_line": "来看看 UrAi 为你准备了什么，{{first_name}}"},
+  {"flow": "welcome", "language": "zh", "tone": "clarity", "subject_line": "你的 UrAi 工具已就绪"},
+  {"flow": "welcome", "language": "zh", "tone": "urgency", "subject_line": "立即开启你的 UrAi 旅程，{{first_name}}"}
+]

--- a/docs/marketing/email_templates/beta-invite.md
+++ b/docs/marketing/email_templates/beta-invite.md
@@ -1,0 +1,122 @@
+# Beta Invite Flow Email Template
+
+## Overview
+Use this template to invite select members to try a new UrAi beta feature. Highlight exclusivity, clear instructions, and feedback channels.
+
+## Placeholders
+- `{{first_name}}`: Recipient's preferred first name.
+- `{{beta_feature_name}}`: Name of the beta feature or release.
+- `{{access_window}}`: Date range or availability window.
+- `{{activation_link}}`: Link or code to activate the beta.
+- `{{feedback_form_link}}`: Feedback capture form.
+- `{{compliance_footer}}`: Insert compliant footer from `compliance.md`.
+
+## Language Variants
+
+### English (EN)
+**Subject cue**: "Early access unlocked for you"
+
+```
+Hi {{first_name}},
+
+We picked you for early access to {{beta_feature_name}}. The beta window runs {{access_window}}, and you can activate it here: {{activation_link}}.
+
+What to expect:
+• A guided overlay introduces the new workflows in under five minutes.
+• You can toggle back to the classic view anytime from settings.
+• Feedback is gold—log it via {{feedback_form_link}} or reply directly.
+
+Thanks for helping us shape tools built for the collective.
+
+{{compliance_footer}}
+```
+
+### Spanish (ES)
+**Sugerencia de asunto**: «Acceso anticipado desbloqueado para ti»
+
+```
+Hola {{first_name}},
+
+Te elegimos para acceder antes que nadie a {{beta_feature_name}}. La ventana beta estará disponible {{access_window}} y puedes activarla aquí: {{activation_link}}.
+
+Lo que encontrarás:
+• Un recorrido guiado muestra los nuevos flujos en menos de cinco minutos.
+• Puedes volver a la vista clásica desde ajustes cuando quieras.
+• Tu opinión es clave: compártela en {{feedback_form_link}} o responde este correo.
+
+Gracias por ayudarnos a crear herramientas para el colectivo.
+
+{{compliance_footer}}
+```
+
+### Portuguese (PT)
+**Sugestão de assunto**: "Acesso antecipado liberado para você"
+
+```
+Olá {{first_name}},
+
+Selecionamos você para testar {{beta_feature_name}} em primeira mão. A janela beta ocorre {{access_window}} e você ativa aqui: {{activation_link}}.
+
+O que vai encontrar:
+• Um tour guiado apresenta os novos fluxos em menos de cinco minutos.
+• É possível voltar à visualização clássica a qualquer momento nas configurações.
+• Sua opinião vale muito: envie pelo {{feedback_form_link}} ou responda a este e-mail.
+
+Obrigado por nos ajudar a criar ferramentas voltadas ao coletivo.
+
+{{compliance_footer}}
+```
+
+### French (FR)
+**Suggestion d’objet** : « Accès anticipé rien que pour vous »
+
+```
+Bonjour {{first_name}},
+
+Vous faites partie du groupe sélectionné pour tester {{beta_feature_name}} en avant-première. La période bêta se déroule {{access_window}} et vous pouvez l’activer ici : {{activation_link}}.
+
+Ce qui vous attend :
+• Un tutoriel guidé présente les nouveaux parcours en moins de cinq minutes.
+• Vous pouvez revenir à l’interface classique à tout moment via les paramètres.
+• Votre avis compte : partagez-le via {{feedback_form_link}} ou répondez simplement à ce message.
+
+Merci de co-construire avec nous des outils pensés pour le collectif.
+
+{{compliance_footer}}
+```
+
+### Hindi (HI)
+**विषय सुझाव**: "आपके लिए अर्ली एक्सेस तैयार है"
+
+```
+नमस्ते {{first_name}},
+
+{{beta_feature_name}} के अर्ली एक्सेस के लिए आपको चुना गया है। बीटा विंडो {{access_window}} तक खुली रहेगी और आप इसे यहाँ सक्रिय कर सकते हैं: {{activation_link}}।
+
+क्या अपेक्षा करें:
+• पाँच मिनट से कम में नया वर्कफ़्लो दिखाने वाला गाइडेड ओवरले।
+• सेटिंग्स से कभी भी क्लासिक व्यू पर लौट सकते हैं।
+• आपकी प्रतिक्रिया अनमोल है—इसे {{feedback_form_link}} पर दर्ज करें या सीधे उत्तर दें।
+
+साझा भविष्य के लिए उपकरण गढ़ने में साथ देने के लिए धन्यवाद।
+
+{{compliance_footer}}
+```
+
+### Simplified Chinese (ZH)
+**主题建议**："专属早鸟体验现已开启"
+
+```
+{{first_name}}，你好：
+
+你被选中优先体验 {{beta_feature_name}}。测试时间为 {{access_window}}，可在此激活：{{activation_link}}。
+
+体验亮点：
+• 引导式教程将在五分钟内带你熟悉全新流程。
+• 随时可在设置中切换回经典视图。
+• 你的反馈最有价值——请通过 {{feedback_form_link}} 提交或直接回复邮件。
+
+感谢你与我们一起打造面向集体的工具。
+
+{{compliance_footer}}
+```

--- a/docs/marketing/email_templates/compliance.md
+++ b/docs/marketing/email_templates/compliance.md
@@ -1,0 +1,117 @@
+# Email Compliance Snippets
+
+Use these modular snippets to meet regional requirements. Insert the relevant language variant into the `{{compliance_footer}}` placeholder of each template.
+
+## Placeholders
+- `{{unsubscribe_link}}`: Personalized unsubscribe or preferences URL.
+- `{{physical_address}}`: Verified mailing address for UrAi.
+- `{{privacy_policy_link}}`: Link to the latest privacy policy.
+- `{{support_email}}`: General support inbox.
+
+## Unsubscribe Footer
+
+### English (EN)
+```
+You receive this email because you joined the UrAi community. Update preferences or unsubscribe anytime: {{unsubscribe_link}}.
+UrAi • {{physical_address}} • Need help? {{support_email}}
+```
+
+### Spanish (ES)
+```
+Recibes este correo por formar parte de la comunidad UrAi. Actualiza tus preferencias o cancela la suscripción aquí: {{unsubscribe_link}}.
+UrAi • {{physical_address}} • ¿Necesitas ayuda? {{support_email}}
+```
+
+### Portuguese (PT)
+```
+Você está recebendo este e-mail por participar da comunidade UrAi. Atualize preferências ou cancele a assinatura aqui: {{unsubscribe_link}}.
+UrAi • {{physical_address}} • Precisa de ajuda? {{support_email}}
+```
+
+### French (FR)
+```
+Vous recevez cet e-mail car vous faites partie de la communauté UrAi. Gérez vos préférences ou désinscrivez-vous ici : {{unsubscribe_link}}.
+UrAi • {{physical_address}} • Besoin d’aide ? {{support_email}}
+```
+
+### Hindi (HI)
+```
+आपको यह ईमेल इसलिए मिला है क्योंकि आप UrAi समुदाय का हिस्सा हैं। अपनी प्राथमिकताएँ अपडेट करें या सदस्यता समाप्त करें: {{unsubscribe_link}}।
+UrAi • {{physical_address}} • सहायता चाहिए? {{support_email}}
+```
+
+### Simplified Chinese (ZH)
+```
+你收到此邮件是因为你加入了 UrAi 社区。管理偏好或取消订阅：{{unsubscribe_link}}。
+UrAi • {{physical_address}} • 需要帮助？{{support_email}}
+```
+
+## Physical Address Statement
+
+### English (EN)
+```
+Official correspondence address: {{physical_address}}.
+```
+
+### Spanish (ES)
+```
+Dirección oficial para correspondencia: {{physical_address}}.
+```
+
+### Portuguese (PT)
+```
+Endereço oficial para correspondências: {{physical_address}}.
+```
+
+### French (FR)
+```
+Adresse officielle de correspondance : {{physical_address}}.
+```
+
+### Hindi (HI)
+```
+आधिकारिक डाक पता: {{physical_address}}।
+```
+
+### Simplified Chinese (ZH)
+```
+官方联系地址：{{physical_address}}。
+```
+
+## Privacy Disclaimer
+
+### English (EN)
+```
+We protect your data according to our Privacy Policy: {{privacy_policy_link}}.
+```
+
+### Spanish (ES)
+```
+Protegemos tus datos conforme a nuestra Política de Privacidad: {{privacy_policy_link}}.
+```
+
+### Portuguese (PT)
+```
+Protegemos seus dados conforme nossa Política de Privacidade: {{privacy_policy_link}}.
+```
+
+### French (FR)
+```
+Nous protégeons vos données conformément à notre Politique de confidentialité : {{privacy_policy_link}}.
+```
+
+### Hindi (HI)
+```
+हम आपके डेटा की सुरक्षा अपनी गोपनीयता नीति के अनुसार करते हैं: {{privacy_policy_link}}।
+```
+
+### Simplified Chinese (ZH)
+```
+我们按照隐私政策保护你的数据：{{privacy_policy_link}}。
+```
+
+## Usage Notes
+- Combine the Unsubscribe Footer with the Privacy Disclaimer in a single block for most regions.
+- Include the Physical Address Statement when local laws require a standalone address line (e.g., CAN-SPAM, GDPR).
+- Localize the order of elements if your ESP enforces specific compliance formats.
+- For SMS fallbacks, shorten the unsubscribe text but retain a clear opt-out instruction in the local language.

--- a/docs/marketing/email_templates/creator-call.md
+++ b/docs/marketing/email_templates/creator-call.md
@@ -1,0 +1,110 @@
+# Creator Call Flow Email Template
+
+## Overview
+Invite community creators or facilitators to join an upcoming collaboration call. Emphasize agenda, value exchange, and preparation requirements.
+
+## Placeholders
+- `{{first_name}}`: Recipient's preferred first name.
+- `{{call_date}}`: Localized date and time of the call.
+- `{{agenda_highlights}}`: Bullet-ready summary of key topics.
+- `{{rsvp_link}}`: RSVP form link.
+- `{{resource_folder_link}}`: Link to prep materials.
+- `{{compliance_footer}}`: Insert compliant footer from `compliance.md`.
+
+## Language Variants
+
+### English (EN)
+**Subject cue**: "Join our creator strategy session"
+
+```
+Hi {{first_name}},
+
+We’re convening creators on {{call_date}} to co-design the next collective storyline. Expect a focused 45 minutes covering:
+{{agenda_highlights}}
+
+Please RSVP so we can send facilitation pairings and access details. Prep materials live here: {{resource_folder_link}}.
+
+Come ready to share one win, one friction point, and one bold idea.
+
+{{compliance_footer}}
+```
+
+### Spanish (ES)
+**Sugerencia de asunto**: «Únete a la sesión estratégica de creadores»
+
+```
+Hola {{first_name}},
+
+Nos reuniremos con creadoras y creadores el {{call_date}} para co-diseñar la próxima narrativa colectiva. Serán 45 minutos enfocados en:
+{{agenda_highlights}}
+
+Confirma tu asistencia para enviarte las parejas de facilitación y los accesos. El material de preparación está aquí: {{resource_folder_link}}.
+
+Llega con un logro, un punto de fricción y una idea audaz.
+
+{{compliance_footer}}
+```
+
+### Portuguese (PT)
+**Sugestão de assunto**: "Participe da sessão estratégica de criadores"
+
+```
+Olá {{first_name}},
+
+Vamos reunir criadoras e criadores em {{call_date}} para co-criar a próxima narrativa coletiva. Serão 45 minutos objetivos com os seguintes tópicos:
+{{agenda_highlights}}
+
+Confirme presença para enviarmos os pares de facilitação e os acessos. Os materiais de preparo estão aqui: {{resource_folder_link}}.
+
+Chegue com uma conquista, um ponto de atrito e uma ideia ousada.
+
+{{compliance_footer}}
+```
+
+### French (FR)
+**Suggestion d’objet** : « Rejoignez notre session stratégie créateur·rices »
+
+```
+Bonjour {{first_name}},
+
+Nous réunissons les créateur·rices le {{call_date}} afin de co-construire la prochaine histoire collective. Comptez 45 minutes intenses autour de :
+{{agenda_highlights}}
+
+Merci de confirmer votre présence pour recevoir les binômes de facilitation et les accès. Les ressources de préparation sont disponibles ici : {{resource_folder_link}}.
+
+Venez avec un succès, un point de friction et une idée audacieuse.
+
+{{compliance_footer}}
+```
+
+### Hindi (HI)
+**विषय सुझाव**: "क्रिएटर रणनीति सत्र में शामिल हों"
+
+```
+नमस्ते {{first_name}},
+
+हम {{call_date}} को क्रिएटरों को एक साथ ला रहे हैं ताकि अगली सामूहिक कहानी को सह-निर्मित किया जा सके। 45 मिनट के इस सत्र में हम चर्चा करेंगे:
+{{agenda_highlights}}
+
+कृपया RSVP करें ताकि हम आपको फसिलिटेशन जोड़े और एक्सेस विवरण भेज सकें। तैयारी की सामग्री यहाँ उपलब्ध है: {{resource_folder_link}}।
+
+एक उपलब्धि, एक चुनौती और एक साहसिक विचार के साथ आइए।
+
+{{compliance_footer}}
+```
+
+### Simplified Chinese (ZH)
+**主题建议**："来参加创作者策略会"
+
+```
+{{first_name}}，你好：
+
+我们将在 {{call_date}} 召集创作者，共同打造下一段集体故事。45 分钟的专注会议将讨论：
+{{agenda_highlights}}
+
+请先 RSVP，以便我们发送协作分组和参会信息。准备资料在此获取：{{resource_folder_link}}。
+
+欢迎带上一项成果、一个卡点和一个大胆想法。
+
+{{compliance_footer}}
+```

--- a/docs/marketing/email_templates/donor-thank-you.md
+++ b/docs/marketing/email_templates/donor-thank-you.md
@@ -1,0 +1,121 @@
+# Donor Thank-You Flow Email Template
+
+## Overview
+Send this note immediately after a contribution posts. Focus on impact transparency and next touch options.
+
+## Placeholders
+- `{{first_name}}`: Donor’s preferred first name.
+- `{{donation_amount}}`: Localized donation amount with currency.
+- `{{initiative_name}}`: Name of the funded initiative.
+- `{{impact_update_link}}`: URL to track impact or read stories.
+- `{{compliance_footer}}`: Insert compliant footer from `compliance.md`.
+
+## Language Variants
+
+### English (EN)
+**Subject cue**: "Your support is already working"
+
+```
+Hi {{first_name}},
+
+Thank you for investing {{donation_amount}} in {{initiative_name}}. Because of you, our facilitators can activate the next round of community-led experiments.
+
+Want to see what you sparked?
+• Follow the live impact board ({{impact_update_link}}) for milestones and transparent spend.
+• Share the project with a friend—every introduction scales the signal.
+• Reply to this email if you’d like a one-on-one briefing.
+
+We’re grateful you trust UrAi to steward collective resources responsibly.
+
+{{compliance_footer}}
+```
+
+### Spanish (ES)
+**Sugerencia de asunto**: «Tu apoyo ya está generando impacto»
+
+```
+Hola {{first_name}},
+
+Gracias por aportar {{donation_amount}} a {{initiative_name}}. Gracias a ti, nuestro equipo puede activar la siguiente ronda de experimentos guiados por la comunidad.
+
+¿Quieres ver lo que impulsaste?
+• Sigue el tablero de impacto en vivo ({{impact_update_link}}) para conocer hitos y uso transparente de fondos.
+• Comparte el proyecto con alguien más; cada invitación amplifica la señal.
+• Responde a este correo si deseas una sesión informativa personalizada.
+
+Agradecemos la confianza que depositas en UrAi para cuidar estos recursos colectivos.
+
+{{compliance_footer}}
+```
+
+### Portuguese (PT)
+**Sugestão de assunto**: "Seu apoio já está transformando"
+
+```
+Olá {{first_name}},
+
+Obrigado por investir {{donation_amount}} em {{initiative_name}}. Com a sua contribuição, nossa equipe pode iniciar a próxima rodada de experimentos conduzidos pela comunidade.
+
+Veja o que você impulsionou:
+• Acompanhe o painel de impacto em tempo real ({{impact_update_link}}) para marcos e uso transparente.
+• Compartilhe o projeto com alguém; cada indicação amplia a rede.
+• Responda este e-mail se quiser um briefing individual.
+
+Agradecemos a confiança em UrAi para administrar esses recursos coletivos com cuidado.
+
+{{compliance_footer}}
+```
+
+### French (FR)
+**Suggestion d’objet** : « Votre soutien produit déjà des résultats »
+
+```
+Bonjour {{first_name}},
+
+Merci d’avoir investi {{donation_amount}} dans {{initiative_name}}. Grâce à vous, nos facilitateur·rices peuvent lancer la prochaine série d’expérimentations menées par la communauté.
+
+Envie de suivre ce que vous avez déclenché ?
+• Consultez le tableau d’impact en direct ({{impact_update_link}}) pour suivre les jalons et l’utilisation transparente des fonds.
+• Partagez le projet autour de vous : chaque recommandation amplifie le signal.
+• Répondez à ce message pour organiser un échange personnalisé.
+
+Merci de faire confiance à UrAi pour gérer les ressources collectives avec responsabilité.
+
+{{compliance_footer}}
+```
+
+### Hindi (HI)
+**विषय सुझाव**: "आपका सहयोग अभी असर दिखा रहा है"
+
+```
+नमस्ते {{first_name}},
+
+{{initiative_name}} के लिए {{donation_amount}} देने के लिए धन्यवाद। आपकी सहायता से हमारी टीम सामुदायिक नेतृत्व वाले अगले प्रयोग तुरंत शुरू कर सकती है।
+
+जो बदलाव आपने शुरू किया उसे देखें:
+• लाइव इम्पैक्ट बोर्ड ({{impact_update_link}}) पर मील के पत्थर और पारदर्शी खर्च देखें।
+• किसी मित्र के साथ परियोजना साझा करें—हर परिचय प्रभाव को बढ़ाता है।
+• व्यक्तिगत ब्रीफिंग के लिए इसी ईमेल का उत्तर दें।
+
+सामूहिक संसाधनों की जिम्मेदार देखरेख के लिए UrAi पर भरोसा करने के लिए आभार।
+
+{{compliance_footer}}
+```
+
+### Simplified Chinese (ZH)
+**主题建议**："你的支持已经带来改变"
+
+```
+{{first_name}}，你好：
+
+感谢你为 {{initiative_name}} 捐赠 {{donation_amount}}。有了你的支持，我们的引导团队可以立即开启下一轮由社区主导的实验。
+
+看看你点燃的改变：
+• 访问实时影响面板（{{impact_update_link}}），了解里程碑与透明的资金使用。
+• 把这个项目分享给朋友，每一次转发都能放大声音。
+• 如需一对一简报，直接回复此邮件即可。
+
+感谢你信任 UrAi，用心守护这些集体资源。
+
+{{compliance_footer}}
+```

--- a/docs/marketing/email_templates/privacy-proof.md
+++ b/docs/marketing/email_templates/privacy-proof.md
@@ -1,0 +1,121 @@
+# Privacy Proof Flow Email Template
+
+## Overview
+Use this message to reassure members about UrAi’s privacy practices, describe certifications, and invite them to review the controls themselves.
+
+## Placeholders
+- `{{first_name}}`: Recipient's preferred first name.
+- `{{privacy_hub_link}}`: Destination for privacy documentation and live dashboards.
+- `{{security_contact}}`: Point of contact for security questions.
+- `{{audit_summary_link}}`: Latest third-party audit overview.
+- `{{compliance_footer}}`: Insert compliant footer from `compliance.md`.
+
+## Language Variants
+
+### English (EN)
+**Subject cue**: "How UrAi keeps your insights private"
+
+```
+Hi {{first_name}},
+
+You asked for transparency—here’s the proof. UrAi encrypts every submission end-to-end, stores only the signals we need, and lets you track access in real time.
+
+What you can review now:
+• Explore the Privacy Hub ({{privacy_hub_link}}) for live data maps and retention settings.
+• Download the latest audit summary ({{audit_summary_link}}) signed by independent reviewers.
+• Message our security team anytime at {{security_contact}} for deeper dives.
+
+Your ideas stay yours. We simply help them move with integrity.
+
+{{compliance_footer}}
+```
+
+### Spanish (ES)
+**Sugerencia de asunto**: «Así protege UrAi tu información»
+
+```
+Hola {{first_name}},
+
+Sabemos que necesitas transparencia. UrAi cifra cada aporte de extremo a extremo, guarda solo los datos indispensables y te permite monitorear los accesos en tiempo real.
+
+Revisa hoy mismo:
+• Entra al Privacy Hub ({{privacy_hub_link}}) para ver mapas de datos en vivo y ajustar retención.
+• Descarga el resumen de auditoría ({{audit_summary_link}}) avalado por revisores independientes.
+• Escribe a nuestro equipo de seguridad en {{security_contact}} si quieres más detalles.
+
+Tus ideas te pertenecen. Nosotros las acompañamos con integridad.
+
+{{compliance_footer}}
+```
+
+### Portuguese (PT)
+**Sugestão de assunto**: "Como a UrAi protege seus dados"
+
+```
+Olá {{first_name}},
+
+Transparência é prioridade aqui. A UrAi criptografa cada envio de ponta a ponta, mantém apenas os sinais necessários e oferece monitoramento de acesso em tempo real.
+
+Veja agora:
+• Acesse o Privacy Hub ({{privacy_hub_link}}) para mapas de dados ao vivo e opções de retenção.
+• Baixe o resumo da auditoria ({{audit_summary_link}}), assinado por especialistas independentes.
+• Fale com nossa equipe de segurança em {{security_contact}} para entender os bastidores.
+
+Suas ideias continuam sendo suas. Nós garantimos que circulem com ética.
+
+{{compliance_footer}}
+```
+
+### French (FR)
+**Suggestion d’objet** : « Comment UrAi protège vos données »
+
+```
+Bonjour {{first_name}},
+
+La transparence est essentielle. UrAi chiffre chaque contribution de bout en bout, ne conserve que l’essentiel et vous offre un suivi des accès en temps réel.
+
+Ce que vous pouvez vérifier :
+• Consultez le Privacy Hub ({{privacy_hub_link}}) pour visualiser les flux de données et régler la conservation.
+• Téléchargez le dernier résumé d’audit ({{audit_summary_link}}) validé par un cabinet indépendant.
+• Contactez notre équipe sécurité à {{security_contact}} pour aller plus loin.
+
+Vos idées restent les vôtres. Nous les faisons avancer avec intégrité.
+
+{{compliance_footer}}
+```
+
+### Hindi (HI)
+**विषय सुझाव**: "UrAi आपकी जानकारी को कैसे सुरक्षित रखता है"
+
+```
+नमस्ते {{first_name}},
+
+पारदर्शिता हमारी प्राथमिकता है। UrAi हर योगदान को एंड-टू-एंड एन्क्रिप्ट करता है, केवल आवश्यक संकेत ही संग्रहीत करता है और आपको वास्तविक समय में एक्सेस मॉनिटर करने देता है।
+
+आज ही देखें:
+• लाइव डेटा मानचित्र और रिटेंशन सेटिंग्स के लिए Privacy Hub ({{privacy_hub_link}}) खोलें।
+• स्वतंत्र समीक्षकों द्वारा प्रमाणित नवीनतम ऑडिट सारांश ({{audit_summary_link}}) डाउनलोड करें।
+• अधिक जानकारी के लिए {{security_contact}} पर हमारी सुरक्षा टीम से संपर्क करें।
+
+आपके विचार आप ही के हैं। हम बस उन्हें ईमानदारी से आगे बढ़ाते हैं।
+
+{{compliance_footer}}
+```
+
+### Simplified Chinese (ZH)
+**主题建议**："UrAi 如何守护你的数据"
+
+```
+{{first_name}}，你好：
+
+透明度对我们至关重要。UrAi 对每一次提交进行端到端加密，只保留必要的信号，并让你实时查看访问记录。
+
+立即可查看：
+• 访问 Privacy Hub（{{privacy_hub_link}}），了解实时数据地图和保留设置。
+• 下载由独立审计方出具的最新审计摘要（{{audit_summary_link}}）。
+• 若需深入交流，可通过 {{security_contact}} 联系安全团队。
+
+你的创意始终属于你。我们只是确保它们被正直地使用。
+
+{{compliance_footer}}
+```

--- a/docs/marketing/email_templates/weekly-scroll.md
+++ b/docs/marketing/email_templates/weekly-scroll.md
@@ -1,0 +1,147 @@
+# Weekly Scroll Flow Email Template
+
+## Overview
+This digest highlights community breakthroughs, upcoming experiments, and curated insights. Keep it skimmable with modular sections.
+
+## Placeholders
+- `{{first_name}}`: Recipient's preferred first name.
+- `{{week_range}}`: Week or date range covered.
+- `{{top_story}}`: Headline story summary.
+- `{{experiment_callout}}`: Key experiment or event to join.
+- `{{resource_roundup}}`: List of recommended resources.
+- `{{feedback_prompt_link}}`: Link for ongoing feedback.
+- `{{compliance_footer}}`: Insert compliant footer from `compliance.md`.
+
+## Language Variants
+
+### English (EN)
+**Subject cue**: "Your UrAi Weekly Scroll"
+
+```
+Hi {{first_name}},
+
+Here’s your Scroll for {{week_range}}. Catch the pulse in minutes:
+
+Top Story
+{{top_story}}
+
+Next Experiment
+{{experiment_callout}}
+
+Resource Roundup
+{{resource_roundup}}
+
+Tell us what you want more of at {{feedback_prompt_link}}.
+
+{{compliance_footer}}
+```
+
+### Spanish (ES)
+**Sugerencia de asunto**: «Tu Scroll semanal de UrAi»
+
+```
+Hola {{first_name}},
+
+Este es tu Scroll de la semana {{week_range}}. Ponte al día en minutos:
+
+Historia destacada
+{{top_story}}
+
+Próximo experimento
+{{experiment_callout}}
+
+Recursos recomendados
+{{resource_roundup}}
+
+Cuéntanos qué quieres ver más en {{feedback_prompt_link}}.
+
+{{compliance_footer}}
+```
+
+### Portuguese (PT)
+**Sugestão de assunto**: "Seu Scroll semanal da UrAi"
+
+```
+Olá {{first_name}},
+
+Aqui está o seu Scroll de {{week_range}}. Capte o essencial em poucos minutos:
+
+História principal
+{{top_story}}
+
+Próximo experimento
+{{experiment_callout}}
+
+Seleção de recursos
+{{resource_roundup}}
+
+Conte o que deseja aprofundar em {{feedback_prompt_link}}.
+
+{{compliance_footer}}
+```
+
+### French (FR)
+**Suggestion d’objet** : « Votre Scroll hebdomadaire UrAi »
+
+```
+Bonjour {{first_name}},
+
+Voici votre Scroll pour la semaine {{week_range}}. Faites le plein d’inspiration en quelques minutes :
+
+Histoire à la une
+{{top_story}}
+
+Prochaine expérimentation
+{{experiment_callout}}
+
+Sélection de ressources
+{{resource_roundup}}
+
+Dites-nous ce que vous voulez explorer davantage sur {{feedback_prompt_link}}.
+
+{{compliance_footer}}
+```
+
+### Hindi (HI)
+**विषय सुझाव**: "आपका UrAi साप्ताहिक Scroll"
+
+```
+नमस्ते {{first_name}},
+
+यह रहा {{week_range}} का आपका Scroll। कुछ मिनटों में पूरी जानकारी पाएँ:
+
+मुख्य कहानी
+{{top_story}}
+
+अगला प्रयोग
+{{experiment_callout}}
+
+चयनित संसाधन
+{{resource_roundup}}
+
+हमें बताएं कि आप क्या और देखना चाहते हैं: {{feedback_prompt_link}}।
+
+{{compliance_footer}}
+```
+
+### Simplified Chinese (ZH)
+**主题建议**："UrAi 每周速览"
+
+```
+{{first_name}}，你好：
+
+这是你在 {{week_range}} 的 Scroll，几分钟了解全部重点：
+
+头条故事
+{{top_story}}
+
+下一项实验
+{{experiment_callout}}
+
+资源精选
+{{resource_roundup}}
+
+想看到更多什么？请告诉我们：{{feedback_prompt_link}}。
+
+{{compliance_footer}}
+```

--- a/docs/marketing/email_templates/welcome.md
+++ b/docs/marketing/email_templates/welcome.md
@@ -1,0 +1,121 @@
+# Welcome Flow Email Template
+
+## Overview
+Use this template for the first touchpoint after someone joins the UrAi community. The copy sets expectations, surfaces quick wins, and reinforces data stewardship.
+
+## Placeholders
+- `{{first_name}}`: Recipient's preferred first name.
+- `{{getting_started_link}}`: URL to onboarding checklist or product tour.
+- `{{support_email}}`: Direct support channel for new members.
+- `{{community_link}}`: Invitation link to community space or forum.
+- `{{compliance_footer}}`: Insert compliant footer from `compliance.md`.
+
+## Language Variants
+
+### English (EN)
+**Subject cue**: "Welcome to UrAi, {{first_name}}!"
+
+```
+Hi {{first_name}},
+
+Welcome to UrAi—we're thrilled you’re here. Start with our guided tour to explore the tools that help you turn insight into collective action.
+
+Top next steps:
+• Visit the getting started dashboard ({{getting_started_link}}) to personalize your experience.
+• Save {{support_email}} so you can reach us when you need a hand.
+• Meet fellow members in the community space ({{community_link}}) and share your first question.
+
+We’re here to back your curiosity and protect your data every step of the way.
+
+{{compliance_footer}}
+```
+
+### Spanish (ES)
+**Sugerencia de asunto**: «Bienvenida/o a UrAi, {{first_name}}»
+
+```
+Hola {{first_name}},
+
+Bienvenida/o a UrAi. Nos alegra recibirte. Comienza con nuestro recorrido guiado para descubrir las herramientas que convierten la intuición colectiva en impacto real.
+
+Próximos pasos clave:
+• Visita el panel de primeros pasos ({{getting_started_link}}) para personalizar tu experiencia.
+• Guarda el correo de soporte {{support_email}} para contactarnos cuando lo necesites.
+• Conoce a otras personas en la comunidad ({{community_link}}) y comparte tu primera pregunta.
+
+Estamos aquí para cuidar tu curiosidad y tus datos en cada paso.
+
+{{compliance_footer}}
+```
+
+### Portuguese (PT)
+**Sugestão de assunto**: "Bem-vinda(o) à UrAi, {{first_name}}"
+
+```
+Olá {{first_name}},
+
+Bem-vinda(o) à UrAi. É um prazer ter você aqui. Comece pelo nosso tour guiado para explorar as ferramentas que transformam inteligência coletiva em ação concreta.
+
+Próximos passos:
+• Acesse o painel de primeiros passos ({{getting_started_link}}) para personalizar sua jornada.
+• Salve o e-mail de suporte {{support_email}} para falar conosco sempre que precisar.
+• Apresente-se na comunidade ({{community_link}}) e compartilhe sua primeira pergunta.
+
+Conte conosco para nutrir sua curiosidade e proteger seus dados sempre.
+
+{{compliance_footer}}
+```
+
+### French (FR)
+**Suggestion d’objet** : « Bienvenue chez UrAi, {{first_name}} »
+
+```
+Bonjour {{first_name}},
+
+Bienvenue chez UrAi ! Nous sommes ravis de vous compter parmi nous. Lancez-vous avec notre visite guidée pour découvrir les outils qui transforment l’intelligence collective en actions concrètes.
+
+Vos prochaines étapes :
+• Ouvrez le tableau de démarrage ({{getting_started_link}}) pour personnaliser votre expérience.
+• Ajoutez notre e-mail d’assistance {{support_email}} à vos contacts pour obtenir de l’aide rapide.
+• Rejoignez la communauté ({{community_link}}) et partagez votre première question.
+
+Nous sommes là pour soutenir votre curiosité et protéger vos données à chaque instant.
+
+{{compliance_footer}}
+```
+
+### Hindi (HI)
+**विषय सुझाव**: "UrAi में आपका स्वागत है, {{first_name}}"
+
+```
+नमस्ते {{first_name}},
+
+UrAi में आपका हार्दिक स्वागत है। हमारी गाइडेड टूर के साथ शुरुआत करें और जानें कि सामूहिक जिज्ञासा को असरदार कार्रवाई में कैसे बदला जाता है।
+
+अगले प्रमुख कदम:
+• अपनी पसंद के अनुसार अनुभव सेट करने के लिए गेटिंग स्टार्टेड डैशबोर्ड ({{getting_started_link}}) खोलें।
+• तुरंत सहायता के लिए हमारे सपोर्ट ईमेल {{support_email}} को सेव करें।
+• समुदाय ({{community_link}}) से जुड़ें और अपना पहला प्रश्न साझा करें।
+
+हम हर कदम पर आपकी जिज्ञासा और आपके डेटा की रक्षा करने के लिए तैयार हैं।
+
+{{compliance_footer}}
+```
+
+### Simplified Chinese (ZH)
+**主题建议**："欢迎加入 UrAi，{{first_name}}"
+
+```
+{{first_name}}，你好：
+
+欢迎加入 UrAi！请先浏览我们的引导式体验，了解如何把集体洞察转化为实际行动。
+
+接下来的关键步骤：
+• 打开新手引导面板（{{getting_started_link}}），按照你的需求定制体验。
+• 保存客服邮箱 {{support_email}}，需要帮助时随时联系我们。
+• 加入社区（{{community_link}}），与成员打招呼并分享你的第一个问题。
+
+我们将一路支持你的好奇心，并细心守护你的数据。
+
+{{compliance_footer}}
+```


### PR DESCRIPTION
## Summary
- add multilingual marketing templates for welcome, privacy proof, donor thanks, creator calls, beta invites, and weekly digests with variable placeholders
- document unsubscribe, address, and privacy compliance snippets in six languages for reuse across flows
- provide Firebase-ready CSV/JSON subject line catalogs per flow covering multiple tones and languages

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6019bedf88325a6759564d8c6987f