### PR TITLE
Add client pragma and typing to Button component

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,9 +1,15 @@
+'use client';
+
 import React from 'react';
 
-const Button = ({ children, variant = 'primary', ...props }) => {
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary' | 'tertiary';
+};
+
+const Button: React.FC<ButtonProps> = ({ children, variant = 'primary', ...props }) => {
   const baseStyles = 'px-4 py-2 rounded-2xl transition-all';
 
-  const variants = {
+  const variants: Record<'primary' | 'secondary' | 'tertiary', string> = {
     primary: 'bg-blue-500 text-white shadow-lg hover:bg-blue-600',
     secondary: 'bg-white/10 backdrop-blur-md text-white hover:bg-white/20',
     tertiary: 'text-white/70 hover:text-white',


### PR DESCRIPTION
## Summary
- mark the shared Button component as a client component so event handlers can be used
- add explicit TypeScript props typing to ensure handlers like onClick are recognized

## Testing
- npm run build *(fails: Next.js CLI unavailable because npm installs are blocked by 403 errors fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68d602158f7483258890353c6c793639