### PR TITLE
Add route loading and error boundaries with telemetry

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const nextJest = require("next/jest");
+
+const createJestConfig = nextJest({
+  dir: "./",
+});
+
+const config = {
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
+};
+
+module.exports = createJestConfig(config);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "codemod:dry": "node scripts/replace-demo-user.mjs --dry",
     "codemod:apply": "node scripts/replace-demo-user.mjs",
     "check:types": "tsc --noEmit",
-    "preflight": "npm run check:types && npm run lint && npm run build"
+    "preflight": "npm run check:types && npm run lint && npm run build",
+    "test": "jest"
   },
   "dependencies": {
     "eslint-config-next": "^15.5.2",

--- a/src/app/__tests__/route-boundaries.test.tsx
+++ b/src/app/__tests__/route-boundaries.test.tsx
@@ -1,0 +1,138 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+
+import RootLoading from "@/app/loading";
+import HomeLoading from "@/app/home/loading";
+import OnboardingLoading from "@/app/onboarding/loading";
+import NarratorLoading from "@/app/narrator/loading";
+import CognitiveMirrorLoading from "@/app/cognitive-mirror/loading";
+import LifeMapLoading from "@/app/life-map/loading";
+import JournalLoading from "@/app/journal/loading";
+import ProfileAndPrivacyLoading from "@/app/profile-and-privacy/loading";
+import RecordLoading from "@/app/record/loading";
+import RitualsAndScrollsLoading from "@/app/rituals-and-scrolls/loading";
+import StatusLoading from "@/app/status/loading";
+import SupportLoading from "@/app/support/loading";
+
+import RootError from "@/app/error";
+import HomeError from "@/app/home/error";
+import OnboardingError from "@/app/onboarding/error";
+import NarratorError from "@/app/narrator/error";
+import CognitiveMirrorError from "@/app/cognitive-mirror/error";
+import LifeMapError from "@/app/life-map/error";
+import JournalError from "@/app/journal/error";
+import ProfileAndPrivacyError from "@/app/profile-and-privacy/error";
+import RecordError from "@/app/record/error";
+import RitualsAndScrollsError from "@/app/rituals-and-scrolls/error";
+import StatusError from "@/app/status/error";
+import SupportError from "@/app/support/error";
+
+import {
+  trackRouteLoadStart,
+  trackRouteLoadComplete,
+  captureRouteError,
+  trackInteraction,
+} from "@/lib/telemetry";
+
+jest.mock("@/lib/telemetry", () => ({
+  trackRouteLoadStart: jest.fn(),
+  trackRouteLoadComplete: jest.fn(),
+  captureRouteError: jest.fn(),
+  trackInteraction: jest.fn(),
+}));
+
+type LoadingCase = {
+  route: string;
+  Component: () => ReactElement;
+};
+
+type ErrorCase = {
+  route: string;
+  Component: ({ error, reset }: { error: Error; reset: () => void }) => ReactElement;
+  secondaryLabel: string;
+};
+
+const loadingCases: LoadingCase[] = [
+  { route: "root", Component: RootLoading },
+  { route: "home", Component: HomeLoading },
+  { route: "onboarding", Component: OnboardingLoading },
+  { route: "narrator", Component: NarratorLoading },
+  { route: "cognitive-mirror", Component: CognitiveMirrorLoading },
+  { route: "life-map", Component: LifeMapLoading },
+  { route: "journal", Component: JournalLoading },
+  { route: "profile-and-privacy", Component: ProfileAndPrivacyLoading },
+  { route: "record", Component: RecordLoading },
+  { route: "rituals-and-scrolls", Component: RitualsAndScrollsLoading },
+  { route: "status", Component: StatusLoading },
+  { route: "support", Component: SupportLoading },
+];
+
+const errorCases: ErrorCase[] = [
+  { route: "root", Component: RootError, secondaryLabel: "Visit support" },
+  { route: "home", Component: HomeError, secondaryLabel: "Open life map" },
+  { route: "onboarding", Component: OnboardingError, secondaryLabel: "Go to home" },
+  { route: "narrator", Component: NarratorError, secondaryLabel: "View journal" },
+  { route: "cognitive-mirror", Component: CognitiveMirrorError, secondaryLabel: "View status" },
+  { route: "life-map", Component: LifeMapError, secondaryLabel: "Return home" },
+  { route: "journal", Component: JournalError, secondaryLabel: "Visit support" },
+  { route: "profile-and-privacy", Component: ProfileAndPrivacyError, secondaryLabel: "Contact support" },
+  { route: "record", Component: RecordError, secondaryLabel: "Support options" },
+  { route: "rituals-and-scrolls", Component: RitualsAndScrollsError, secondaryLabel: "Check status" },
+  { route: "status", Component: StatusError, secondaryLabel: "Message support" },
+  { route: "support", Component: SupportError, secondaryLabel: "View status" },
+];
+
+describe("route loading boundaries", () => {
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it.each(loadingCases)("emits telemetry for %s loading", ({ route, Component }) => {
+    const { unmount } = render(<Component />);
+
+    const loadStartMock = trackRouteLoadStart as jest.Mock;
+    expect(loadStartMock.mock.calls.some(([calledRoute]) => calledRoute === route)).toBe(true);
+
+    unmount();
+
+    const loadCompleteMock = trackRouteLoadComplete as jest.Mock;
+    expect(loadCompleteMock.mock.calls.some(([calledRoute]) => calledRoute === route)).toBe(true);
+  });
+});
+
+describe("route error boundaries", () => {
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it.each(errorCases)("logs telemetry for %s errors", ({ route, Component, secondaryLabel }) => {
+    const testError = new Error("boom");
+    const reset = jest.fn();
+
+    render(<Component error={testError} reset={reset} />);
+
+    const captureMock = captureRouteError as jest.Mock;
+    expect(captureMock.mock.calls.some(([calledRoute, err]) => calledRoute === route && err === testError)).toBe(true);
+
+    const retryButton = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(retryButton);
+
+    expect(reset).toHaveBeenCalled();
+
+    const interactionMock = trackInteraction as jest.Mock;
+    expect(
+      interactionMock.mock.calls.some(([action, metadata]) => action === "route_error_retry" && metadata?.route === route),
+    ).toBe(true);
+
+    const secondaryLink = screen.getByRole("link", { name: secondaryLabel });
+    fireEvent.click(secondaryLink);
+
+    expect(
+      interactionMock.mock.calls.some(
+        ([action, metadata]) => action === "route_error_navigation" && metadata?.route === route,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/app/cognitive-mirror/error.tsx
+++ b/src/app/cognitive-mirror/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function CognitiveMirrorError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="cognitive-mirror"
+      error={error}
+      reset={reset}
+      title="Cognitive mirror is foggy"
+      description="We couldn’t project your reflection data. Try again or hop to the status page for more detail."
+      secondaryAction={{ label: "View status", href: "/status" }}
+    />
+  );
+}

--- a/src/app/cognitive-mirror/loading.tsx
+++ b/src/app/cognitive-mirror/loading.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function CognitiveMirrorLoading() {
+  useRouteLoadTelemetry("cognitive-mirror");
+
+  return (
+    <div className="min-h-screen bg-black px-6 py-10 text-white">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="h-8 w-56 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="h-5 w-40 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-64 w-full rounded-2xl bg-white/10 animate-pulse" aria-hidden="true" />
+        </div>
+      </div>
+      <span className="sr-only">Loading cognitive mirror</span>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function RootError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="root"
+      error={error}
+      reset={reset}
+      title="The stage lights flickered"
+      description="The landing sequence stalled. Try again or head to support while we reset the scene."
+      secondaryAction={{ label: "Visit support", href: "/support" }}
+    />
+  );
+}

--- a/src/app/home/error.tsx
+++ b/src/app/home/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function HomeError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="home"
+      error={error}
+      reset={reset}
+      title="Home experience stalled"
+      description="The home scene didn’t finish loading. Try again or jump to your life map while we reload the assets."
+      secondaryAction={{ label: "Open life map", href: "/life-map" }}
+    />
+  );
+}

--- a/src/app/home/loading.tsx
+++ b/src/app/home/loading.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function HomeLoading() {
+  useRouteLoadTelemetry("home");
+
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-between overflow-hidden bg-black px-6 py-10 text-white">
+      <div className="flex w-full max-w-3xl items-center justify-between text-sm text-white/50">
+        <div className="h-4 w-24 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="h-9 w-32 rounded-full border border-white/20 bg-white/10 animate-pulse" aria-hidden="true" />
+      </div>
+      <div className="flex flex-1 flex-col items-center justify-center gap-8 py-16">
+        <div className="h-60 w-40 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="h-16 w-16 rounded-full bg-blue-400/60 blur-sm animate-pulse" aria-hidden="true" />
+        <div className="h-12 w-48 rounded-full bg-white/20 animate-pulse" aria-hidden="true" />
+      </div>
+      <div className="flex gap-4 pb-6">
+        <div className="h-9 w-20 rounded-full border border-white/20 bg-white/5 animate-pulse" aria-hidden="true" />
+        <div className="h-9 w-20 rounded-full border border-white/20 bg-white/5 animate-pulse" aria-hidden="true" />
+        <div className="h-9 w-24 rounded-full border border-white/20 bg-white/5 animate-pulse" aria-hidden="true" />
+      </div>
+      <span className="sr-only">Loading home experience</span>
+    </div>
+  );
+}

--- a/src/app/journal/error.tsx
+++ b/src/app/journal/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function JournalError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="journal"
+      error={error}
+      reset={reset}
+      title="Journal is unavailable"
+      description="We couldn’t pull in your latest entries. Try again or visit the support hub for updates."
+      secondaryAction={{ label: "Visit support", href: "/support" }}
+    />
+  );
+}

