### PR TITLE
Add P1 release hardening gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Check P0 launch gate
         run: npm run launch:p0
 
+      - name: Check P1 release gate
+        run: npm run release:p1
+
       - name: Seed demo data
         run: npm run seed:demo
 

--- a/docs/P1_RELEASE_HARDENING.md
+++ b/docs/P1_RELEASE_HARDENING.md
@@ -1,0 +1,129 @@
+# URAI P1 Release Hardening
+
+P1 is the staging-to-production release discipline layer for URAI V1.
+
+P1 does not add new product scope. It prevents a working P0 demo from turning into an unsafe or unrepeatable production deploy.
+
+## Goal
+
+A production promotion is allowed only when:
+
+- the canonical P0 launch gate is green,
+- staging and production targets are explicit,
+- staging smoke tests have passed,
+- the release candidate commit SHA is documented,
+- the rollback commit SHA is documented,
+- risky modules are behind flags or explicitly out of scope,
+- production approval is explicit,
+- deploys are not performed from ad hoc local branches.
+
+## Required evidence
+
+Set these values in the release environment, CI job, or local shell before running the strict P1 gate:
+
+```bash
+URAI_STAGING_PROJECT_ID="..."
+URAI_PRODUCTION_PROJECT_ID="..."
+URAI_RELEASE_CANDIDATE_SHA="..."
+URAI_ROLLBACK_TARGET_SHA="..."
+URAI_STAGING_SMOKE_TESTED=1
+URAI_PRODUCTION_DEPLOY_APPROVED=1
+```
+
+Optional context values:
+
+```bash
+URAI_STAGING_DEPLOY_URL="https://..."
+URAI_PRODUCTION_DEPLOY_URL="https://..."
+URAI_RELEASE_NOTES_URL="https://..."
+URAI_ROLLBACK_RUNBOOK_URL="https://..."
+```
+
+## Commands
+
+Static P1 structure check:
+
+```bash
+npm run release:p1
+```
+
+Full local command gate:
+
+```bash
+URAI_P1_RUN_COMMANDS=1 npm run release:p1
+```
+
+Strict promotion gate:
+
+```bash
+URAI_P1_STRICT=1 \
+URAI_P1_RUN_COMMANDS=1 \
+URAI_STAGING_PROJECT_ID="..." \
+URAI_PRODUCTION_PROJECT_ID="..." \
+URAI_RELEASE_CANDIDATE_SHA="..." \
+URAI_ROLLBACK_TARGET_SHA="..." \
+URAI_STAGING_SMOKE_TESTED=1 \
+URAI_PRODUCTION_DEPLOY_APPROVED=1 \
+npm run release:p1
+```
+
+## Promotion sequence
+
+1. Merge only a green P0 gate.
+2. Cut or identify a release-candidate SHA.
+3. Deploy that SHA to staging.
+4. Run smoke tests against staging.
+5. Confirm staging and production use the same architecture class and required Firebase resources.
+6. Confirm rollback target SHA.
+7. Approve production promotion.
+8. Deploy only the verified release-candidate SHA.
+9. Record deploy URL, release notes, rollback target, and smoke-test evidence in the P1 issue.
+
+## Staging parity checklist
+
+- [ ] Staging Firebase project ID documented.
+- [ ] Production Firebase project ID documented.
+- [ ] Firestore rules/indexes path matches production.
+- [ ] Functions build/deploy path matches production.
+- [ ] Required environment keys are documented without committing secret values.
+- [ ] Public demo routes exist in staging and production.
+- [ ] Waitlist persistence path is equivalent between staging and production.
+- [ ] Private data read rules are equivalent between staging and production.
+
+## Risky module flag checklist
+
+Risky modules must be disabled, feature-flagged, or explicitly marked out of P1 scope before production promotion.
+
+- [ ] Admin/debug surfaces.
+- [ ] Story/export pipeline.
+- [ ] Marketplace/payment surfaces.
+- [ ] Spatial/XR surfaces.
+- [ ] Relationship insights.
+- [ ] Passive/private memory ingestion.
+- [ ] Any AI flow that writes persistent user-facing state.
+
+## Rollback requirements
+
+A production deploy must have:
+
+- known-good rollback commit SHA,
+- exact command or hosting-provider action for rollback,
+- Firebase rules/index rollback note,
+- owner responsible for executing rollback,
+- criteria for rollback decision.
+
+## Production deploy rule
+
+A production deploy is valid only if the deployed commit equals `URAI_RELEASE_CANDIDATE_SHA` and the P1 strict gate passes.
+
+Do not treat local ad hoc deploys from unverified branches as production releases.
+
+## Output
+
+The P1 gate writes:
+
+```txt
+tmp/p1-release-gate-report.md
+```
+
+Attach or summarize that report in GitHub issue #191 before marking P1 done.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typecheck": "tsc --noEmit",
     "preflight": "npm run check:v1 && npm run check:types && npm run lint && npm run test:unit && npm run build",
     "launch:p0": "node scripts/p0-launch-gate.mjs",
