### PR TITLE
Fix onboarding layout and asset references

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,17 @@
-import './globals.css';
-import MainLayout from '../components/layout/MainLayout';
+import "./globals.css";
+import RouteAwareLayout from "@/components/layout/RouteAwareLayout";
+import { ReactNode } from "react";
 
 export const metadata = {
   title: 'URAI',
   description: 'Your Emotional Media OS',
 };
 
-export default function RootLayout({ children, ...props }) {
-  const isOnboarding = props.router?.pathname === '/onboarding';
-
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        {isOnboarding ? children : <MainLayout>{children}</MainLayout>}
+        <RouteAwareLayout>{children}</RouteAwareLayout>
       </body>
     </html>
   );

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Button from '../components/ui/Button';
+import Button from '@/components/ui/Button';
 
 export default function OnboardingPage() {
   return (

--- a/src/components/HomeScene.tsx
+++ b/src/components/HomeScene.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Image from "next/image";
+
 export default function HomeScene() {
   return (
     <div className="relative w-full h-dvh bg-black overflow-hidden">
@@ -17,12 +19,12 @@ export default function HomeScene() {
         loop
         className="absolute inset-0 w-full h-full object-cover"
       />
-      <video
-        src="/assets/avatar/avatar-demo.mp4"
-        autoPlay
-        muted
-        loop
-        className="absolute inset-0 w-full h-full object-contain"
+      <Image
+        src="/assets/avatar/Texture.png"
+        alt="Avatar preview"
+        fill
+        className="object-contain"
+        priority
       />
     </div>
   );

--- a/src/components/layout/RouteAwareLayout.tsx
+++ b/src/components/layout/RouteAwareLayout.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React from "react";
+import { usePathname } from "next/navigation";
+
+import MainLayout from "@/components/layout/MainLayout";
+
+type RouteAwareLayoutProps = {
+  children: React.ReactNode;
+};
+
+const RouteAwareLayout = ({ children }: RouteAwareLayoutProps) => {
+  const pathname = usePathname();
+  const isOnboardingRoute = pathname === "/onboarding" || pathname?.startsWith("/onboarding/");
+
+  if (isOnboardingRoute) {
+    return <>{children}</>;
+  }
+
+  return <MainLayout>{children}</MainLayout>;
+};
+
+export default RouteAwareLayout;


### PR DESCRIPTION
## Summary
- fix the onboarding page to import the shared UI button from the correct module
- wrap the root layout with a client-side route-aware layout so the onboarding flow bypasses the main chrome
- replace the missing avatar video reference with an existing texture image so the home scene no longer 404s

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d60174cc8c832599ee964acb82c66d