--- a/src/app/journal/loading.tsx
+++ b/src/app/journal/loading.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function JournalLoading() {
+  useRouteLoadTelemetry("journal");
+
+  return (
+    <div className="min-h-screen bg-black px-6 py-10 text-white">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="h-8 w-32 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
+              <div className="h-4 w-40 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+              <div className="h-16 w-full rounded-2xl bg-white/10 animate-pulse" aria-hidden="true" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <span className="sr-only">Loading journal entries</span>
+    </div>
+  );
+}

--- a/src/app/life-map/error.tsx
+++ b/src/app/life-map/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function LifeMapError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="life-map"
+      error={error}
+      reset={reset}
+      title="Life map is out of orbit"
+      description="The map of your states didn’t render. Try again or drop into the home scene while we realign things."
+      secondaryAction={{ label: "Return home", href: "/home" }}
+    />
+  );
+}

--- a/src/app/life-map/loading.tsx
+++ b/src/app/life-map/loading.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function LifeMapLoading() {
+  useRouteLoadTelemetry("life-map");
+
+  return (
+    <div className="min-h-screen bg-black px-6 py-10 text-white">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <div className="h-8 w-36 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="flex flex-wrap gap-3">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className="h-9 w-20 rounded-full border border-white/15 bg-white/5 animate-pulse" aria-hidden="true" />
+          ))}
+        </div>
+      </div>
+      <span className="sr-only">Loading life map</span>
+    </div>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function RootLoading() {
+  useRouteLoadTelemetry("root");
+
+  return (
+    <div className="relative flex h-dvh w-full items-center justify-center overflow-hidden bg-black">
+      <div className="absolute inset-0 bg-gradient-to-b from-white/10 via-white/5 to-black animate-pulse" aria-hidden="true" />
+      <div className="relative z-10 flex flex-col items-center gap-6 text-center text-white/70">
+        <div className="h-32 w-32 rounded-full bg-white/20 blur-xl" aria-hidden="true" />
+        <div className="space-y-3">
+          <div className="mx-auto h-3 w-48 rounded-full bg-white/20" aria-hidden="true" />
+          <div className="mx-auto h-3 w-32 rounded-full bg-white/10" aria-hidden="true" />
+        </div>
+      </div>
+      <span className="sr-only">Loading URAI</span>
+    </div>
+  );
+}

