### PR TITLE
Add Firebase auth client helpers and emulator integration tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+import nextJest from 'next/jest';
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const config = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testTimeout: 60000,
+};
+
+export default createJestConfig(config);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,11 @@
+import '@testing-library/jest-dom/extend-expect';
+
+process.env.NEXT_PUBLIC_FIREBASE_API_KEY = process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? 'fake-api-key';
+process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? 'fake.firebaseapp.com';
+process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? 'demo-urai';
+process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? 'demo-urai.appspot.com';
+process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? '1234567890';
+process.env.NEXT_PUBLIC_FIREBASE_APP_ID = process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? '1:1234567890:web:abcdef123456';
+process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST = process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST ?? 'http://127.0.0.1:9099';
+process.env.GCLOUD_PROJECT = process.env.GCLOUD_PROJECT ?? 'demo-urai';
+process.env.FIREBASE_PROJECT = process.env.FIREBASE_PROJECT ?? 'demo-urai';

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint --ext .ts,.tsx src || true",
+    "test": "jest",
     "ci": "npm ci && npm run check:types && npm run lint && npm run build",
     "health": "bash ./scripts/baseline_health_check.sh",
     "clean": "rimraf .next node_modules .turbo",

--- a/src/app/__tests__/auth.integration.test.tsx
+++ b/src/app/__tests__/auth.integration.test.tsx
@@ -1,0 +1,278 @@
+import { ChildProcess, spawn } from 'child_process';
+import path from 'path';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { createUserWithEmailAndPassword, signOut as firebaseSignOut } from 'firebase/auth';
+import HomePage from '../home/page';
+import OnboardingPage from '../onboarding/page';
+import { initAuthClient, useAuth } from '../auth';
+import { auth as getFirebaseAuth } from '@/lib/firebase';
+
+const routerPushMock = jest.fn();
+const routerReplaceMock = jest.fn();
+
+let mockPathname = '/';
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useRouter: () => ({
+    push: routerPushMock,
+    replace: routerReplaceMock,
+  }),
+  usePathname: () => mockPathname,
+}));
+
+const PROJECT_ID = 'demo-urai';
+const EMULATOR_HOST = '127.0.0.1';
+const EMULATOR_PORT = 9099;
+const EMULATOR_URL = `http://${EMULATOR_HOST}:${EMULATOR_PORT}`;
+
+let emulatorProcess: ChildProcess | null = null;
+let emulatorAvailable = true;
+
+async function startAuthEmulator() {
+  const binCandidates = [
+    path.join(process.cwd(), 'node_modules', '.bin', 'firebase'),
+    'firebase',
+  ];
+
+  for (const candidate of binCandidates) {
+    try {
+      const child = spawn(candidate, [
+        'emulators:start',
+        '--only',
+        'auth',
+        '--project',
+        PROJECT_ID,
+        '--host',
+        EMULATOR_HOST,
+        '--port',
+        String(EMULATOR_PORT),
+      ], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const readyPromise = new Promise<void>((resolve, reject) => {
+        const handleOutput = (data: Buffer) => {
+          const text = data.toString();
+          if (text.includes('All emulators ready!')) {
+            child.stdout?.off('data', handleOutput);
+            child.stderr?.off('data', handleOutput);
+            resolve();
+          }
+        };
+
+        const handleError = (error: Error) => {
+          child.stdout?.off('data', handleOutput);
+          child.stderr?.off('data', handleOutput);
+          reject(error);
+        };
+
+        child.once('error', handleError);
+        child.stdout?.on('data', handleOutput);
+        child.stderr?.on('data', handleOutput);
+      });
+
+      emulatorProcess = child;
+      await readyPromise;
+      return;
+    } catch (error) {
+      // Try the next candidate
+    }
+  }
+
+  throw new Error('Unable to locate firebase-tools CLI to start the Auth emulator');
+}
+
+async function stopAuthEmulator() {
+  if (!emulatorProcess) {
+    return;
+  }
+
+  emulatorProcess.kill();
+  await new Promise<void>((resolve) => {
+    emulatorProcess?.once('exit', () => resolve());
+  });
+  emulatorProcess = null;
+}
+
+async function assignCustomClaims(uid: string, claims: Record<string, unknown>) {
+  const response = await fetch(`${EMULATOR_URL}/emulator/v1/projects/${PROJECT_ID}/accounts:update`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      localId: uid,
+      customAttributes: JSON.stringify(claims),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to set custom claims: ${response.status} ${response.statusText}`);
+  }
+}
+
+const { AuthProvider } = initAuthClient();
+
+function AuthStateProbe() {
+  const authState = useAuth();
+  return (
+    <div data-testid="auth-state">
+      {authState.userStatus}:{authState.user?.email ?? 'none'}
+    </div>
+  );
+}
+
+beforeAll(async () => {
+  jest.setTimeout(120000);
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST = EMULATOR_URL;
+  process.env.FIREBASE_AUTH_EMULATOR_HOST = `${EMULATOR_HOST}:${EMULATOR_PORT}`;
+  try {
+    await startAuthEmulator();
+  } catch (error) {
+    emulatorAvailable = false;
+    console.warn('Skipping auth integration tests; unable to launch Firebase emulator.', error);
+  }
+});
+
+afterAll(async () => {
+  if (emulatorAvailable) {
+    await stopAuthEmulator();
+  }
+});
+
+beforeEach(async () => {
+  routerPushMock.mockClear();
+  routerReplaceMock.mockClear();
+  mockPathname = '/';
+
+  if (!emulatorAvailable) {
+    return;
+  }
+
+  const auth = getFirebaseAuth();
+  await firebaseSignOut(auth).catch(() => undefined);
+});
+
+describe('Auth integration (Firebase emulator)', () => {
+  test('sign-in and sign-out update the auth context state', async () => {
+    if (!emulatorAvailable) {
+      return;
+    }
+
+    const auth = getFirebaseAuth();
+    const email = `user-${Date.now()}@example.com`;
+    const password = 'Password123!';
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    await act(async () => {
+      await createUserWithEmailAndPassword(auth, email, password);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state')).toHaveTextContent(`authenticated:${email}`);
+    });
+
+    await act(async () => {
+      await firebaseSignOut(auth);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state')).toHaveTextContent('unauthenticated:none');
+    });
+  });
+
+  test('home route redirects anonymous or signed-out users to onboarding', async () => {
+    if (!emulatorAvailable) {
+      return;
+    }
+
+    const auth = getFirebaseAuth();
+    await firebaseSignOut(auth).catch(() => undefined);
+
+    mockPathname = '/home';
+
+    render(
+      <AuthProvider>
+        <HomePage />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith('/onboarding');
+    });
+
+    expect(screen.getByText(/Redirecting you to onboarding/i)).toBeInTheDocument();
+  });
+
+  test('home route renders role-based content once claims resolve', async () => {
+    if (!emulatorAvailable) {
+      return;
+    }
+
+    const auth = getFirebaseAuth();
+    const email = `guide-${Date.now()}@example.com`;
+    const password = 'Password123!';
+
+    await act(async () => {
+      await createUserWithEmailAndPassword(auth, email, password);
+    });
+
+    const currentUser = auth.currentUser;
+    if (!currentUser) {
+      throw new Error('User not available after sign-in');
+    }
+
+    await assignCustomClaims(currentUser.uid, { roles: ['guide'] });
+    await act(async () => {
+      await currentUser.getIdToken(true);
+    });
+
+    mockPathname = '/home';
+
+    render(
+      <AuthProvider>
+        <HomePage />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Guide Dashboard')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Review Journeys')).toBeInTheDocument();
+  });
+
+  test('onboarding route forwards signed-in members to home', async () => {
+    if (!emulatorAvailable) {
+      return;
+    }
+
+    const auth = getFirebaseAuth();
+    const email = `member-${Date.now()}@example.com`;
+    const password = 'Password123!';
+
+    await act(async () => {
+      await createUserWithEmailAndPassword(auth, email, password);
+    });
+
+    mockPathname = '/onboarding';
+
+    render(
+      <AuthProvider>
+        <OnboardingPage />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith('/home');
+    });
+  });
+});
+

--- a/src/app/auth.ts
+++ b/src/app/auth.ts
@@ -1,0 +1,197 @@
+'use client';
+
+import { auth as getFirebaseAuth } from '@/lib/firebase';
+import {
+  Auth,
+  GoogleAuthProvider,
+  IdTokenResult,
+  User,
+  UserCredential,
+  connectAuthEmulator,
+  onIdTokenChanged,
+  signInAnonymously as firebaseSignInAnonymously,
+  signInWithPopup,
+  signOut as firebaseSignOut,
+} from 'firebase/auth';
+import React, {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export type AuthStatus = 'idle' | 'loading' | 'authenticated' | 'unauthenticated';
+export type ClaimsStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface AuthContextValue {
+  /** Firebase Auth instance */
+  auth: Auth;
+  /** Current signed-in Firebase user */
+  user: User | null;
+  /** Custom claims decoded from the ID token */
+  claims: IdTokenResult['claims'] | null;
+  /** Whether we are currently resolving the user */
+  userStatus: AuthStatus;
+  /** Whether we are currently resolving the claims for the active user */
+  claimsStatus: ClaimsStatus;
+  /** Last error encountered while resolving auth state */
+  error: Error | null;
+  /** Signs a user in with the configured Google provider */
+  signInWithGoogle: () => Promise<UserCredential>;
+  /** Signs the current user out */
+  signOut: () => Promise<void>;
+  /** Issues an anonymous sign-in (primarily for tests) */
+  signInAnonymously: () => Promise<UserCredential>;
+}
+
+interface AuthClient {
+  AuthProvider: React.FC<{ children: ReactNode }>;
+}
+
+let cachedClient: AuthClient | null = null;
+let AuthContext: React.Context<AuthContextValue | undefined> | null = null;
+let emulatorLinked = false;
+
+function useFirebaseAuthInstance(): Auth {
+  const auth = getFirebaseAuth();
+
+  if (!emulatorLinked) {
+    const host = process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST;
+    if (host) {
+      connectAuthEmulator(auth, host.startsWith('http') ? host : `http://${host}`, {
+        disableWarnings: true,
+      });
+    }
+    emulatorLinked = true;
+  }
+
+  return auth;
+}
+
+export function initAuthClient(): AuthClient {
+  if (cachedClient && AuthContext) {
+    return cachedClient;
+  }
+
+  AuthContext = createContext<AuthContextValue | undefined>(undefined);
+  const firebaseAuth = useFirebaseAuthInstance();
+  const providers = {
+    google: new GoogleAuthProvider(),
+  } as const;
+
+  const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+    const [user, setUser] = useState<User | null>(null);
+    const [claims, setClaims] = useState<IdTokenResult['claims'] | null>(null);
+    const [userStatus, setUserStatus] = useState<AuthStatus>('idle');
+    const [claimsStatus, setClaimsStatus] = useState<ClaimsStatus>('idle');
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+      setUserStatus('loading');
+
+      const unsubscribe = onIdTokenChanged(
+        firebaseAuth,
+        async (firebaseUser) => {
+          setError(null);
+          setUser(firebaseUser);
+
+          if (!firebaseUser) {
+            setClaims(null);
+            setUserStatus('unauthenticated');
+            setClaimsStatus('idle');
+            return;
+          }
+
+          setUserStatus('authenticated');
+          setClaimsStatus('loading');
+
+          try {
+            const tokenResult = await firebaseUser.getIdTokenResult(true);
+            setClaims(tokenResult.claims);
+            setClaimsStatus('ready');
+          } catch (err) {
+            setClaims(null);
+            setClaimsStatus('error');
+            setError(err instanceof Error ? err : new Error('Failed to resolve ID token claims.'));
+          }
+        },
+        (err) => {
+          setError(err instanceof Error ? err : new Error('Failed to resolve auth state.'));
+          setUser(null);
+          setClaims(null);
+          setUserStatus('unauthenticated');
+          setClaimsStatus('idle');
+        }
+      );
+
+      return () => unsubscribe();
+    }, [firebaseAuth]);
+
+    const signInWithGoogle = useCallback(async () => {
+      try {
+        setError(null);
+        return await signInWithPopup(firebaseAuth, providers.google);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Unable to sign in with Google.'));
+        throw err;
+      }
+    }, [firebaseAuth]);
+
+    const signOut = useCallback(async () => {
+      try {
+        setError(null);
+        await firebaseSignOut(firebaseAuth);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Unable to sign out.'));
+        throw err;
+      }
+    }, [firebaseAuth]);
+
+    const signInAnonymously = useCallback(async () => {
+      try {
+        setError(null);
+        return await firebaseSignInAnonymously(firebaseAuth);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Unable to sign in anonymously.'));
+        throw err;
+      }
+    }, [firebaseAuth]);
+
+    const value = useMemo<AuthContextValue>(
+      () => ({
+        auth: firebaseAuth,
+        user,
+        claims,
+        userStatus,
+        claimsStatus,
+        error,
+        signInWithGoogle,
+        signOut,
+        signInAnonymously,
+      }),
+      [firebaseAuth, user, claims, userStatus, claimsStatus, error, signInWithGoogle, signOut, signInAnonymously]
+    );
+
+    return <AuthContext!.Provider value={value}>{children}</AuthContext!.Provider>;
+  };
+
+  cachedClient = { AuthProvider };
+  return cachedClient;
+}
+
+export function useAuth(): AuthContextValue {
+  if (!AuthContext) {
+    initAuthClient();
+  }
+
+  const context = useContext(AuthContext!);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider.');
+  }
+
+  return context;
+}
+

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,30 +1,114 @@
 "use client";