+    "release:p1": "node scripts/p1-release-gate.mjs",
     "seed:demo": "node scripts/seed-demo.mjs",
     "seed:firestore": "node scripts/seed-demo.mjs --firestore",
     "waitlist:export": "node scripts/export-waitlist.mjs",

--- a/scripts/p1-release-gate.mjs
+++ b/scripts/p1-release-gate.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = process.cwd();
+const reportDir = path.join(root, "tmp");
+fs.mkdirSync(reportDir, { recursive: true });
+
+const runCommands = process.env.URAI_P1_RUN_COMMANDS === "1";
+const strict = process.env.URAI_P1_STRICT === "1";
+const checks = [];
+
+function normalizeStatus(status) {
+  if (["pass", "fail", "unverified"].includes(status)) return status;
+  return status ? "pass" : "fail";
+}
+
+function add(name, status, evidence = "", remediation = "") {
+  checks.push({ name, status: normalizeStatus(status), evidence, remediation });
+}
+
+function exists(file) {
+  return fs.existsSync(path.join(root, file));
+}
+
+function read(file) {
+  return fs.readFileSync(path.join(root, file), "utf8");
+}
+
+function readJson(file) {
+  return JSON.parse(read(file));
+}
+
+function hasText(file, pattern) {
+  return exists(file) && pattern.test(read(file));
+}
+
+function envPresent(name) {
+  return Boolean(process.env[name]?.trim());
+}
+
+function envSha(name) {
+  const value = process.env[name]?.trim() || "";
+  return /^[a-f0-9]{7,40}$/i.test(value);
+}
+
+function envOne(name) {
+  return process.env[name] === "1";
+}
+
+function checkFile(file, why) {
+  add(`Required file exists: ${file}`, exists(file), exists(file) ? file : "missing", why);
+}
+
+for (const [file, why] of [
+  ["docs/P1_RELEASE_HARDENING.md", "Document staging, production, rollback, and promotion discipline."],
+  ["scripts/p1-release-gate.mjs", "Provide an executable P1 gate."],
+  ["scripts/p0-launch-gate.mjs", "P1 must build on the canonical P0 gate."],
+  ["docs/V1_DEPLOY_CHECKLIST.md", "Keep deployment checklist visible."],
+  ["docs/V1_QA_CHECKLIST.md", "Keep QA checklist visible."],
+  ["firebase.json", "Declare Firebase deploy paths."],
+  ["firestore.rules", "Protect data before promotion."],
+  ["firestore.indexes.json", "Declare indexes before promotion."],
+  [".github/workflows/ci.yml", "Run CI validation before promotion."],
+  ["package.json", "Expose P1 command."]
+]) {
+  checkFile(file, why);
+}
+
+if (exists("package.json")) {
+  const packageJson = readJson("package.json");
+  add("package script exists: launch:p0", Boolean(packageJson.scripts?.["launch:p0"]), packageJson.scripts?.["launch:p0"] || "missing", "Add launch:p0 script from P0 gate.");
+  add("package script exists: release:p1", Boolean(packageJson.scripts?.["release:p1"]), packageJson.scripts?.["release:p1"] || "missing", "Add release:p1 script.");
+  add("package script exists: test:smoke", Boolean(packageJson.scripts?.["test:smoke"]), packageJson.scripts?.["test:smoke"] || "missing", "Add staging smoke test script.");
+}
+
+if (exists("docs/P1_RELEASE_HARDENING.md")) {
+  for (const token of [
+    "URAI_STAGING_PROJECT_ID",
+    "URAI_PRODUCTION_PROJECT_ID",
+    "URAI_RELEASE_CANDIDATE_SHA",
+    "URAI_ROLLBACK_TARGET_SHA",
+    "URAI_STAGING_SMOKE_TESTED",
+    "URAI_PRODUCTION_DEPLOY_APPROVED",
+    "rollback",
+    "release-candidate",
+    "ad hoc local branches"
+  ]) {
+    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    add(`P1 docs mention ${token}`, hasText("docs/P1_RELEASE_HARDENING.md", new RegExp(escaped, "i")), "docs/P1_RELEASE_HARDENING.md", `Document ${token} in P1 release hardening docs.`);
+  }
+}
+
+if (exists(".github/workflows/ci.yml")) {
+  const ci = read(".github/workflows/ci.yml");
+  add("CI still runs P0 launch gate", ci.includes("npm run launch:p0"), ".github/workflows/ci.yml", "Run npm run launch:p0 in CI before promotion.");
+  add("CI runs P1 release gate", ci.includes("npm run release:p1"), ".github/workflows/ci.yml", "Run npm run release:p1 in CI before promotion.");
+}
+
+const commandChecks = [
+  "npm run launch:p0",
+  "npm run test:smoke"
+];
+
+for (const command of commandChecks) {
+  if (!runCommands) {
+    add(`Command declared, not executed: ${command}`, "unverified", command, `Run URAI_P1_RUN_COMMANDS=1 npm run release:p1 to execute ${command}.`);
+    continue;
+  }
+
+  const [bin, ...args] = command.split(" ");
+  const result = spawnSync(bin, args, { cwd: root, encoding: "utf8", stdio: "pipe" });
+  const output = `${result.stdout || ""}\n${result.stderr || ""}`.trim().slice(-3000);
+  add(`Command passes: ${command}`, result.status === 0, output || `exit ${result.status}`, `Fix failing command: ${command}`);
+}
+
+const environmentEvidence = [
+  ["Staging project ID provided", envPresent("URAI_STAGING_PROJECT_ID"), "URAI_STAGING_PROJECT_ID", "Set URAI_STAGING_PROJECT_ID."],
+  ["Production project ID provided", envPresent("URAI_PRODUCTION_PROJECT_ID"), "URAI_PRODUCTION_PROJECT_ID", "Set URAI_PRODUCTION_PROJECT_ID."],
+  ["Release candidate SHA provided", envSha("URAI_RELEASE_CANDIDATE_SHA"), process.env.URAI_RELEASE_CANDIDATE_SHA || "missing", "Set URAI_RELEASE_CANDIDATE_SHA to the verified commit."],
+  ["Rollback target SHA provided", envSha("URAI_ROLLBACK_TARGET_SHA"), process.env.URAI_ROLLBACK_TARGET_SHA || "missing", "Set URAI_ROLLBACK_TARGET_SHA to a known-good commit."],
+  ["Staging smoke test evidence provided", envOne("URAI_STAGING_SMOKE_TESTED"), "URAI_STAGING_SMOKE_TESTED", "Set URAI_STAGING_SMOKE_TESTED=1 after staging smoke passes."],
+  ["Production deployment explicitly approved", envOne("URAI_PRODUCTION_DEPLOY_APPROVED"), "URAI_PRODUCTION_DEPLOY_APPROVED", "Set URAI_PRODUCTION_DEPLOY_APPROVED=1 only after staging signoff."]
+];
+
+for (const [name, ok, evidence, remediation] of environmentEvidence) {
+  add(name, ok ? "pass" : "unverified", evidence, remediation);
+}
+
+if (envPresent("URAI_STAGING_PROJECT_ID") && envPresent("URAI_PRODUCTION_PROJECT_ID")) {
+  add("Staging and production project IDs are different", process.env.URAI_STAGING_PROJECT_ID !== process.env.URAI_PRODUCTION_PROJECT_ID, "URAI_STAGING_PROJECT_ID / URAI_PRODUCTION_PROJECT_ID", "Use separate staging and production project IDs.");
+}
+
+if (envSha("URAI_RELEASE_CANDIDATE_SHA") && envSha("URAI_ROLLBACK_TARGET_SHA")) {
+  add("Release candidate and rollback SHAs are different", process.env.URAI_RELEASE_CANDIDATE_SHA !== process.env.URAI_ROLLBACK_TARGET_SHA, "URAI_RELEASE_CANDIDATE_SHA / URAI_ROLLBACK_TARGET_SHA", "Rollback target should be a separate known-good commit.");
+}
+
+const passed = checks.filter((check) => check.status === "pass");
+const failed = checks.filter((check) => check.status === "fail");
+const unverified = checks.filter((check) => check.status === "unverified");
+const verdict = failed.length === 0 && unverified.length === 0
+  ? "P1 READY"
+  : failed.length === 0
+    ? "P1 STRUCTURALLY READY - EVIDENCE STILL REQUIRED"
+    : "P1 NOT READY";
+
+function section(title, rows) {
+  if (!rows.length) return `## ${title}\n\nNone.\n`;
+  return `## ${title}\n\n${rows.map((check) => `- **${check.name}**\n  - Status: ${check.status}\n  - Evidence: ${check.evidence || "none"}\n  - Next action: ${check.remediation || "none"}`).join("\n")}\n`;
+}
+
+const report = `# URAI P1 Release Gate Report\n\nGenerated: ${new Date().toISOString()}\n\nVerdict: **${verdict}**\n\nSummary:\n\n- Passed: ${passed.length}\n- Failed: ${failed.length}\n- Unverified: ${unverified.length}\n\n${section("Failed checks", failed)}\n${section("Unverified evidence", unverified)}\n${section("Passed checks", passed)}\n## Commands\n\nStatic P1 gate:\n\n\`\`\`bash\nnpm run release:p1\n\`\`\`\n\nFull local command gate:\n\n\`\`\`bash\nURAI_P1_RUN_COMMANDS=1 npm run release:p1\n\`\`\`\n\nStrict promotion gate:\n\n\`\`\`bash\nURAI_P1_STRICT=1 \\\nURAI_P1_RUN_COMMANDS=1 \\\nURAI_STAGING_PROJECT_ID=\"...\" \\\nURAI_PRODUCTION_PROJECT_ID=\"...\" \\\nURAI_RELEASE_CANDIDATE_SHA=\"...\" \\\nURAI_ROLLBACK_TARGET_SHA=\"...\" \\\nURAI_STAGING_SMOKE_TESTED=1 \\\nURAI_PRODUCTION_DEPLOY_APPROVED=1 \\\nnpm run release:p1\n\`\`\`\n`;
+
+fs.writeFileSync(path.join(reportDir, "p1-release-gate-report.md"), report);
+console.log(report);
+
+if (failed.length > 0) process.exitCode = 1;
+if (strict && unverified.length > 0) process.exitCode = 1;