--- a/src/app/narrator/error.tsx
+++ b/src/app/narrator/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function NarratorError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="narrator"
+      error={error}
+      reset={reset}
+      title="Narrators are warming up"
+      description="The roster of narrators didn't load. Try again or open your journal while we re-sync the voices."
+      secondaryAction={{ label: "View journal", href: "/journal" }}
+    />
+  );
+}

--- a/src/app/narrator/loading.tsx
+++ b/src/app/narrator/loading.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function NarratorLoading() {
+  useRouteLoadTelemetry("narrator");
+
+  return (
+    <div className="min-h-screen bg-black px-6 py-10 text-white">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <div className="h-8 w-40 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-6">
+          <div className="h-5 w-48 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="space-y-3 pt-3">
+            <div className="h-11 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+            <div className="h-11 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+            <div className="h-11 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          </div>
+        </div>
+      </div>
+      <span className="sr-only">Loading narrator options</span>
+    </div>
+  );
+}

--- a/src/app/onboarding/error.tsx
+++ b/src/app/onboarding/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function OnboardingError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="onboarding"
+      error={error}
+      reset={reset}
+      title="Onboarding paused"
+      description="We couldn't start the onboarding flow. Try again or explore the home scene while we stabilize things."
+      secondaryAction={{ label: "Go to home", href: "/home" }}
+    />
+  );
+}