-import React from 'react';
-import Button from '@/components/ui/Button';
-import Chip from '@/components/ui/Chip';
+
+import React, { useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Chip from "@/components/ui/Chip";
+import { useAuth } from "../auth";
+
+const ROLE_CONTENT: Record<string, { title: string; description: string; cta: string }> = {
+  admin: {
+    title: "Admin Mission Control",
+    description: "Monitor cohorts, adjust rituals, and keep the constellation aligned.",
+    cta: "Open Control Surface",
+  },
+  guide: {
+    title: "Guide Dashboard",
+    description: "Review member reflections and respond with tailored prompts.",
+    cta: "Review Journeys",
+  },
+  member: {
+    title: "Welcome back to your Sky",
+    description: "Tap into your rituals, narrate your day, and track the rhythm of your life.",
+    cta: "Tap the sky",
+  },
+};
 
 export default function HomePage() {
+  const router = useRouter();
+  const { user, claims, userStatus, claimsStatus, error, signOut } = useAuth();
+
+  const isUserLoading = userStatus === "loading";
+  const isClaimsLoading = userStatus === "authenticated" && claimsStatus !== "ready";
+
+  useEffect(() => {
+    if (!isUserLoading && (!user || user.isAnonymous)) {
+      router.replace("/onboarding");
+    }
+  }, [router, user, isUserLoading]);
+
+  const roles = useMemo(() => {
+    const claimRoles = claims?.roles ?? claims?.role;
+    if (Array.isArray(claimRoles)) {
+      return claimRoles as string[];
+    }
+    if (typeof claimRoles === "string") {
+      return [claimRoles];
+    }
+    return [] as string[];
+  }, [claims]);
+
+  const activeRoleKey = roles[0]?.toLowerCase() ?? "member";
+  const roleContent = ROLE_CONTENT[activeRoleKey] ?? ROLE_CONTENT.member;
+
+  if (isUserLoading || isClaimsLoading) {
+    return (
+      <div className="relative flex min-h-screen flex-col items-center justify-center bg-black text-white">
+        <span className="text-sm uppercase tracking-[0.3em] text-white/50">Loading</span>
+        <h1 className="mt-3 text-2xl font-semibold">Warming the constellation…</h1>
+        <p className="mt-2 text-sm text-white/60">Preparing your personalized home experience.</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-black px-6 text-center text-white">
+        <h1 className="text-2xl font-semibold">We hit a snag.</h1>
+        <p className="mt-3 max-w-md text-sm text-white/60">{error.message}</p>
+        <div className="mt-6 flex gap-4">
+          <Button variant="secondary" onClick={() => router.replace("/onboarding")}>Try again</Button>
+          <Button variant="tertiary" onClick={() => signOut()}>Sign out</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user || user.isAnonymous) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-black text-white">
+        <p className="text-sm text-white/60">Redirecting you to onboarding…</p>
+      </div>
+    );
+  }
+
   return (
     <div className="relative flex min-h-screen flex-col items-center justify-center text-center">
-      <div className="absolute left-0 right-0 top-0 flex items-center justify-between p-4">
-        <span className="text-sm">Listening locally</span>
-        <Button variant="secondary">Local-Only</Button>
+      <div className="absolute left-0 right-0 top-0 flex items-center justify-between p-4 text-white/70">
+        <span className="text-sm">Signed in as {user.email ?? user.displayName ?? user.uid}</span>
+        <div className="flex gap-2">
+          <Button variant="secondary" onClick={() => router.push("/profile-and-privacy")}>Profile</Button>
+          <Button variant="tertiary" onClick={() => signOut()}>Sign out</Button>
+        </div>
       </div>
 
-      <div className="flex flex-1 flex-col items-center justify-center">
+      <div className="flex flex-1 flex-col items-center justify-center text-white">
+        <div className="mb-6 rounded-full border border-white/10 px-4 py-1 text-xs uppercase tracking-[0.3em] text-white/60">
+          {activeRoleKey === "member" ? "Local mode" : `${activeRoleKey} mode`}
+        </div>
         <div className="mb-4 h-60 w-40 rounded-full bg-white/10"></div>
         <div className="mb-8 h-16 w-16 rounded-full bg-blue-500 shadow-lg"></div>
 
-        <Button variant="primary" onClick={() => (window.location.href = '/life-map')}>
-          Tap the sky
-        </Button>
+        <Button variant="primary" onClick={() => router.push("/life-map")}>{roleContent.cta}</Button>
+        <p className="mt-4 max-w-sm text-sm text-white/70">{roleContent.description}</p>
       </div>
 
-      <div className="mb-24 flex space-x-4">
-        <Chip>Mirror</Chip>
-        <Chip>Narrator</Chip>
-        <Chip>Rituals</Chip>
+      <div className="mb-24 flex flex-wrap items-center justify-center gap-3 text-white/80">
+        {[roleContent.title, ...roles.filter((role) => role.toLowerCase() !== activeRoleKey)].map((label) => (
+          <Chip key={label}>{label}</Chip>
+        ))}
       </div>
     </div>
   );
 }
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,20 @@
 import './globals.css';
