### PR TITLE
Add symlinks for missing home scene demo videos

### DIFF
--- a/public/assets/avatar/avatar-demo.mp4
+++ b/public/assets/avatar/avatar-demo.mp4
@@ -1,0 +1,1 @@
+../ground/cosmic/ground-cosmic-10.mp4

--- a/public/assets/ground/ground-demo.mp4
+++ b/public/assets/ground/ground-demo.mp4
@@ -1,0 +1,1 @@
+cosmic/ground-cosmic-09.mp4

--- a/public/assets/sky/sky-demo.mp4
+++ b/public/assets/sky/sky-demo.mp4
@@ -1,0 +1,1 @@
+cosmic/sky-cosmic-09.mp4


### PR DESCRIPTION
## Summary
- add demo video symlinks under `public/assets` so the home scene video layers resolve without 404s

## Testing
- `npm install` *(fails: 403 Forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d602d326c88325a7fe096718bec141