--- a/src/app/onboarding/loading.tsx
+++ b/src/app/onboarding/loading.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function OnboardingLoading() {
+  useRouteLoadTelemetry("onboarding");
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-black text-white">
+      <div className="space-y-3 text-center">
+        <div className="mx-auto h-10 w-36 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="mx-auto h-4 w-64 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+      </div>
+      <div className="h-12 w-40 rounded-full bg-white/20 animate-pulse" aria-hidden="true" />
+      <span className="sr-only">Preparing onboarding</span>
+    </div>
+  );
+}

--- a/src/app/profile-and-privacy/error.tsx
+++ b/src/app/profile-and-privacy/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function ProfileAndPrivacyError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="profile-and-privacy"
+      error={error}
+      reset={reset}
+      title="Profile controls are offline"
+      description="We couldn’t load your profile and privacy preferences. Try again or ping support if it keeps happening."
+      secondaryAction={{ label: "Contact support", href: "/support" }}
+    />
+  );
+}

--- a/src/app/profile-and-privacy/loading.tsx
+++ b/src/app/profile-and-privacy/loading.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function ProfileAndPrivacyLoading() {
+  useRouteLoadTelemetry("profile-and-privacy");
+
+  return (
+    <div className="min-h-screen bg-black px-6 py-10 text-white">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <div className="h-8 w-60 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="h-4 w-48 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-4 w-64 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-4 w-40 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        </div>
+      </div>
+      <span className="sr-only">Loading profile and privacy settings</span>
+    </div>
+  );
+}

--- a/src/app/record/error.tsx
+++ b/src/app/record/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function RecordError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="record"
+      error={error}
+      reset={reset}
+      title="Recorder is muted"
+      description="We couldn't start the recording studio. Try again or review support resources for troubleshooting."
+      secondaryAction={{ label: "Support options", href: "/support" }}
+    />
+  );
+}

--- a/src/app/record/loading.tsx
+++ b/src/app/record/loading.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function RecordLoading() {
+  useRouteLoadTelemetry("record");
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-black px-6 text-white">
+      <div className="h-8 w-56 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+      <div className="h-12 w-48 rounded-full bg-white/20 animate-pulse" aria-hidden="true" />
+      <div className="h-24 w-72 rounded-3xl border border-white/15 bg-white/5 animate-pulse" aria-hidden="true" />
+      <span className="sr-only">Preparing recorder</span>
+    </div>
+  );
+}

--- a/src/app/rituals-and-scrolls/error.tsx
+++ b/src/app/rituals-and-scrolls/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function RitualsAndScrollsError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="rituals-and-scrolls"
+      error={error}
+      reset={reset}
+      title="Rituals are delayed"
+      description="The rituals & scrolls feed isn’t available right now. Try again or check the status board."
+      secondaryAction={{ label: "Check status", href: "/status" }}
+    />
+  );
+}

--- a/src/app/rituals-and-scrolls/loading.tsx
+++ b/src/app/rituals-and-scrolls/loading.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function RitualsAndScrollsLoading() {
+  useRouteLoadTelemetry("rituals-and-scrolls");
+
+  return (
+    <div className="min-h-screen bg-black px-6 py-10 text-white">
+      <div className="mx-auto max-w-2xl space-y-5">
+        <div className="h-8 w-52 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        <div className="space-y-3">
+          <div className="h-4 w-64 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-4 w-56 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        </div>
+      </div>
+      <span className="sr-only">Loading rituals & scrolls</span>
+    </div>
+  );
+}

--- a/src/app/status/error.tsx
+++ b/src/app/status/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function StatusError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="status"
+      error={error}
+      reset={reset}
+      title="Status dashboard offline"
+      description="We couldn't fetch the latest uptime signals. Try again or reach out if you're spotting something urgent."
+      secondaryAction={{ label: "Message support", href: "/support" }}
+    />
+  );
+}

