### PR TITLE
Tighten URAI V1 launch closeout gate evidence

### DIFF
--- a/docs/LAUNCH_CLOSEOUT_RUNBOOK.md
+++ b/docs/LAUNCH_CLOSEOUT_RUNBOOK.md
@@ -37,6 +37,8 @@ From the release-candidate commit:
 
 ```bash
 npm install
+npm run check:lockfile
+npm run check:v1
 npm run launch:p0
 npm run release:p1
 npm run seed:demo
@@ -51,11 +53,12 @@ Record the command output summary in #196.
 
 ## 3. Run strict P1 promotion gate
 
-Strict P1 requires real deployment evidence values.
+Strict P1 requires real deployment evidence values. Include `URAI_P0_RUN_COMMANDS=1` so the generated P1 report contains full P0 command evidence instead of only the nested P0 pass/fail marker.
 
 ```bash
 URAI_P1_STRICT=1 \
 URAI_P1_RUN_COMMANDS=1 \
+URAI_P0_RUN_COMMANDS=1 \
 URAI_STAGING_PROJECT_ID="..." \
 URAI_PRODUCTION_PROJECT_ID="..." \
 URAI_RELEASE_CANDIDATE_SHA="..." \
@@ -190,9 +193,11 @@ Production URL: `...`
 
 ### Gates
 
+- [ ] `npm run check:lockfile` passed
+- [ ] `npm run check:v1` passed
 - [ ] `npm run launch:p0` passed
 - [ ] `npm run release:p1` passed
-- [ ] strict P1 gate passed
+- [ ] strict P1 gate passed with `URAI_P0_RUN_COMMANDS=1`
 - [ ] `tmp/p1-release-gate-report.md` summary attached
 
 ### Visual proof


### PR DESCRIPTION
## Summary

Tightens the URAI V1 launch closeout runbook so the final evidence package captures the structural gates that review feedback called out after #197 merged.

## Changes

- adds `npm run check:lockfile` to the local structural gate sequence
- adds `npm run check:v1` to the local structural gate sequence
- adds `URAI_P0_RUN_COMMANDS=1` to the strict P1 command so nested P0 execution evidence is captured in the generated report
- updates the closeout comment template to require those checks in #196 evidence

## Tracking

Supports #196.

## Test plan

Docs-only change. No runtime behavior changed.