### PR TITLE
Add staging promotion checklist and rollback runbook

### DIFF
--- a/docs/ROLLBACK_RUNBOOK.md
+++ b/docs/ROLLBACK_RUNBOOK.md
@@ -1,0 +1,178 @@
+# URAI V1 Rollback Runbook
+
+This runbook defines what to do when a staging or production release must be rolled back or disabled.
+
+Parent issue: #185
+
+## Principles
+
+- Prefer fast recovery over debugging live production.
+- Roll back to the last known good release candidate when core routes are broken.
+- Disable risky feature flags before rolling back when the failure is isolated to an optional feature.
+- Do not test fixes directly in production.
+- Record the incident, owner, time, and recovery action.
+
+## Trigger conditions
+
+Rollback or disablement is required when any of these happen after deploy:
+
+- [ ] `/` does not load.
+- [ ] `/u/adamclamp` does not load.
+- [ ] `/api/companion` returns persistent 5xx errors.
+- [ ] `/api/waitlist` cannot accept valid submissions in the intended environment.
+- [ ] Firestore rules expose private passive, memory, or relationship data.
+- [ ] Admin/debug route is publicly accessible when it should be guarded.
+- [ ] A deploy breaks mobile layout enough to block demo use.
+- [ ] Error volume indicates broad runtime failure.
+- [ ] A privacy/security concern is discovered.
+
+## First response checklist
+
+- [ ] Stop further deploys.
+- [ ] Identify current deployed commit.
+- [ ] Identify last known good commit.
+- [ ] Capture the failing route/API and error.
+- [ ] Check whether the failure is feature-flagged.
+- [ ] Check whether rollback is safer than hotfix.
+- [ ] Assign one release owner.
+- [ ] Record timestamps and action taken.
+
+## Disablement before rollback
+
+Use this first if the issue is isolated to a non-core or feature-flagged surface:
+
+- [ ] Disable experimental spatial/avatar modules.
+- [ ] Disable Ancient Signals overlay if it causes runtime failure.
+- [ ] Disable trust/telemetry/cooldown experiment if it causes runtime failure.
+- [ ] Disable admin/debug public access if it is exposed.
+- [ ] Disable optional jobs/asset generation flows if they are causing failures.
+
+If the home route, public constellation route, companion API, or waitlist API is broken, proceed to rollback.
+
+## Firebase Hosting rollback
+
+Use the Firebase Console or Firebase CLI to roll back Hosting to the last known good release.
+
+Preferred console path:
+
+1. Open Firebase Console.
+2. Select the correct project.
+3. Open Hosting.
+4. Select the affected site/channel.
+5. Choose the last known good release.
+6. Roll back.
+7. Run post-rollback smoke checks.
+
+CLI path, if release/channel IDs are known:
+
+```bash
+firebase hosting:channel:list
+firebase hosting:releases:list
+# Use Firebase Console/CLI rollback command appropriate for the configured hosting target.
+```
+
+Record:
+
+- Project:
+- Site/channel:
+- Bad release:
+- Restored release:
+- Operator:
+- Time:
+
+## Firestore rules/indexes rollback
+
+If rules or indexes caused the issue:
+
+- [ ] Revert the rules/index change in git or restore the last known good release artifact.
+- [ ] Deploy only rules/indexes if app code is otherwise healthy.
+
+```bash
+firebase deploy --only firestore:rules,firestore:indexes
+```
+
+After deploy:
+
+- [ ] Confirm public demo reads still work.
+- [ ] Confirm private passive data is not publicly readable.
+- [ ] Confirm private memory data is not publicly readable.
+- [ ] Confirm private relationship data is not publicly readable.
+- [ ] Confirm waitlist write behavior is still intended.
+
+## Functions rollback or disablement
+
+If Functions caused the issue:
+
+- [ ] Identify failing function(s).
+- [ ] Check logs.
+- [ ] Revert to last known good Functions commit or disable the failing function if safe.
+- [ ] Deploy Functions only if app/hosting is otherwise healthy.
+
+```bash
+firebase deploy --only functions
+```
+
+After deploy:
+
+- [ ] Confirm companion API if affected.
+- [ ] Confirm scheduled rollups if affected.
+- [ ] Confirm callable functions if affected.
+- [ ] Confirm no retry storm or runaway cost issue remains.
+
+## Git rollback path
+
+For app-code rollback:
+
+```bash
+git checkout main
+git pull
+git revert <bad-merge-commit-sha>
+npm install
+npm run check:v1
+npm run test:unit
+npm run test:rules
+npm run check:types
+npm run lint
+npm run build
+npm run test:smoke
+```
+
+Then open and merge a rollback PR. If emergency policy allows direct deploy from a reverted commit, record who approved it and why.
+
+## Post-rollback smoke checks
+
+Required after any rollback:
+
+- [ ] `/` loads.
+- [ ] `/u/adamclamp` loads.
+- [ ] `/api/companion` accepts a valid POST.
+- [ ] `/api/waitlist` accepts a valid POST in the intended mode.
+- [ ] Mobile home route works.
+- [ ] Mobile public constellation route works.
+- [ ] No private passive/memory/relationship data is public.
+- [ ] Error logs return to normal.
+
+## Incident record template
+
+- Date/time:
+- Environment: staging / production
+- Release candidate commit:
+- Deployed release ID or URL:
+- Trigger condition:
+- User impact:
+- Decision: disable / rollback / hotfix
+- Action taken:
+- Restored commit/release:
+- Owner:
+- Verification result:
+- Follow-up issue(s):
+
+## Follow-up requirements
+
+After recovery:
+
+- [ ] Open an issue for root-cause analysis.
+- [ ] Add or update a test that would have caught the failure.
+- [ ] Update the staging promotion checklist if a gate was missing.
+- [ ] Update feature flags or deploy protections if rollback was avoidable.
+- [ ] Close the incident only after root cause and prevention are documented.

