### PR TITLE
Polish canonical V1 demo copy and states

### DIFF
--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { handle } = await params;
   const profile = getDemoProfileByHandle(handle);
   const title = `@${profile.user.handle} Public Constellation`;
-  const description = `${profile.user.displayName}'s URAI memory constellation, mood forecast, weekly reflection, and symbolic timeline.`;
+  const description = `${profile.user.displayName}'s URAI demo constellation with a mood forecast, weekly reflection, and public-safe memory timeline.`;
 
   return {
     title,
@@ -37,9 +37,18 @@ export default async function PublicConstellationPage({ params }: PageProps) {
   return (
     <main className="min-h-dvh bg-black px-5 py-8 text-white">
       <section className="mx-auto max-w-6xl">
-        <p className="text-xs uppercase tracking-[0.45em] text-white/45">Public Constellation</p>
+        <div className="flex flex-wrap items-center gap-3">
+          <p className="text-xs uppercase tracking-[0.45em] text-white/45">Public Constellation</p>
+          <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">
+            Demo data · public-safe view
+          </span>
+        </div>
         <h1 className="mt-4 text-4xl font-semibold">@{profile.user.handle}</h1>
-        <p className="mt-3 max-w-2xl text-white/65">{profile.user.tagline}</p>
+        <p className="mt-3 max-w-2xl text-white/70">{profile.user.tagline}</p>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-white/55">
+          This page shows the V1 demo path: a shareable constellation, a mood forecast,
+          a weekly reflection, and a waitlist CTA without exposing private memory data.
+        </p>
 
         <div className="mt-8 grid gap-4 md:grid-cols-3">
           <ForecastCard forecast={profile.moodForecast} />
@@ -48,7 +57,16 @@ export default async function PublicConstellationPage({ params }: PageProps) {
         </div>
 
         <section className="mt-8">
-          <h2 className="text-2xl font-semibold">Memory Blooms</h2>
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/40">Demo memories</p>
+              <h2 className="mt-2 text-2xl font-semibold">Memory Blooms</h2>
+            </div>
+            <p className="max-w-md text-sm leading-6 text-white/50">
+              Each card is intentionally summarized for a public viewer: clear enough to feel the story,
+              bounded enough to avoid private-detail leakage.
+            </p>
+          </div>
           <div className="mt-4 grid gap-4 md:grid-cols-3">
             {profile.memoryBlooms.map((bloom) => (
               <article key={bloom.id} className="rounded-3xl border border-white/10 bg-white/10 p-4">
@@ -62,7 +80,16 @@ export default async function PublicConstellationPage({ params }: PageProps) {
         </section>
 
         <section className="mt-8">
-          <h2 className="text-2xl font-semibold">Star Timeline</h2>
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/40">Pattern timeline</p>
+              <h2 className="mt-2 text-2xl font-semibold">Star Timeline</h2>
+            </div>
+            <p className="max-w-md text-sm leading-6 text-white/50">
+              The timeline makes the demo legible on first pass: what happened, how intense it felt,
+              and which symbolic tags the companion can explain.
+            </p>
+          </div>
           <div className="mt-4 grid gap-3 md:grid-cols-3">
             {profile.timelineEvents.map((event) => (
               <article key={event.id} className="rounded-3xl border border-white/10 bg-white/5 p-4">

--- a/src/components/CompanionChat.tsx
+++ b/src/components/CompanionChat.tsx
@@ -16,7 +16,7 @@ export default function CompanionChat() {
     if (isSending) return;
 
     if (!trimmedMessage) {
-      setErrorMessage("Write a question for the companion first.");
+      setErrorMessage("Ask a short question first so the demo can respond clearly.");
       return;
     }
 
@@ -31,7 +31,7 @@ export default function CompanionChat() {
       });
 
       if (!response.ok) {
-        setErrorMessage("URAI could not read that pattern yet. Try a shorter question.");
+        setErrorMessage("The companion could not read that prompt yet. Try a shorter question.");
         return;
       }
 
@@ -47,8 +47,11 @@ export default function CompanionChat() {
 
   return (
     <section className="rounded-3xl border border-white/10 bg-black/35 p-4 text-white shadow-2xl backdrop-blur-md">
-      <p className="text-xs uppercase tracking-[0.3em] text-white/50">Companion</p>
-      <h2 className="mb-3 text-lg font-semibold">Ask URAI what the pattern means</h2>
+      <p className="text-xs uppercase tracking-[0.3em] text-white/50">Companion Demo</p>
+      <h2 className="mb-2 text-lg font-semibold">Ask what the pattern means</h2>
+      <p className="mb-3 text-sm leading-6 text-white/60">
+        Try one focused prompt. The demo returns a short interpretation of the visible constellation.
+      </p>
       <form
         className="flex flex-col gap-2 sm:flex-row"
         onSubmit={(event) => {
@@ -66,7 +69,7 @@ export default function CompanionChat() {
             setMessage(event.target.value);
             if (errorMessage) setErrorMessage("");
           }}
-          placeholder="What should I build next?"
+          placeholder="What pattern stands out today?"
           className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/45 outline-none transition focus:border-white/40 focus:ring-2 focus:ring-white/20"
           aria-describedby={errorMessage ? "companion-error" : reply ? "companion-reply" : undefined}
           aria-invalid={Boolean(errorMessage)}
@@ -76,7 +79,7 @@ export default function CompanionChat() {
           disabled={!canSubmit}
           className="rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-black transition hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/50 disabled:cursor-not-allowed disabled:opacity-40"
         >
-          {isSending ? "Reading..." : "Send"}
+          {isSending ? "Reading..." : "Ask"}
         </button>
       </form>
       {errorMessage && (
@@ -87,7 +90,7 @@ export default function CompanionChat() {
       {reply && (
         <div id="companion-reply" className="mt-4 rounded-2xl bg-white/10 p-3" aria-live="polite">
           <p className="text-sm leading-6 text-white/90">{reply.reply}</p>
-          <p className="mt-2 text-xs text-white/60">Mood: {reply.moodTag}</p>
+          <p className="mt-2 text-xs uppercase tracking-[0.2em] text-white/50">Mood tag · {reply.moodTag}</p>
         </div>
       )}
     </section>

--- a/src/components/HomeScene.tsx
+++ b/src/components/HomeScene.tsx
@@ -17,11 +17,11 @@ type HomeMode = "home" | "transitioning" | "lifemap";
 
 const TONE_COPY = {
   calm: {
-    idle: "Tap the sky to open your Life Map",
+    idle: "Tap the sky to open the demo Life Map",
     opening: "Softening into the Life Map...",
   },
   focused: {
-    idle: "Tap the sky to trace today’s pattern",
+    idle: "Tap the sky to trace the demo pattern",
     opening: "Focusing the constellation...",
   },
   charged: {
@@ -112,9 +112,9 @@ export default function HomeScene() {
         onClick={openLifeMap}
         disabled={isTransitioning}
         className="sky-trigger"
-        aria-label="Open URAI Life Map from the sky"
+        aria-label="Open URAI demo Life Map from the sky"
       >
-        <span className="sr-only">Open URAI Life Map</span>
+        <span className="sr-only">Open URAI demo Life Map</span>
       </button>
 
       <div className="absolute inset-0 bg-gradient-to-b from-indigo-950 via-black to-black" />
@@ -166,17 +166,27 @@ export default function HomeScene() {
 
       <section className="relative z-20 mx-auto flex min-h-dvh w-full max-w-6xl flex-col justify-between px-5 py-8">
         <div className="max-w-3xl pt-10">
-          <p className="text-xs uppercase tracking-[0.45em] text-white/50">
-            URAI V1 Demo Spine
-          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="text-xs uppercase tracking-[0.45em] text-white/50">
+              URAI V1 Demo Spine
+            </p>
+            <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">
+              Public-safe demo data
+            </span>
+          </div>
 
           <h1 className="mt-4 text-4xl font-semibold tracking-tight md:text-6xl">
-            A passive emotional operating system for memory, mood, and meaning.
+            A public demo for memory patterns, mood signals, and personal meaning.
           </h1>
 
           <p className="mt-5 max-w-2xl text-base leading-7 text-white/70 md:text-lg">
-            This route renders the core loop: symbolic environment, mood forecast,
-            weekly reflection, companion narrator, and Ancient Signals body-weather.
+            This launch path shows the working V1 loop: a symbolic environment, a mood forecast,
+            a weekly reflection, a companion interpretation, and a waitlist CTA.
+          </p>
+
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-white/50">
+            The demo is intentionally narrow: it uses curated demo data, avoids private memory exposure,
+            and keeps future roadmap surfaces out of the public path.
           </p>
 
           <div className="mt-6 flex flex-wrap gap-3">
@@ -193,7 +203,7 @@ export default function HomeScene() {
               disabled={isTransitioning}
               className="inline-flex rounded-full border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-white backdrop-blur transition hover:bg-white/15 disabled:cursor-progress disabled:opacity-70"
             >
-              {isTransitioning ? copy.opening : "Open Life Map"}
+              {isTransitioning ? copy.opening : "Preview Life Map"}
             </button>
           </div>
         </div>

--- a/src/components/WaitlistForm.tsx
+++ b/src/components/WaitlistForm.tsx
@@ -25,7 +25,7 @@ export default function WaitlistForm({ source, handle }: Props) {
 
     if (!emailPattern.test(trimmedEmail)) {
       setStatus("error");
-      setErrorMessage("Enter a valid email address before joining.");
+      setErrorMessage("Enter a valid email address to join the waitlist.");
       return;
     }
 
@@ -46,7 +46,7 @@ export default function WaitlistForm({ source, handle }: Props) {
 
       if (!response.ok) {
         setStatus("error");
-        setErrorMessage("We could not join the waitlist. Check the email and try again.");
+        setErrorMessage("We could not save that email. Check it and try again.");
         return;
       }
 
@@ -63,7 +63,7 @@ export default function WaitlistForm({ source, handle }: Props) {
       <p className="text-xs uppercase tracking-[0.3em] text-white/50">Early Access</p>
       <h2 className="mt-1 text-xl font-semibold">Join the URAI waitlist</h2>
       <p className="mt-2 text-sm leading-6 text-white/70">
-        Get the first public build when the demo spine moves into launch testing.
+        Get notified when the public V1 demo is ready for broader testing.
       </p>
       <form
         className="mt-4 flex flex-col gap-2 sm:flex-row"
@@ -98,11 +98,12 @@ export default function WaitlistForm({ source, handle }: Props) {
           disabled={!canSubmit}
           className="rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-black transition hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/50 disabled:cursor-not-allowed disabled:opacity-40"
         >
-          {status === "sending" ? "Joining..." : "Join"}
+          {status === "sending" ? "Joining..." : status === "joined" ? "Joined" : "Join"}
         </button>
       </form>
       <div id={statusId} aria-live="polite">
-        {status === "joined" && <p className="mt-3 text-sm text-emerald-200">You are on the list.</p>}
+        {status === "sending" && <p className="mt-3 text-sm text-white/55">Saving your spot...</p>}
+        {status === "joined" && <p className="mt-3 text-sm text-emerald-200">You are on the list. We will send launch access here.</p>}
         {status === "error" && <p className="mt-3 text-sm text-red-200">{errorMessage}</p>}
       </div>
     </section>

--- a/tests/e2e/v1-smoke.spec.ts
+++ b/tests/e2e/v1-smoke.spec.ts
@@ -15,7 +15,7 @@ test.describe("URAI V1 smoke", () => {
 
     await expectBodyText(page, /^Mood Forecast$/);
     await expectBodyText(page, /^Weekly Reflection$/);
-    await expectBodyText(page, /^Companion$/);
+    await expectBodyText(page, /^Companion Demo$/);
     await expectBodyText(page, /^Early Access$/);
   });
 
@@ -23,6 +23,7 @@ test.describe("URAI V1 smoke", () => {
     await page.goto("/u/adamclamp", { waitUntil: "domcontentloaded" });
 
     await expectBodyText(page, /^Public Constellation$/);
+    await expectBodyText(page, /^Demo data · public-safe view$/);
     await expectBodyText(page, /^@adamclamp$/);
     await expectBodyText(page, /^Memory Blooms$/);
     await expectBodyText(page, /^Star Timeline$/);
@@ -50,7 +51,7 @@ test.describe("URAI V1 smoke", () => {
     const email = page.locator("#waitlist-email-public-constellation");
     const form = email.locator("xpath=ancestor::form");
     await expect(email).toBeVisible();
-    await expect(form.getByRole("button", { name: "Join" })).toBeDisabled();
+    await expect(form.getByRole("button", { name: /Join|Joined/ })).toBeDisabled();
   });
 
   test("companion API responds to a valid prompt", async ({ request }) => {
@@ -73,6 +74,6 @@ test.describe("URAI V1 smoke", () => {
     const input = page.locator("#companion-message");
     const form = input.locator("xpath=ancestor::form");
     await expect(input).toBeVisible();
-    await expect(form.getByRole("button", { name: "Send" })).toBeDisabled();
+    await expect(form.getByRole("button", { name: "Ask" })).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary

Focused P2 polish for the canonical URAI V1 demo path.

This keeps P2 scoped to user-visible clarity and does not add new product surfaces.

## Changes

- Reframes `/` as a narrow public V1 demo, not a broad future roadmap claim.
- Adds public-safe demo-data framing to `/u/adamclamp`.
- Improves public constellation section headers and explanatory text.
- Tightens companion demo copy, placeholder, CTA, and error guidance.
- Improves waitlist loading/success/error states and launch expectation copy.

## Non-goals

- No new product surfaces.
- No investor deck work.
- No B2B/jobs flow.
- No spatial/XR expansion.
- No story/export pipeline.
- No production promotion evidence changes. P1 operational evidence remains tracked in #191.

## Tracking

Addresses first pass of #194.

## Test plan

CI should run the existing gates:

```bash
npm run launch:p0
npm run release:p1
npm run seed:demo
npm run test:unit
npm run test:rules
npm run typecheck
npm run lint
npm run build
```

Manual review after CI:

- `/` desktop and mobile copy clarity
- `/u/adamclamp` desktop and mobile copy clarity
- Companion happy path and empty-input guard
- Waitlist invalid email, sending, success, and error states