### PR TITLE
Add onboarding gate client wrapper

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+const nextJest = require("next/jest");
+
+const createJestConfig = nextJest({
+  dir: "./",
+});
+
+const customJestConfig = {
+  testEnvironment: "jsdom",
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint --ext .ts,.tsx src || true",
+    "test": "node node_modules/jest/bin/jest.js",
     "ci": "npm ci && npm run check:types && npm run lint && npm run build",
     "health": "bash ./scripts/baseline_health_check.sh",
     "clean": "rimraf .next node_modules .turbo",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,18 @@
-import './globals.css';
-import MainLayout from '../components/layout/MainLayout';
+import "./globals.css";
+import { ReactNode } from "react";
+
+import OnboardingGate from "../components/layout/OnboardingGate";
 
 export const metadata = {
-  title: 'URAI',
-  description: 'Your Emotional Media OS',
+  title: "URAI",
+  description: "Your Emotional Media OS",
 };
 
-export default function RootLayout({ children, ...props }) {
-  const isOnboarding = props.router?.pathname === '/onboarding';
-
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        {isOnboarding ? children : <MainLayout>{children}</MainLayout>}
+        <OnboardingGate>{children}</OnboardingGate>
       </body>
     </html>
   );

--- a/src/components/layout/OnboardingGate.tsx
+++ b/src/components/layout/OnboardingGate.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+import MainLayout from "./MainLayout";
+
+type OnboardingGateProps = {
+  children: ReactNode;
+};
+
+const OnboardingGate = ({ children }: OnboardingGateProps) => {
+  const pathname = usePathname();
+  const isOnboardingRoute = pathname?.startsWith("/onboarding");
+
+  if (isOnboardingRoute) {
+    return <>{children}</>;
+  }
+
+  return <MainLayout>{children}</MainLayout>;
+};
+
+export default OnboardingGate;

--- a/src/components/layout/__tests__/OnboardingGate.test.tsx
+++ b/src/components/layout/__tests__/OnboardingGate.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import OnboardingGate from "../OnboardingGate";
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+
+const usePathname = jest.requireMock("next/navigation").usePathname as jest.Mock;
+
+jest.mock("../MainLayout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="main-layout">{children}</div>
+  ),
+}));
+
+describe("OnboardingGate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders children directly for onboarding routes", () => {
+    usePathname.mockReturnValue("/onboarding");
+
+    render(
+      <OnboardingGate>
+        <p>Onboarding Content</p>
+      </OnboardingGate>
+    );
+
+    expect(screen.getByText("Onboarding Content")).toBeInTheDocument();
+    expect(screen.queryByTestId("main-layout")).toBeNull();
+  });
+
+  it("wraps children with MainLayout for non-onboarding routes", () => {
+    usePathname.mockReturnValue("/dashboard");
+
+    render(
+      <OnboardingGate>
+        <p>Main App</p>
+      </OnboardingGate>
+    );
+
+    expect(screen.getByTestId("main-layout")).toBeInTheDocument();
+    expect(screen.getByText("Main App")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap the root layout with a client-side onboarding gate that selects the correct shell per route
- add a dedicated OnboardingGate component that reads the current pathname and wraps MainLayout when appropriate
- configure Jest for the project and cover both onboarding and main layout rendering paths with new unit tests

## Testing
- npm test *(fails: jest binary is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d602fa2c748325abbf951a80982f69