### PR TITLE
Let Ancient Signals drive HomeScene ground state

### DIFF
--- a/src/components/HomeScene.tsx
+++ b/src/components/HomeScene.tsx
@@ -18,7 +18,6 @@ export default function HomeScene() {
       <div className="absolute inset-0 bg-gradient-to-b from-indigo-950 via-black to-black" />
       <AncientSignalAmbientLayer result={ancientResult} source={source} loading={loading} />
       <GroundLayer
-        forcedTier={profile.symbolicState.groundTier}
         state={{
           moodScore: ancientResult.auraAtmosphere.warmth,
           rhythmState: ancientResult.preverbalState === "recovering" ? "recovering" : ancientResult.preverbalState === "activated" ? "overstimulated" : "stable",


### PR DESCRIPTION
## Summary

Small post-merge polish after #170.

`HomeScene` was passing Ancient Signals state into `GroundLayer`, but also passing `forcedTier={profile.symbolicState.groundTier}`. Because `GroundLayer` prioritizes `forcedTier`, the Ancient Signals state could not actually affect the rendered ground tier.

This removes the forced tier from HomeScene so `GroundLayer` resolves from the Ancient Signals state:

- `auraAtmosphere.warmth` -> mood score
- `preverbalState` -> rhythm state
- `recoveryPulseScore` -> recovery score
- `seekingScore` -> vitality score
- `signalDepth.auraAtmosphere` -> symbolic intensity
- `activationScore` -> shadow stress

The demo profile is still used for the visible Forecast/Weekly Reflection cards.

## Verification

Not run in connector. Suggested local check:

```bash
npm run check:types
npm run build
```