-import MainLayout from '../components/layout/MainLayout';
+import type { Metadata } from 'next';
+import AppProviders from './providers';
+import React from 'react';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'URAI',
   description: 'Your Emotional Media OS',
 };
 
-export default function RootLayout({ children, ...props }) {
-  const isOnboarding = props.router?.pathname === '/onboarding';
-
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
-        {isOnboarding ? children : <MainLayout>{children}</MainLayout>}
+        <AppProviders>{children}</AppProviders>
       </body>
     </html>
   );
 }
+

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,16 +1,59 @@
 "use client";
 
-import React from 'react';
-import Button from '@/components/ui/Button';
+import React, { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import { useAuth } from "../auth";
 
 export default function OnboardingPage() {
+  const router = useRouter();
+  const { user, userStatus, claimsStatus, error, signInWithGoogle } = useAuth();
+  const [isSigningIn, setIsSigningIn] = useState(false);
+
+  const isLoading = useMemo(
+    () => userStatus === "loading" || (userStatus === "authenticated" && claimsStatus === "loading"),
+    [userStatus, claimsStatus]
+  );
+
+  useEffect(() => {
+    if (user && !user.isAnonymous && userStatus === "authenticated") {
+      router.replace("/home");
+    }
+  }, [router, user, userStatus]);
+
+  const handleSignIn = async () => {
+    try {
+      setIsSigningIn(true);
+      await signInWithGoogle();
+    } finally {
+      setIsSigningIn(false);
+    }
+  };
+
+  if (isLoading || isSigningIn) {
+    return (
+      <div className="h-screen flex flex-col items-center justify-center bg-black text-white">
+        <h1 className="text-2xl font-semibold">Preparing your experience…</h1>
+        <p className="mt-4 text-sm text-white/60">We are checking your account details.</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="h-screen flex flex-col items-center justify-center text-center bg-black text-white">
+    <div className="h-screen flex flex-col items-center justify-center text-center bg-black text-white px-6">
       <h1 className="text-4xl font-bold mb-4">URAI</h1>
-      <p className="text-lg mb-8">Your Emotional Media OS</p>
-      <Button variant="primary" onClick={() => window.location.href='/home'}>
-        Get Started
+      <p className="text-lg mb-8 text-white/80">Your Emotional Media OS</p>
+
+      {error ? (
+        <div className="mb-6 rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {error.message}
+        </div>
+      ) : null}
+
+      <Button variant="primary" onClick={handleSignIn} disabled={isSigningIn}>
+        {isSigningIn ? "Connecting…" : "Continue with Google"}
       </Button>
     </div>
   );
 }
+

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { PropsWithChildren } from 'react';
+import { usePathname } from 'next/navigation';
+import MainLayout from '@/components/layout/MainLayout';
+import { initAuthClient } from './auth';
+
+const { AuthProvider } = initAuthClient();
+
+export default function AppProviders({ children }: PropsWithChildren) {
+  const pathname = usePathname();
+  const isOnboardingRoute = pathname?.startsWith('/onboarding');
+
+  return (
+    <AuthProvider>
+      {isOnboardingRoute ? children : <MainLayout>{children}</MainLayout>}
+    </AuthProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a typed Firebase Auth client helper that exposes loading state, provider sign-ins, and emulator support
- wrap the app with an Auth provider and enhance onboarding/home pages with redirects, loaders, and role-aware UI
- configure Jest and add emulator-driven integration tests covering sign-in, sign-out, and protected routes

## Testing
- npm test *(fails locally: Jest binary not available until dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d602fc18a0832582add07aead242c5