### PR TITLE
Fix onboarding button import path

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Button from '../components/ui/Button';
+import Button from '@/components/ui/Button';
 
 export default function OnboardingPage() {
   return (


### PR DESCRIPTION
## Summary
- update the onboarding page to import the shared Button component via the configured src alias

## Testing
- npm run check:types *(fails: missing type definition packages such as @types/react in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d602d17ad083258511475834719add