--- a/docs/STAGING_PROMOTION_CHECKLIST.md
+++ b/docs/STAGING_PROMOTION_CHECKLIST.md
@@ -1,0 +1,154 @@
+# URAI V1 Staging Promotion Checklist
+
+This checklist gates promotion from a validated release candidate to production. It is intentionally operational: do not promote unless each required item is checked or explicitly marked not applicable with a reason.
+
+Parent issue: #185
+
+## Release candidate identity
+
+- [ ] Release candidate commit SHA recorded.
+- [ ] Source branch recorded.
+- [ ] PR or merge commit recorded.
+- [ ] Release owner recorded.
+- [ ] Date/time of staging signoff recorded.
+
+## Canonical V1 scope
+
+The V1 launch surface is limited to the canonical demo spine unless a later issue explicitly expands scope.
+
+Required routes/APIs:
+
+- [ ] `/` renders the V1 home/demo spine.
+- [ ] `/u/adamclamp` renders the public constellation demo.
+- [ ] `/api/companion` accepts valid POST requests and returns companion JSON.
+- [ ] `/api/waitlist` accepts valid POST requests and returns dry-run locally or writes when Firebase Admin is configured.
+
+Optional/guarded V1-adjacent routes:
+
+- [ ] `/u/adamclamp/life-map` verified if included in the release target.
+- [ ] `/settings/trust` verified if included in the release target.
+- [ ] `/admin/debug/adamclamp` is protected or disabled publicly.
+
+## Required command validation
+
+Run from a clean checkout before staging signoff:
+
+```bash
+npm install
+npm run check:v1
+npm run seed:demo
+npm run test:unit
+npm run test:rules
+npm run check:types
+npm run lint
+npm run build
+npx playwright install --with-deps chromium
+npm run test:smoke
+npm run test:e2e
+```
+
+Acceptance:
+
+- [ ] Clean install passes.
+- [ ] V1 sanity check passes.
+- [ ] Demo seed artifact is generated.
+- [ ] Unit tests pass.
+- [ ] Firestore rules tests pass.
+- [ ] Typecheck passes.
+- [ ] Lint passes.
+- [ ] Production build passes.
+- [ ] Playwright smoke tests pass.
+- [ ] Full Playwright E2E passes.
+
+## Firebase Functions validation
+
+Run separately because Functions use their own package context:
+
+```bash
+cd functions
+npm install
+npm run build
+```
+
+Acceptance:
+
+- [ ] Functions install passes.
+- [ ] Functions build passes.
+- [ ] Functions runtime/version expectations are recorded.
+
+## Staging environment binding
+
+Do not paste secret values into this file or into GitHub issues.
+
+- [ ] Staging Firebase project ID confirmed by release owner.
+- [ ] Production Firebase project ID confirmed separately.
+- [ ] Active local Firebase target checked before deploy.
+- [ ] Hosting target checked before deploy.
+- [ ] Firestore rules target checked before deploy.
+- [ ] Firestore indexes target checked before deploy.
+- [ ] Functions target checked before deploy.
+- [ ] Required deployment credentials exist in the deploy environment.
+- [ ] No secret values are committed to the repo.
+
+## Staging deploy check
+
+Use the provider-specific deploy path for the current environment. If using Firebase directly, the expected deploy surface is:
+
+```bash
+firebase deploy --only hosting,firestore:rules,firestore:indexes,functions
+```
+
+Acceptance:
+
+- [ ] Hosting deploy succeeds.
+- [ ] Firestore rules deploy succeeds.
+- [ ] Firestore indexes deploy succeeds.
+- [ ] Functions deploy succeeds.
+- [ ] Deploy log or run URL recorded.
+
+## Manual staging smoke test
+
+Desktop:
+
+- [ ] Home route loads.
+- [ ] Public constellation route loads.
+- [ ] Companion request works.
+- [ ] Waitlist submit works in the intended staging mode.
+- [ ] No console error blocks the core demo.
+- [ ] No private passive/memory/relationship data is publicly exposed.
+
+Mobile:
+
+- [ ] Home route loads on mobile viewport/device.
+- [ ] Public constellation route loads on mobile viewport/device.
+- [ ] Waitlist form is usable.
+- [ ] Companion form is usable.
+- [ ] Layout is not broken by the main CTA/header/content.
+
+## Data and privacy signoff
+
+- [ ] Public/demo data is intentional.
+- [ ] Private passive data is not publicly readable.
+- [ ] Private memory data is not publicly readable.
+- [ ] Private relationship data is not publicly readable.
+- [ ] Waitlist writes are server-side or otherwise protected as intended.
+- [ ] Demo data is seeded/anonymized.
+- [ ] Privacy launch gate issue is reviewed if active.
+
+## Go/no-go decision
+
+Promote only when all required checks above are green.
+
+Record:
+
+- Release candidate commit:
+- Staging URL:
+- Deploy run/log URL:
+- Smoke tester:
+- Smoke test date/time:
+- Decision: Go / No-Go
+- Notes:
+
+## Production promotion rule
+
+Production deploy must come from the signed-off release candidate commit. If the commit changes after signoff, rerun this checklist.


### PR DESCRIPTION
## Summary

Adds the missing V1 release-safety documentation from #185:

- `docs/STAGING_PROMOTION_CHECKLIST.md`
- `docs/ROLLBACK_RUNBOOK.md`

## Why

PR #181 unblocked and merged V1 QA/CI validation. The next launch gap is release discipline: staging signoff, environment confirmation, Firebase deploy checks, manual smoke checks, data/privacy checks, and rollback procedure.

## Contents

### Staging promotion checklist

Covers:

- release candidate identity
- canonical V1 route/API scope
- required command validation
- Firebase Functions validation
- staging environment binding
- staging deploy checks
- desktop/mobile smoke tests
- data/privacy signoff
- go/no-go record
- production promotion rule

### Rollback runbook

Covers:

- trigger conditions
- first response checklist
- feature disablement before rollback
- Firebase Hosting rollback guidance
- Firestore rules/indexes rollback
- Functions rollback/disablement
- Git rollback path
- post-rollback smoke checks
- incident record template
- required follow-up actions

Closes part of #185.

## Validation

Docs-only change. No runtime validation required.