### PR TITLE
Add client directive and typings to Button component

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,9 +1,17 @@
-import React from 'react';
+'use client';
 
-const Button = ({ children, variant = 'primary', ...props }) => {
+import React, { type ButtonHTMLAttributes } from 'react';
+
+type Variant = 'primary' | 'secondary' | 'tertiary';
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant;
+};
+
+const Button: React.FC<ButtonProps> = ({ children, variant = 'primary', ...props }) => {
   const baseStyles = 'px-4 py-2 rounded-2xl transition-all';
 
-  const variants = {
+  const variants: Record<Variant, string> = {
     primary: 'bg-blue-500 text-white shadow-lg hover:bg-blue-600',
     secondary: 'bg-white/10 backdrop-blur-md text-white hover:bg-white/20',
     tertiary: 'text-white/70 hover:text-white',


### PR DESCRIPTION
## Summary
- add the client component directive to the shared Button
- type the component props with ButtonHTMLAttributes while keeping variant styling intact

## Testing
- npm run build *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d609689c8c8325b9761b3ed0bb1b3f