### PR TITLE
Update Firestore owner checks and add rule tests

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,33 +1,81 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function ownerUid() {
+      return request.method == 'create'
+        ? request.resource.data.ownerUid
+        : resource.data.ownerUid;
+    }
+
     // Each user can access their own user doc
     match /users/{uid} {
       allow read, write: if request.auth != null && request.auth.uid == uid;
     }
 
     // Top-level collections use `ownerUid`
-    match /dreams/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /rituals/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /timelineEvents/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /personaEvolutions/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /soulThreads/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /socialArchetypes/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /weeklyScrolls/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /moods/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /shadowMetrics/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /obscuraPatterns/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /cognitiveStress/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /recoveryBlooms/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /relationshipConstellations/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /voiceEvents/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /dreamConstellations/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /memoryBlooms/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /badges/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /notifications/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /journalEntries/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /events/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
-    match /insightMarket/{id} { allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerUid; }
+    match /dreams/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /rituals/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /timelineEvents/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /personaEvolutions/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /soulThreads/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /socialArchetypes/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /weeklyScrolls/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /moods/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /shadowMetrics/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /obscuraPatterns/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /cognitiveStress/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /recoveryBlooms/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /relationshipConstellations/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /voiceEvents/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /dreamConstellations/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /memoryBlooms/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /badges/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /notifications/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /journalEntries/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /events/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
+    match /insightMarket/{id} {
+      allow read, write: if request.auth != null && request.auth.uid == ownerUid();
+    }
 
     // Feedback + bug capture live outside auth to make onboarding frictionless
     match /feedback/{id} {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.js'],
+  verbose: true,
+  testTimeout: 20000,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^19.1.1"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^3.0.0",
         "@playwright/test": "^1.40.0",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "codemod:dry": "node scripts/replace-demo-user.mjs --dry",
     "codemod:apply": "node scripts/replace-demo-user.mjs",
     "check:types": "tsc --noEmit",
-    "preflight": "npm run check:types && npm run lint && npm run build"
+    "preflight": "npm run check:types && npm run lint && npm run build",
+    "test:rules": "jest --config jest.config.js tests/rules"
   },
   "dependencies": {
     "eslint-config-next": "^15.5.2",
@@ -24,6 +25,7 @@
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^3.0.0",
     "@playwright/test": "^1.40.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",

--- a/tests/rules/firestoreRules.test.js
+++ b/tests/rules/firestoreRules.test.js
@@ -1,0 +1,86 @@
+const path = require('path');
+const fs = require('fs');
+const {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+} = require('@firebase/rules-unit-testing');
+
+const PROJECT_ID = 'urai-security-rules-test';
+const RULES_PATH = path.resolve(__dirname, '../../firestore.rules');
+const OWNER_ENFORCED_COLLECTIONS = [
+  'dreams',
+  'rituals',
+  'timelineEvents',
+  'personaEvolutions',
+  'soulThreads',
+  'socialArchetypes',
+  'weeklyScrolls',
+  'moods',
+  'shadowMetrics',
+  'obscuraPatterns',
+  'cognitiveStress',
+  'recoveryBlooms',
+  'relationshipConstellations',
+  'voiceEvents',
+  'dreamConstellations',
+  'memoryBlooms',
+  'badges',
+  'notifications',
+  'journalEntries',
+  'events',
+  'insightMarket',
+];
+
+let testEnv;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: fs.readFileSync(RULES_PATH, 'utf8'),
+    },
+  });
+});
+
+afterAll(async () => {
+  if (testEnv) {
+    await testEnv.cleanup();
+  }
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+const getAuthedDb = (uid) => testEnv.authenticatedContext(uid).firestore();
+
+describe('owner-enforced collections', () => {
+  describe.each(OWNER_ENFORCED_COLLECTIONS)('%s', (collectionName) => {
+    it('allows an authenticated user to create their own document', async () => {
+      const uid = 'user_123';
+      const db = getAuthedDb(uid);
+      const docRef = db.collection(collectionName).doc('doc-owner');
+
+      await assertSucceeds(
+        docRef.set({
+          ownerUid: uid,
+          createdAt: new Date().toISOString(),
+        }),
+      );
+    });
+
+    it("denies creating a document when the ownerUid doesn't match the authenticated user", async () => {
+      const uid = 'user_123';
+      const db = getAuthedDb(uid);
+      const docRef = db.collection(collectionName).doc('doc-mismatch');
+
+      await assertFails(
+        docRef.set({
+          ownerUid: 'someone_else',
+          createdAt: new Date().toISOString(),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an `ownerUid()` helper in the Firestore rules and reuse it across the top-level collections to support create semantics
- introduce Jest configuration and a reusable rule test suite that validates matching-owner create requests succeed and mismatched owners fail across the protected collections
- expose an `npm run test:rules` script for running the Firestore security rule tests locally

## Testing
- npm run test:rules *(fails in this environment because Jest and rule testing dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d602f28464832580c2f63f9466d269