### PR TITLE
Add Ancient Signals verification workflow

### DIFF
--- a/.github/workflows/ancient-signals-verify.yml
+++ b/.github/workflows/ancient-signals-verify.yml
@@ -1,0 +1,73 @@
+name: Ancient Signals Verification
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/**"
+      - "functions/**"
+      - "firestore.rules"
+      - "firestore.indexes.json"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/ancient-signals-verify.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "functions/**"
+      - "firestore.rules"
+      - "firestore.indexes.json"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/ancient-signals-verify.yml"
+
+jobs:
+  app:
+    name: App typecheck and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install app dependencies
+        run: npm ci
+
+      - name: Check V1 contract
+        run: npm run check:v1
+
+      - name: Typecheck app
+        run: npm run check:types
+
+      - name: Build app
+        run: npm run build
+
+  functions:
+    name: Firebase Functions build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install function dependencies
+        run: npm ci
+
+      - name: Build functions
+        run: npm run build

--- a/functions/src/ancientPassiveRollups.ts
+++ b/functions/src/ancientPassiveRollups.ts
@@ -1,5 +1,3 @@
-import * as admin from "firebase-admin";
-
 export interface PassiveRollupOptions {
   ownerUid: string;
   startAt: string;


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to make the Ancient Signals post-merge verification repeatable instead of only manual.

## What this checks

- Root app V1 contract via `npm run check:v1`
- Root app typecheck via `npm run check:types`
- Root app production build via `npm run build`
- Firebase Functions install/build in `functions/` using Node 22

## Why

Issue #171 notes that PR #170 merged Ancient Signals but Actions did not appear to run on the merge commit. This workflow gives the repo a clean CI gate for future Ancient Signals/app/functions changes.

Closes part of #171.