--- a/src/app/status/loading.tsx
+++ b/src/app/status/loading.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function StatusLoading() {
+  useRouteLoadTelemetry("status");
+
+  return (
+    <main className="min-h-screen bg-black px-6 py-16 text-white">
+      <div className="mx-auto max-w-5xl space-y-10">
+        <header className="space-y-4">
+          <div className="h-3 w-32 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-8 w-72 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-4 w-full rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-4 w-3/4 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        </header>
+        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="h-28 rounded-3xl border border-white/10 bg-white/5 animate-pulse" aria-hidden="true" />
+          ))}
+        </section>
+        <section className="h-48 rounded-3xl border border-white/10 bg-white/5 animate-pulse" aria-hidden="true" />
+      </div>
+      <span className="sr-only">Loading service status</span>
+    </main>
+  );
+}

--- a/src/app/support/error.tsx
+++ b/src/app/support/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RouteErrorFallback from "@/components/RouteErrorFallback";
+
+export default function SupportError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <RouteErrorFallback
+      route="support"
+      error={error}
+      reset={reset}
+      title="Support desk is busy"
+      description="We couldn’t load the help guides. Try again or view the status feed for live updates."
+      secondaryAction={{ label: "View status", href: "/status" }}
+    />
+  );
+}

--- a/src/app/support/loading.tsx
+++ b/src/app/support/loading.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useRouteLoadTelemetry } from "@/lib/useRouteLoadTelemetry";
+
+export default function SupportLoading() {
+  useRouteLoadTelemetry("support");
+
+  return (
+    <main className="min-h-screen bg-black px-6 py-16 text-white">
+      <div className="mx-auto max-w-4xl space-y-10">
+        <header className="space-y-4 text-center sm:text-left">
+          <div className="h-3 w-28 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-8 w-64 rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+          <div className="h-4 w-full rounded-full bg-white/10 animate-pulse" aria-hidden="true" />
+        </header>
+        <section className="grid gap-6 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-48 rounded-3xl border border-white/10 bg-white/5 animate-pulse" aria-hidden="true" />
+          ))}
+        </section>
+        <section className="h-40 rounded-3xl border border-white/10 bg-white/5 animate-pulse" aria-hidden="true" />
+      </div>
+      <span className="sr-only">Loading support content</span>
+    </main>
+  );
+}