### PR DESCRIPTION
## Summary

Adds the P1 staging-to-production release hardening lane on top of the merged P0 gate.

This is intentionally separate from P0 product/demo validation. P1 is release discipline:

- staging project/target evidence
- production project/target evidence
- staging smoke-test gate
- release-candidate SHA
- rollback target SHA
- explicit production approval
- prevention of ad hoc production deploys from unverified local branches

## Changes

- Adds `docs/P1_RELEASE_HARDENING.md`
- Adds `scripts/p1-release-gate.mjs`
- Adds `npm run release:p1`
- Runs `npm run release:p1` in CI after `npm run launch:p0`

## Commands

Static gate:

```bash
npm run release:p1
```

Full command gate:

```bash
URAI_P1_RUN_COMMANDS=1 npm run release:p1
```

Strict promotion gate:

```bash
URAI_P1_STRICT=1 \
URAI_P1_RUN_COMMANDS=1 \
URAI_STAGING_PROJECT_ID="..." \
URAI_PRODUCTION_PROJECT_ID="..." \
URAI_RELEASE_CANDIDATE_SHA="..." \
URAI_ROLLBACK_TARGET_SHA="..." \
URAI_STAGING_SMOKE_TESTED=1 \
URAI_PRODUCTION_DEPLOY_APPROVED=1 \
npm run release:p1
```

## Tracking

Implements the first executable pass for #191.

## Test plan

Not run locally in this environment. CI should run the structural P1 gate. Strict P1 promotion requires real staging/prod evidence.