### PR TITLE
Make onboarding page client-ready with router navigation

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,12 +1,17 @@
+'use client';
+
 import React from 'react';
-import Button from '../components/ui/Button';
+import { useRouter } from 'next/navigation';
+import Button from '@/components/ui/Button';
 
 export default function OnboardingPage() {
+  const router = useRouter();
+
   return (
     <div className="h-screen flex flex-col items-center justify-center text-center bg-black text-white">
       <h1 className="text-4xl font-bold mb-4">URAI</h1>
       <p className="text-lg mb-8">Your Emotional Media OS</p>
-      <Button variant="primary" onClick={() => window.location.href='/home'}>
+      <Button variant="primary" onClick={() => router.push('/home')}>
         Get Started
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- add the `'use client'` directive so the onboarding page can use client hooks and event handlers
- switch the Button import to the configured alias and use `next/navigation`'s router for navigation

## Testing
- not run (npm install was blocked by peer dependency conflicts)


------
https://chatgpt.com/codex/tasks/task_e_68d602f12e308325b46c182beeeba796