--- a/src/components/RouteErrorFallback.tsx
+++ b/src/components/RouteErrorFallback.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { ReactNode, useCallback, useEffect, useRef } from "react";
+import { captureRouteError, trackInteraction, TelemetryMetadata } from "@/lib/telemetry";
+
+type SecondaryAction = {
+  label: string;
+  href: string;
+  beforeNavigate?: () => void;
+};
+
+type RouteErrorFallbackProps = {
+  route: string;
+  error: Error;
+  reset: () => void;
+  title?: ReactNode;
+  description?: ReactNode;
+  retryLabel?: string;
+  metadata?: TelemetryMetadata;
+  secondaryAction?: SecondaryAction;
+};
+
+export default function RouteErrorFallback({
+  route,
+  error,
+  reset,
+  title = "We hit a snag",
+  description = "Give it another go, or head somewhere else while we investigate.",
+  retryLabel = "Try again",
+  metadata,
+  secondaryAction,
+}: RouteErrorFallbackProps) {
+  const loggedRef = useRef(false);
+
+  useEffect(() => {
+    if (loggedRef.current) {
+      return;
+    }
+    captureRouteError(route, error, metadata);
+    loggedRef.current = true;
+  }, [error, metadata, route]);
+
+  const handleRetry = useCallback(() => {
+    trackInteraction("route_error_retry", { route, ...metadata });
+    reset();
+  }, [metadata, reset, route]);
+
+  const handleNavigate = useCallback(() => {
+    trackInteraction("route_error_navigation", { route, href: secondaryAction?.href, ...metadata });
+    secondaryAction?.beforeNavigate?.();
+  }, [metadata, route, secondaryAction]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-black px-6 py-16 text-center text-white">
+      <div className="max-w-md space-y-4">
+        <h2 className="text-2xl font-semibold sm:text-3xl">{title}</h2>
+        <p className="text-base leading-relaxed text-white/70">{description}</p>
+        <div className="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleRetry}
+            className="inline-flex min-w-[160px] items-center justify-center rounded-full bg-white px-6 py-2 text-sm font-semibold text-black transition hover:bg-white/90"
+          >
+            {retryLabel}
+          </button>
+          {secondaryAction ? (
+            <Link
+              href={secondaryAction.href}
+              onClick={handleNavigate}
+              className="inline-flex min-w-[160px] items-center justify-center rounded-full border border-white/30 px-6 py-2 text-sm font-semibold text-white transition hover:border-white/50"
+            >
+              {secondaryAction.label}
+            </Link>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,89 @@
+export type TelemetryEventType =
+  | "route_load_start"
+  | "route_load_complete"
+  | "route_error"
+  | "interaction";
+
+export type TelemetryMetadata = Record<string, unknown> | undefined;
+
+export type TelemetryEvent = {
+  type: TelemetryEventType;
+  route?: string;
+  action?: string;
+  metadata?: TelemetryMetadata;
+  error?: Error;
+  timestamp: number;
+};
+
+type TelemetrySubscriber = (event: TelemetryEvent) => void;
+
+const subscribers: TelemetrySubscriber[] = [];
+
+export function subscribeToTelemetry(subscriber: TelemetrySubscriber) {
+  subscribers.push(subscriber);
+  return () => {
+    const index = subscribers.indexOf(subscriber);
+    if (index >= 0) {
+      subscribers.splice(index, 1);
+    }
+  };
+}
+
+function emit(event: TelemetryEvent) {
+  subscribers.forEach((subscriber) => {
+    try {
+      subscriber(event);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn("Telemetry subscriber failed", error);
+    }
+  });
+
+  if (typeof window !== "undefined") {
+    const globalTelemetry = (window as unknown as { uraiTelemetry?: { emit?: (event: TelemetryEvent) => void } }).uraiTelemetry;
+    if (globalTelemetry?.emit) {
+      try {
+        globalTelemetry.emit(event);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn("Global telemetry emit failed", error);
+      }
+    }
+  }
+
+  if (process.env.NODE_ENV !== "production") {
+    const { type, route, action, metadata } = event;
+    const payload = { route, action, metadata };
+    // eslint-disable-next-line no-console
+    console.debug(`[telemetry] ${type}`, payload);
+  }
+}
+
+export function trackRouteLoadStart(route: string, metadata?: TelemetryMetadata) {
+  emit({ type: "route_load_start", route, metadata, timestamp: Date.now() });
+}
+
+export function trackRouteLoadComplete(route: string, metadata?: TelemetryMetadata) {
+  emit({ type: "route_load_complete", route, metadata, timestamp: Date.now() });
+}
+
+export function captureRouteError(route: string, error: Error, metadata?: TelemetryMetadata) {
+  emit({ type: "route_error", route, error, metadata, timestamp: Date.now() });
+
+  if (typeof window !== "undefined") {
+    const sentry = (window as unknown as { Sentry?: { captureException?: (error: Error, context?: Record<string, unknown>) => void } }).Sentry;
+    if (sentry?.captureException) {
+      sentry.captureException(error, {
+        tags: { route },
+        extra: metadata ?? {},
+      });
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(`Route error in ${route}`, error, metadata);
+}
+
+export function trackInteraction(action: string, metadata?: TelemetryMetadata) {
+  emit({ type: "interaction", action, metadata, timestamp: Date.now() });
+}

--- a/src/lib/useRouteLoadTelemetry.ts
+++ b/src/lib/useRouteLoadTelemetry.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+import { trackRouteLoadComplete, trackRouteLoadStart, TelemetryMetadata } from "@/lib/telemetry";
+
+export function useRouteLoadTelemetry(route: string, metadata?: TelemetryMetadata) {
+  useEffect(() => {
+    trackRouteLoadStart(route, metadata);
+    return () => {
+      trackRouteLoadComplete(route, metadata);
+    };
+    // metadata is intentionally excluded from deps to avoid re-emitting when object identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [route]);
+}


### PR DESCRIPTION
## Summary
- add shared telemetry helpers and an error fallback component to standardize analytics and logging across route boundaries
- create skeleton `loading.tsx` and friendly `error.tsx` experiences for every top-level app route, each wired into the telemetry utilities
- configure Jest and add route boundary tests to ensure telemetry hooks fire for loading, retry, and navigation interactions

## Testing
- npm test -- --runInBand *(fails: jest binary unavailable because npm install is blocked by registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d60303a4008325b3c44983b73b0ad6