### PR TITLE
Add P0 launch gate verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Check V1 wiring
         run: npm run check:v1
 
+      - name: Check P0 launch gate
+        run: npm run launch:p0
+
       - name: Seed demo data
         run: npm run seed:demo
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:types": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "preflight": "npm run check:v1 && npm run check:types && npm run lint && npm run test:unit && npm run build",
+    "launch:p0": "node scripts/p0-launch-gate.mjs",
     "seed:demo": "node scripts/seed-demo.mjs",
     "seed:firestore": "node scripts/seed-demo.mjs --firestore",
     "waitlist:export": "node scripts/export-waitlist.mjs",

--- a/scripts/p0-launch-gate.mjs
+++ b/scripts/p0-launch-gate.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = process.cwd();
+const reportDir = path.join(root, "tmp");
+fs.mkdirSync(reportDir, { recursive: true });
+
+const runCommands = process.env.URAI_P0_RUN_COMMANDS === "1";
+const checks = [];
+
+function add(name, status, evidence = "", remediation = "") {
+  checks.push({ name, status, evidence, remediation });
+}
+
+function exists(file) {
+  return fs.existsSync(path.join(root, file));
+}
+
+function read(file) {
+  return fs.readFileSync(path.join(root, file), "utf8");
+}
+
+function readJson(file) {
+  return JSON.parse(read(file));
+}
+
+function hasText(file, pattern) {
+  return exists(file) && pattern.test(read(file));
+}
+
+function checkFile(file, why) {
+  add(`Required file exists: ${file}`, exists(file) ? "pass" : "fail", exists(file) ? file : "missing", why);
+}
+
+function checkPackageScript(packageJson, script) {
+  const command = packageJson.scripts?.[script];
+  add(`package script exists: ${script}`, command ? "pass" : "fail", command || "missing", `Add npm script '${script}'.`);
+}
+
+const requiredFiles = [
+  ["README.md", "Keep the canonical V1 route and validation instructions visible."],
+  ["package.json", "Define the launch validation commands."],
+  ["package-lock.json", "Lock dependency versions for repeatable installs."],
+  ["env.local.template", "Document all required Firebase environment values."],
+  ["firebase.json", "Bind Firestore rules and indexes."],
+  ["firestore.rules", "Protect private and server-only data."],
+  ["firestore.indexes.json", "Deploy required Firestore indexes."],
+  ["src/app/page.tsx", "Serve the public home demo spine at /."],
+  ["src/app/u/[handle]/page.tsx", "Serve the public Adam Clamp constellation route."],
+  ["src/app/api/companion/route.ts", "Serve the companion narrator API."],
+  ["src/app/api/waitlist/route.ts", "Serve the waitlist capture API."],
+  ["src/components/HomeScene.tsx", "Render the home demo scene."],
+  ["src/components/CompanionChat.tsx", "Render and exercise the companion flow."],
+  ["src/components/WaitlistForm.tsx", "Render and exercise waitlist capture."],
+  ["src/lib/firebase-admin.ts", "Support configured Firestore writes for waitlist persistence."],
+  ["scripts/check-v1.mjs", "Verify required V1 wiring."],
+  ["scripts/check-lockfile.mjs", "Fail stale lockfiles before launch."],
+  ["scripts/seed-demo.mjs", "Generate deterministic demo seed data."],
+  ["docs/V1_DEPLOY_CHECKLIST.md", "Keep deploy readiness checklist in repo."],
+  ["docs/V1_QA_CHECKLIST.md", "Keep QA checklist in repo."],
+  ["docs/V1_MANUAL_TESTS.md", "Keep manual API/browser recipes in repo."],
+  [".github/workflows/ci.yml", "Run app and Functions validation in GitHub Actions."],
+  ["functions/package.json", "Validate Firebase Functions separately."]
+];
+
+for (const [file, why] of requiredFiles) checkFile(file, why);
+
+let packageJson = null;
+if (exists("package.json")) {
+  packageJson = readJson("package.json");
+  for (const script of [
+    "check:v1",
+    "check:lockfile",
+    "seed:demo",
+    "test:unit",
+    "test:rules",
+    "check:types",
+    "lint",
+    "build",
+    "preflight",
+    "test:smoke",
+    "test:e2e"
+  ]) {
+    checkPackageScript(packageJson, script);
+  }
+
+  add("Node engine pinned to 20 for app", packageJson.engines?.node === "20" ? "pass" : "fail", packageJson.engines?.node || "missing", "Set package.json engines.node to 20.");
+}
+
+if (exists("functions/package.json")) {
+  const functionsPackageJson = readJson("functions/package.json");
+  add("Firebase Functions build script exists", functionsPackageJson.scripts?.build ? "pass" : "fail", functionsPackageJson.scripts?.build || "missing", "Add functions/package.json build script.");
+  add("Firebase Functions Node engine pinned to 22", functionsPackageJson.engines?.node === "22" ? "pass" : "fail", functionsPackageJson.engines?.node || "missing", "Set functions/package.json engines.node to 22.");
+}
+
+if (exists("firebase.json")) {
+  const firebaseJson = readJson("firebase.json");
+  add("firebase.json points to firestore.rules", firebaseJson.firestore?.rules === "firestore.rules" ? "pass" : "fail", firebaseJson.firestore?.rules || "missing", "Set firestore.rules to firestore.rules.");
+  add("firebase.json points to firestore.indexes.json", firebaseJson.firestore?.indexes === "firestore.indexes.json" ? "pass" : "fail", firebaseJson.firestore?.indexes || "missing", "Set firestore.indexes to firestore.indexes.json.");
+}
+
+if (exists("firestore.rules")) {
+  const rules = read("firestore.rules");
+  add("waitlistSignups is server-only in rules", /waitlistSignups/.test(rules) && /allow\s+read,\s*write:\s*if\s*false/.test(rules), "firestore.rules", "Ensure waitlistSignups cannot be read or written from client rules.");
+  add("Firestore rules include deny-by-default fallback", /match\s+\/\{document=\*\*\}/.test(rules) && /allow\s+read,\s*write:\s*if\s*false/.test(rules), "firestore.rules", "Add final match /{document=**} deny rule.");
+}
+
+const routeChecks = [
+  ["README documents home route", "README.md", /\/` cinematic home scene|`\/` cinematic home scene/],
+  ["README documents Adam Clamp route", "README.md", /\/u\/adamclamp/],
+  ["README documents companion API", "README.md", /\/api\/companion/],
+  ["README documents waitlist API", "README.md", /\/api\/waitlist/],
+  ["manual tests include companion curl", "docs/V1_MANUAL_TESTS.md", /curl -X POST http:\/\/localhost:3014\/api\/companion/],
+  ["manual tests include waitlist curl", "docs/V1_MANUAL_TESTS.md", /curl -X POST http:\/\/localhost:3014\/api\/waitlist/],
+  ["QA checklist includes mobile and desktop coverage", "docs/V1_QA_CHECKLIST.md", /mobile and desktop/]
+];
+
+for (const [name, file, pattern] of routeChecks) {
+  add(name, hasText(file, pattern) ? "pass" : "fail", file, `Update ${file} so this route or test is explicitly covered.`);
+}
+
+if (exists(".github/workflows/ci.yml")) {
+  const ci = read(".github/workflows/ci.yml");
+  for (const token of [
+    "npm run check:lockfile",
+    "npm run check:v1",
+    "npm run seed:demo",
+    "npm run test:unit",
+    "npm run test:rules",
+    "npm run typecheck",
+    "npm run lint",
+    "npm run build",
+    "working-directory: functions",
+    "npm run build"
+  ]) {
+    add(`CI includes ${token}`, ci.includes(token) ? "pass" : "fail", ".github/workflows/ci.yml", `Add '${token}' to CI.`);
+  }
+}
+
+const commands = [
+  "npm run check:lockfile",
+  "npm run check:v1",
+  "npm run seed:demo",
+  "npm run test:unit",
+  "npm run test:rules",
+  "npm run check:types",
+  "npm run lint",
+  "npm run build",
+  "npm run preflight"
+];
+
+for (const command of commands) {
+  if (!runCommands) {
+    add(`Command declared, not executed: ${command}`, "unverified", command, `Run URAI_P0_RUN_COMMANDS=1 npm run launch:p0 to execute ${command}.`);
+    continue;
+  }
+
+  const [bin, ...args] = command.split(" ");
+  const result = spawnSync(bin, args, { cwd: root, encoding: "utf8", stdio: "pipe" });
+  const output = `${result.stdout || ""}\n${result.stderr || ""}`.trim().slice(-3000);
+  add(`Command passes: ${command}`, result.status === 0 ? "pass" : "fail", output || `exit ${result.status}`, `Fix failing command: ${command}`);
+}
+
+const manualEvidence = [
+  ["Desktop demo manually verified", process.env.URAI_P0_DESKTOP_VERIFIED],
+  ["Mobile demo manually verified", process.env.URAI_P0_MOBILE_VERIFIED],
+  ["Configured waitlist Firestore persistence verified", process.env.URAI_P0_WAITLIST_PERSISTENCE_VERIFIED],
+  ["Firestore rules and indexes deployed", process.env.URAI_P0_FIREBASE_RULES_INDEXES_DEPLOYED],
+  ["Private data read safety verified", process.env.URAI_P0_PRIVATE_DATA_SAFETY_VERIFIED],
+  ["30-60 second demo recording captured", process.env.URAI_P0_DEMO_RECORDING_URL]
+];
+
+for (const [name, value] of manualEvidence) {
+  add(name, value ? "pass" : "unverified", value || "missing", `Set evidence env var or paste proof into the P0 issue before marking done.`);
+}
+
+const passed = checks.filter((check) => check.status === "pass");
+const failed = checks.filter((check) => check.status === "fail");
+const unverified = checks.filter((check) => check.status === "unverified");
+const verdict = failed.length === 0 && unverified.length === 0
+  ? "P0 READY"
+  : failed.length === 0
+    ? "P0 STRUCTURALLY READY - EVIDENCE STILL REQUIRED"
+    : "P0 NOT READY";
+
+function section(title, rows) {
+  if (!rows.length) return `## ${title}\n\nNone.\n`;
+  return `## ${title}\n\n${rows.map((check) => `- **${check.name}**\n  - Status: ${check.status}\n  - Evidence: ${check.evidence || "none"}\n  - Next action: ${check.remediation || "none"}`).join("\n")}\n`;
+}
+
+const report = `# URAI P0 Launch Gate Report\n\nGenerated: ${new Date().toISOString()}\n\nVerdict: **${verdict}**\n\nSummary:\n\n- Passed: ${passed.length}\n- Failed: ${failed.length}\n- Unverified: ${unverified.length}\n\n${section("Failed checks", failed)}\n${section("Unverified evidence", unverified)}\n${section("Passed checks", passed)}\n## Commands\n\nStatic gate:\n\n\`\`\`bash\nnpm run launch:p0\n\`\`\`\n\nFull local gate:\n\n\`\`\`bash\nURAI_P0_RUN_COMMANDS=1 npm run launch:p0\n\`\`\`\n\nFull evidence gate example:\n\n\`\`\`bash\nURAI_P0_RUN_COMMANDS=1 \\\nURAI_P0_DESKTOP_VERIFIED=1 \\\nURAI_P0_MOBILE_VERIFIED=1 \\\nURAI_P0_WAITLIST_PERSISTENCE_VERIFIED=1 \\\nURAI_P0_FIREBASE_RULES_INDEXES_DEPLOYED=1 \\\nURAI_P0_PRIVATE_DATA_SAFETY_VERIFIED=1 \\\nURAI_P0_DEMO_RECORDING_URL=\"https://example.com/demo.mp4\" \\\nnpm run launch:p0\n\`\`\`\n`;
+
+fs.writeFileSync(path.join(reportDir, "p0-launch-gate-report.md"), report);
+console.log(report);
+
+if (failed.length > 0) process.exitCode = 1;
+if (failed.length === 0 && unverified.length > 0 && process.env.URAI_P0_STRICT === "1") process.exitCode = 1;

--- a/scripts/p0-launch-gate.mjs
+++ b/scripts/p0-launch-gate.mjs
@@ -10,8 +10,13 @@ fs.mkdirSync(reportDir, { recursive: true });
 const runCommands = process.env.URAI_P0_RUN_COMMANDS === "1";
 const checks = [];
 
+function normalizeStatus(status) {
+  if (["pass", "fail", "unverified"].includes(status)) return status;
+  return status ? "pass" : "fail";
+}
+
 function add(name, status, evidence = "", remediation = "") {
-  checks.push({ name, status, evidence, remediation });
+  checks.push({ name, status: normalizeStatus(status), evidence, remediation });
 }
 
 function exists(file) {
@@ -31,12 +36,12 @@ function hasText(file, pattern) {
 }
 
 function checkFile(file, why) {
-  add(`Required file exists: ${file}`, exists(file) ? "pass" : "fail", exists(file) ? file : "missing", why);
+  add(`Required file exists: ${file}`, exists(file), exists(file) ? file : "missing", why);
 }
 
 function checkPackageScript(packageJson, script) {
   const command = packageJson.scripts?.[script];
-  add(`package script exists: ${script}`, command ? "pass" : "fail", command || "missing", `Add npm script '${script}'.`);
+  add(`package script exists: ${script}`, Boolean(command), command || "missing", `Add npm script '${script}'.`);
 }
 
 const requiredFiles = [
@@ -86,19 +91,19 @@ if (exists("package.json")) {
     checkPackageScript(packageJson, script);
   }
 
-  add("Node engine pinned to 20 for app", packageJson.engines?.node === "20" ? "pass" : "fail", packageJson.engines?.node || "missing", "Set package.json engines.node to 20.");
+  add("Node engine pinned to 20 for app", packageJson.engines?.node === "20", packageJson.engines?.node || "missing", "Set package.json engines.node to 20.");
 }
 
 if (exists("functions/package.json")) {
   const functionsPackageJson = readJson("functions/package.json");
-  add("Firebase Functions build script exists", functionsPackageJson.scripts?.build ? "pass" : "fail", functionsPackageJson.scripts?.build || "missing", "Add functions/package.json build script.");
-  add("Firebase Functions Node engine pinned to 22", functionsPackageJson.engines?.node === "22" ? "pass" : "fail", functionsPackageJson.engines?.node || "missing", "Set functions/package.json engines.node to 22.");
+  add("Firebase Functions build script exists", Boolean(functionsPackageJson.scripts?.build), functionsPackageJson.scripts?.build || "missing", "Add functions/package.json build script.");
+  add("Firebase Functions Node engine pinned to 22", functionsPackageJson.engines?.node === "22", functionsPackageJson.engines?.node || "missing", "Set functions/package.json engines.node to 22.");
 }
 
 if (exists("firebase.json")) {
   const firebaseJson = readJson("firebase.json");
-  add("firebase.json points to firestore.rules", firebaseJson.firestore?.rules === "firestore.rules" ? "pass" : "fail", firebaseJson.firestore?.rules || "missing", "Set firestore.rules to firestore.rules.");
-  add("firebase.json points to firestore.indexes.json", firebaseJson.firestore?.indexes === "firestore.indexes.json" ? "pass" : "fail", firebaseJson.firestore?.indexes || "missing", "Set firestore.indexes to firestore.indexes.json.");
+  add("firebase.json points to firestore.rules", firebaseJson.firestore?.rules === "firestore.rules", firebaseJson.firestore?.rules || "missing", "Set firestore.rules to firestore.rules.");
+  add("firebase.json points to firestore.indexes.json", firebaseJson.firestore?.indexes === "firestore.indexes.json", firebaseJson.firestore?.indexes || "missing", "Set firestore.indexes to firestore.indexes.json.");
 }
 
 if (exists("firestore.rules")) {
@@ -108,7 +113,7 @@ if (exists("firestore.rules")) {
 }
 
 const routeChecks = [
-  ["README documents home route", "README.md", /\/` cinematic home scene|`\/` cinematic home scene/],
+  ["README documents home route", "README.md", /`\/` cinematic home scene/],
   ["README documents Adam Clamp route", "README.md", /\/u\/adamclamp/],
   ["README documents companion API", "README.md", /\/api\/companion/],
   ["README documents waitlist API", "README.md", /\/api\/waitlist/],
@@ -118,7 +123,7 @@ const routeChecks = [
 ];
 
 for (const [name, file, pattern] of routeChecks) {
-  add(name, hasText(file, pattern) ? "pass" : "fail", file, `Update ${file} so this route or test is explicitly covered.`);
+  add(name, hasText(file, pattern), file, `Update ${file} so this route or test is explicitly covered.`);
 }
 
 if (exists(".github/workflows/ci.yml")) {
@@ -126,16 +131,16 @@ if (exists(".github/workflows/ci.yml")) {
   for (const token of [
     "npm run check:lockfile",
     "npm run check:v1",
+    "npm run launch:p0",
     "npm run seed:demo",
     "npm run test:unit",
     "npm run test:rules",
     "npm run typecheck",
     "npm run lint",
     "npm run build",
-    "working-directory: functions",
-    "npm run build"
+    "working-directory: functions"
   ]) {
-    add(`CI includes ${token}`, ci.includes(token) ? "pass" : "fail", ".github/workflows/ci.yml", `Add '${token}' to CI.`);
+    add(`CI includes ${token}`, ci.includes(token), ".github/workflows/ci.yml", `Add '${token}' to CI.`);
   }
 }
 
@@ -160,7 +165,7 @@ for (const command of commands) {
   const [bin, ...args] = command.split(" ");
   const result = spawnSync(bin, args, { cwd: root, encoding: "utf8", stdio: "pipe" });
   const output = `${result.stdout || ""}\n${result.stderr || ""}`.trim().slice(-3000);
-  add(`Command passes: ${command}`, result.status === 0 ? "pass" : "fail", output || `exit ${result.status}`, `Fix failing command: ${command}`);
+  add(`Command passes: ${command}`, result.status === 0, output || `exit ${result.status}`, `Fix failing command: ${command}`);
 }
 
 const manualEvidence = [
@@ -173,7 +178,7 @@ const manualEvidence = [
 ];
 
 for (const [name, value] of manualEvidence) {
-  add(name, value ? "pass" : "unverified", value || "missing", `Set evidence env var or paste proof into the P0 issue before marking done.`);
+  add(name, value ? "pass" : "unverified", value || "missing", "Set evidence env var or paste proof into the P0 issue before marking done.");
 }
 
 const passed = checks.filter((check) => check.status === "pass");


### PR DESCRIPTION
## Summary

Adds a P0-specific launch gate for the canonical URAI V1 demo spine.

This keeps the immediate launch path focused on what P0 actually requires:

- `/`
- `/u/adamclamp`
- `/api/companion`
- `/api/waitlist`
- lockfile and V1 wiring checks
- demo seed generation
- unit/rules/type/lint/build/preflight validation
- Firebase rules/indexes evidence
- configured waitlist persistence evidence
- desktop/mobile demo verification
- private-data safety evidence
- 30-60 second demo recording evidence

## Why

The existing independent release verifier is useful, but it checks many future/full-system surfaces. For P0, we need a narrower launch gate that does not block the canonical demo on later roadmap work.

## New command

```bash
npm run launch:p0
```

Full local execution gate:

```bash
URAI_P0_RUN_COMMANDS=1 npm run launch:p0
```

Full evidence gate example:

```bash
URAI_P0_RUN_COMMANDS=1 \
URAI_P0_DESKTOP_VERIFIED=1 \
URAI_P0_MOBILE_VERIFIED=1 \
URAI_P0_WAITLIST_PERSISTENCE_VERIFIED=1 \
URAI_P0_FIREBASE_RULES_INDEXES_DEPLOYED=1 \
URAI_P0_PRIVATE_DATA_SAFETY_VERIFIED=1 \
URAI_P0_DEMO_RECORDING_URL="https://example.com/demo.mp4" \
npm run launch:p0
```

## Output

Writes:

```txt
tmp/p0-launch-gate-report.md
```

## Test plan

Not run in this environment. GitHub/source access is available through the connector, but this runtime cannot clone or execute the repo. Next step is to run the new command locally or in CI.