### PR TITLE
Update V1 lockfile launch status

### DIFF
--- a/docs/V1_LAUNCH_STATUS.md
+++ b/docs/V1_LAUNCH_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Current status
 
-V1 demo spine is implemented and repo-wired, including the merged Ancient Signals layer, but still needs local/CI runtime validation and a refreshed `package-lock.json`.
+V1 demo spine is implemented and repo-wired, including the merged Ancient Signals layer. Lockfiles were refreshed by the Dependabot/npm update merge, but local/CI runtime validation is still required before launch.
 
 ## Implemented
 
@@ -37,20 +37,7 @@ V1 demo spine is implemented and repo-wired, including the merged Ancient Signal
 
 ## Known blocker
 
-`package-lock.json` is stale after dependency changes.
-
-Run locally:
-
-```bash
-npm install
-```
-
-Then commit:
-
-```bash
-git add package-lock.json
-git commit -m "Refresh package lockfile"
-```
+No repo-level blocker is currently documented after the lockfile refresh merge. Runtime/build/deploy validation is still pending.
 
 ## Required validation
 
@@ -98,7 +85,6 @@ firebase deploy --only firestore:rules,firestore:indexes,functions
 
 ## Launch readiness checklist
 
-- [ ] `package-lock.json` refreshed and committed
 - [ ] `npm run check:lockfile` passes
 - [ ] `npm run preflight` passes
 - [ ] `npm run test:smoke` passes


### PR DESCRIPTION
## Summary

Updates `docs/V1_LAUNCH_STATUS.md` after the Dependabot/npm merge refreshed lockfiles.

## Changes

- Notes the lockfile refresh merge has landed
- Removes stale `package-lock.json` blocker instructions
- Keeps runtime/build/deploy validation as pending
- Keeps Ancient Signals validation checklist in launch readiness

## Verification

Docs-only. No runtime validation performed in connector.