### PR TITLE
Add V1.1 visual magic to home ascent and Life Map

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,7 +8,6 @@ body {
   font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
-/* V1.1 visual magic: keep the Life Map fast 2.5D, but give it spatial depth. */
 .life-map-shell::before,
 .life-map-shell::after {
   content: "";
@@ -38,6 +37,17 @@ body {
   opacity: 0.9;
   transform: perspective(800px) rotateX(58deg);
   transform-origin: center bottom;
+}
+
+.webgl-life-map-field {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.92;
+  pointer-events: none;
+  mix-blend-mode: screen;
 }
 
 .lifemap-space::before,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,3 +7,122 @@ body {
   color: #fff;
   font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
+
+/* V1.1 visual magic: keep the Life Map fast 2.5D, but give it spatial depth. */
+.life-map-shell::before,
+.life-map-shell::after {
+  content: "";
+  position: absolute;
+  inset: -18%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.life-map-shell::before {
+  background:
+    radial-gradient(circle at 22% 28%, rgba(125, 211, 252, 0.16), transparent 18%),
+    radial-gradient(circle at 76% 34%, rgba(196, 181, 253, 0.14), transparent 20%),
+    radial-gradient(ellipse at 50% 86%, rgba(15, 23, 42, 0.95), transparent 34%);
+  filter: blur(10px);
+  opacity: 0.84;
+  animation: uraiSpatialNebula 24s ease-in-out infinite alternate;
+}
+
+.life-map-shell::after {
+  inset: auto -12% -18% -12%;
+  height: 44%;
+  background:
+    radial-gradient(ellipse at 50% 10%, rgba(255, 255, 255, 0.12), transparent 18%),
+    radial-gradient(ellipse at 50% 28%, rgba(125, 211, 252, 0.14), transparent 28%),
+    linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.78));
+  opacity: 0.9;
+  transform: perspective(800px) rotateX(58deg);
+  transform-origin: center bottom;
+}
+
+.lifemap-space::before,
+.lifemap-space::after {
+  content: "";
+  position: absolute;
+  inset: 8% 10% 18%;
+  pointer-events: none;
+  border-radius: 999px;
+  z-index: 0;
+}
+
+.lifemap-space::before {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    0 0 60px rgba(125, 211, 252, 0.12),
+    inset 0 0 80px rgba(196, 181, 253, 0.08);
+  transform: perspective(900px) rotateX(62deg) scale(0.92);
+}
+
+.lifemap-space::after {
+  inset: 16% 18% 26%;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  transform: perspective(900px) rotateX(62deg) scale(1.18);
+  animation: uraiDepthRing 18s linear infinite;
+}
+
+.starfield,
+.connections,
+.memory-star {
+  z-index: 1;
+}
+
+.companion-orb .orb-core {
+  animation: uraiOrbCorePulse 5.5s ease-in-out infinite !important;
+}
+
+.avatar-heart {
+  animation: uraiAvatarHeartPulse 4.8s ease-in-out infinite !important;
+}
+
+@keyframes uraiSpatialNebula {
+  from {
+    transform: translate3d(-1.5%, -0.8%, 0) scale(1);
+    opacity: 0.62;
+  }
+  to {
+    transform: translate3d(1.2%, 1.1%, 0) scale(1.08);
+    opacity: 0.92;
+  }
+}
+
+@keyframes uraiDepthRing {
+  to {
+    transform: perspective(900px) rotateX(62deg) scale(1.18) rotateZ(360deg);
+  }
+}
+
+@keyframes uraiOrbCorePulse {
+  0%, 100% {
+    transform: scale(0.96);
+    opacity: 0.82;
+  }
+  50% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+}
+
+@keyframes uraiAvatarHeartPulse {
+  0%, 100% {
+    transform: translateX(-50%) scale(0.96);
+    opacity: 0.78;
+  }
+  50% {
+    transform: translateX(-50%) scale(1.08);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .life-map-shell::before,
+  .lifemap-space::after,
+  .companion-orb .orb-core,
+  .avatar-heart {
+    animation: none !important;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,25 @@ body {
   font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
+.home-webgl-sky,
+.webgl-life-map-field {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.home-webgl-sky {
+  opacity: 0.72;
+}
+
+.webgl-life-map-field {
+  opacity: 0.92;
+}
+
 .life-map-shell::before,
 .life-map-shell::after {
   content: "";
@@ -37,17 +56,6 @@ body {
   opacity: 0.9;
   transform: perspective(800px) rotateX(58deg);
   transform-origin: center bottom;
-}
-
-.webgl-life-map-field {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0.92;
-  pointer-events: none;
-  mix-blend-mode: screen;
 }
 
 .lifemap-space::before,

--- a/src/components/GroundLayer.tsx
+++ b/src/components/GroundLayer.tsx
@@ -18,10 +18,16 @@ const TIER_CLASSES: Record<GroundTier, string> = {
 };
 
 const BLOOM_SCALES = [0.72, 0.95, 0.82, 1.12, 0.68, 1.04, 0.88];
-const PARTICLES = Array.from({ length: 12 }).map((_, index) => ({
+const ROOT_ARCS = [
+  { left: "12%", width: "28%", delay: "0s", opacity: 0.34 },
+  { left: "32%", width: "36%", delay: "0.8s", opacity: 0.42 },
+  { left: "58%", width: "30%", delay: "1.4s", opacity: 0.3 },
+];
+const PARTICLES = Array.from({ length: 16 }).map((_, index) => ({
   top: `${(index * 23) % 100}%`,
   left: `${(index * 37) % 100}%`,
-  opacity: 0.45 + (index % 4) * 0.12
+  opacity: 0.35 + (index % 5) * 0.1,
+  delay: `${(index % 6) * 0.4}s`,
 }));
 
 export default function GroundLayer({ state, forcedTier, className }: Props) {
@@ -39,44 +45,61 @@ export default function GroundLayer({ state, forcedTier, className }: Props) {
       ].join(" ")}
       data-ground-tier={tier}
     >
-      <div className="w-full h-1/3 relative">
+      <div className="ground-system w-full h-[42%] relative overflow-hidden">
         <div
-          className="absolute inset-0"
+          className="ground-base absolute inset-0"
           style={{
             background:
               tier === 1
-                ? "radial-gradient(ellipse at bottom, #1a1a1a 0%, #000 70%)"
+                ? "radial-gradient(ellipse at bottom, #1a1a1a 0%, #050505 58%, transparent 82%)"
                 : tier === 2
-                ? "radial-gradient(ellipse at bottom, #1f2a1f 0%, #000 70%)"
+                ? "radial-gradient(ellipse at bottom, #1f2a1f 0%, #050705 58%, transparent 82%)"
                 : tier === 3
-                ? "radial-gradient(ellipse at bottom, #243824 0%, #000 70%)"
+                ? "radial-gradient(ellipse at bottom, #243824 0%, #061006 58%, transparent 82%)"
                 : tier === 4
-                ? "radial-gradient(ellipse at bottom, #2d4d2d 0%, #000 70%)"
-                : "radial-gradient(ellipse at bottom, #355f35 0%, #000 70%)"
+                ? "radial-gradient(ellipse at bottom, #2d4d2d 0%, #071407 58%, transparent 82%)"
+                : "radial-gradient(ellipse at bottom, #355f35 0%, #071607 58%, transparent 82%)"
           }}
         />
 
         <div
-          className="absolute inset-0"
+          className="ground-aura absolute inset-0"
           style={{
             background:
               tier >= 3
-                ? "radial-gradient(ellipse at center, rgba(120,255,160,0.15), transparent 70%)"
-                : "none"
+                ? "radial-gradient(ellipse at 50% 72%, rgba(120,255,160,0.22), transparent 54%), radial-gradient(ellipse at 50% 100%, rgba(255,255,255,0.08), transparent 32%)"
+                : "radial-gradient(ellipse at 50% 88%, rgba(255,255,255,0.05), transparent 40%)"
           }}
         />
 
+        <div className="absolute inset-x-0 bottom-0 h-24 opacity-70">
+          {ROOT_ARCS.map((arc, index) => (
+            <span
+              key={index}
+              className="ground-root absolute bottom-3 h-10 rounded-[999px] border-t border-emerald-200/30"
+              style={{
+                left: arc.left,
+                width: arc.width,
+                opacity: tier >= 2 ? arc.opacity : arc.opacity * 0.45,
+                animationDelay: arc.delay,
+              }}
+            />
+          ))}
+        </div>
+
         {tier >= 4 && (
-          <div className="absolute inset-0 flex items-end justify-center pb-6">
+          <div className="absolute inset-0 flex items-end justify-center pb-7">
             <div className="flex gap-3">
               {BLOOM_SCALES.slice(0, tier === 5 ? 7 : 4).map((scale, index) => (
                 <div
                   key={index}
-                  className="w-2 h-6 rounded-full"
+                  className="ground-bloom w-2 rounded-full"
                   style={{
+                    height: tier === 5 ? "2.1rem" : "1.65rem",
                     background: tier === 5 ? "#baffc9" : "#7cff9e",
-                    boxShadow: tier === 5 ? "0 0 10px rgba(186,255,201,0.8)" : "0 0 6px rgba(124,255,158,0.6)",
-                    transform: `scaleY(${scale})`
+                    boxShadow: tier === 5 ? "0 0 10px rgba(186,255,201,0.8), 0 0 26px rgba(120,255,160,0.3)" : "0 0 6px rgba(124,255,158,0.6)",
+                    transform: `scaleY(${scale})`,
+                    animationDelay: `${index * 0.22}s`,
                   }}
                 />
               ))}
@@ -89,18 +112,78 @@ export default function GroundLayer({ state, forcedTier, className }: Props) {
             {PARTICLES.map((particle, index) => (
               <div
                 key={index}
-                className="absolute w-1 h-1 rounded-full"
+                className="ground-particle absolute w-1 h-1 rounded-full"
                 style={{
                   background: "#e6fff2",
                   top: particle.top,
                   left: particle.left,
-                  opacity: particle.opacity
+                  opacity: particle.opacity,
+                  animationDelay: particle.delay,
                 }}
               />
             ))}
           </div>
         )}
       </div>
+
+      <style jsx>{`
+        .ground-system {
+          mask-image: linear-gradient(to top, black 0%, black 66%, transparent 100%);
+        }
+
+        .ground-base,
+        .ground-aura {
+          transition: opacity 800ms ease, transform 1200ms ease;
+        }
+
+        .ground-aura {
+          animation: groundBreath 7s ease-in-out infinite;
+        }
+
+        .ground-root {
+          transform-origin: center bottom;
+          animation: rootPulse 5.5s ease-in-out infinite;
+        }
+
+        .ground-bloom {
+          transform-origin: bottom center;
+          animation: bloomSway 4.8s ease-in-out infinite;
+        }
+
+        .ground-particle {
+          box-shadow: 0 0 10px rgba(230,255,242,0.85), 0 0 20px rgba(120,255,160,0.35);
+          animation: particleLift 6s ease-in-out infinite;
+        }
+
+        @keyframes groundBreath {
+          0%, 100% { opacity: 0.72; transform: scaleY(0.96); }
+          50% { opacity: 1; transform: scaleY(1.04); }
+        }
+
+        @keyframes rootPulse {
+          0%, 100% { transform: scaleX(0.92); filter: drop-shadow(0 0 0 rgba(120,255,160,0)); }
+          50% { transform: scaleX(1.06); filter: drop-shadow(0 0 8px rgba(120,255,160,0.28)); }
+        }
+
+        @keyframes bloomSway {
+          0%, 100% { translate: 0 0; opacity: 0.78; }
+          50% { translate: 0 -0.22rem; opacity: 1; }
+        }
+
+        @keyframes particleLift {
+          0%, 100% { transform: translateY(0) scale(0.9); opacity: 0.28; }
+          50% { transform: translateY(-1.5rem) scale(1.1); opacity: 0.9; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .ground-aura,
+          .ground-root,
+          .ground-bloom,
+          .ground-particle {
+            animation: none !important;
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/src/components/HomeScene.tsx
+++ b/src/components/HomeScene.tsx
@@ -6,6 +6,7 @@ import AncientSignalAmbientLayer from "@/components/ancient-signals/AncientSigna
 import CompanionChat from "@/components/CompanionChat";
 import ForecastCard from "@/components/ForecastCard";
 import GroundLayer from "@/components/GroundLayer";
+import HomeWebGLSky from "@/components/HomeWebGLSky";
 import LifeMapScene from "@/components/lifemap/LifeMapScene";
 import { useEmotionalTone } from "@/components/lifemap/useEmotionalTone";
 import WaitlistForm from "@/components/WaitlistForm";
@@ -37,20 +38,16 @@ const TONE_COPY = {
 export default function HomeScene() {
   const profile = adamClampDemoProfile;
   const { result: ancientResult, source, loading } = useAncientSignals();
-
   const [mode, setMode] = useState<HomeMode>("home");
   const [reduceMotion, setReduceMotion] = useState(false);
   const emotionalTone = useEmotionalTone();
 
   useEffect(() => {
     if (typeof window === "undefined") return undefined;
-
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
     const onChange = () => setReduceMotion(mq.matches);
-
     onChange();
     mq.addEventListener("change", onChange);
-
     return () => mq.removeEventListener("change", onChange);
   }, []);
 
@@ -64,23 +61,16 @@ export default function HomeScene() {
 
   useEffect(() => {
     if (mode !== "transitioning") return undefined;
-
     if (reduceMotion) {
       setMode("lifemap");
       return undefined;
     }
-
     const timer = window.setTimeout(() => setMode("lifemap"), transitionDuration);
     return () => window.clearTimeout(timer);
   }, [mode, reduceMotion, transitionDuration]);
 
-  const openLifeMap = () => {
-    setMode(reduceMotion ? "lifemap" : "transitioning");
-  };
-
-  const returnHome = () => {
-    setMode("home");
-  };
+  const openLifeMap = () => setMode(reduceMotion ? "lifemap" : "transitioning");
+  const returnHome = () => setMode("home");
 
   if (mode === "lifemap") {
     return (
@@ -102,11 +92,7 @@ export default function HomeScene() {
   const copy = TONE_COPY[emotionalTone];
 
   return (
-    <main
-      className={`home-scene tone-${emotionalTone} ${
-        isTransitioning ? "is-transitioning" : ""
-      } relative min-h-dvh overflow-hidden bg-black text-white`}
-    >
+    <main className={`home-scene tone-${emotionalTone} ${isTransitioning ? "is-transitioning" : ""}`}>
       <button
         type="button"
         onClick={openLifeMap}
@@ -117,8 +103,8 @@ export default function HomeScene() {
         <span className="sr-only">Open URAI demo Life Map</span>
       </button>
 
-      <div className="absolute inset-0 bg-gradient-to-b from-indigo-950 via-black to-black" />
-
+      <div className="sky-base" aria-hidden />
+      <HomeWebGLSky />
       <AncientSignalAmbientLayer result={ancientResult} source={source} loading={loading} />
 
       <GroundLayer
@@ -139,23 +125,10 @@ export default function HomeScene() {
       />
 
       <div className="emotional-wash" aria-hidden />
-      <div className="ambient-drift" aria-hidden />
-      <div className="sky-breath" aria-hidden />
       <div className="cloud-veil cloud-low" aria-hidden />
       <div className="cloud-veil cloud-high" aria-hidden />
-
-      <div className="parallax-field parallax-near" aria-hidden>
-        <span />
-        <span />
-        <span />
-      </div>
-
-      <div className="parallax-field parallax-far" aria-hidden>
-        <span />
-        <span />
-        <span />
-        <span />
-      </div>
+      <div className="ascent-column" aria-hidden />
+      <div className="transition-vignette" aria-hidden />
 
       <div className="soul-anchor" aria-hidden>
         <div className="avatar-halo" />
@@ -178,8 +151,6 @@ export default function HomeScene() {
         <span className="orb-ring orb-ring-two" />
       </button>
 
-      <div className="ascent-column" aria-hidden />
-
       <div className="star-tunnel" aria-hidden>
         <span className="star star-one" />
         <span className="star star-two" />
@@ -188,16 +159,12 @@ export default function HomeScene() {
         <span className="star star-five" />
       </div>
 
-      <div className="transition-vignette" aria-hidden />
-
-      <section className="content-stage relative z-20 mx-auto flex min-h-dvh w-full max-w-6xl flex-col justify-between px-5 py-8">
-        <div className="max-w-3xl pt-10">
+      <section className="content-stage">
+        <div className="hero-copy">
           <div className="flex flex-wrap items-center gap-3">
-            <p className="text-xs uppercase tracking-[0.45em] text-white/50">
-              URAI V1 Demo Spine
-            </p>
+            <p className="text-xs uppercase tracking-[0.45em] text-white/50">URAI V1 Demo Spine</p>
             <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs text-white/60">
-              Public-safe demo data
+              WebGL spatial home · Public-safe demo data
             </span>
           </div>
 
@@ -206,23 +173,18 @@ export default function HomeScene() {
           </h1>
 
           <p className="mt-5 max-w-2xl text-base leading-7 text-white/70 md:text-lg">
-            This launch path shows the working V1 loop: a symbolic environment, a mood forecast,
-            a weekly reflection, a companion interpretation, and a waitlist CTA.
+            This launch path shows the working V1 loop: a WebGL emotional sky, symbolic ground,
+            mood forecast, weekly reflection, companion interpretation, and waitlist CTA.
           </p>
 
           <p className="mt-3 max-w-2xl text-sm leading-6 text-white/50">
-            The demo is intentionally narrow: it uses curated demo data, avoids private memory exposure,
-            and keeps future roadmap surfaces out of the public path.
+            Tap the orb to ascend from the home scene into the WebGL-backed Life Map.
           </p>
 
           <div className="mt-6 flex flex-wrap gap-3">
-            <Link
-              href="/u/adamclamp"
-              className="inline-flex rounded-full bg-white px-5 py-3 text-sm font-semibold text-black"
-            >
+            <Link href="/u/adamclamp" className="inline-flex rounded-full bg-white px-5 py-3 text-sm font-semibold text-black">
               Open public constellation
             </Link>
-
             <button
               type="button"
               onClick={openLifeMap}
@@ -242,10 +204,7 @@ export default function HomeScene() {
         </div>
       </section>
 
-      <div className="tone-chip" aria-hidden>
-        {emotionalTone}
-      </div>
-
+      <div className="tone-chip" aria-hidden>{emotionalTone}</div>
       <div className="tap-hint">{isTransitioning ? copy.opening : copy.idle}</div>
 
       <style jsx>{`
@@ -254,189 +213,69 @@ export default function HomeScene() {
           --tone-b: rgba(196, 181, 253, 0.12);
           --tone-c: rgba(255, 255, 255, 0.07);
           --tone-speed: 1;
+          position: relative;
+          min-height: 100dvh;
+          overflow: hidden;
+          background: #000;
+          color: white;
           isolation: isolate;
         }
 
-        .tone-calm {
-          --tone-a: rgba(125, 211, 252, 0.13);
-          --tone-b: rgba(196, 181, 253, 0.1);
-          --tone-c: rgba(255, 255, 255, 0.06);
-          --tone-speed: 1;
-        }
+        .tone-focused { --tone-a: rgba(96,165,250,.16); --tone-b: rgba(45,212,191,.1); --tone-speed: .9; }
+        .tone-charged { --tone-a: rgba(251,191,36,.15); --tone-b: rgba(244,114,182,.12); --tone-speed: .75; }
+        .tone-restorative { --tone-a: rgba(167,139,250,.15); --tone-b: rgba(14,165,233,.1); --tone-speed: 1.25; }
 
-        .tone-focused {
-          --tone-a: rgba(96, 165, 250, 0.15);
-          --tone-b: rgba(45, 212, 191, 0.1);
-          --tone-c: rgba(219, 234, 254, 0.08);
-          --tone-speed: 0.9;
-        }
-
-        .tone-charged {
-          --tone-a: rgba(251, 191, 36, 0.13);
-          --tone-b: rgba(244, 114, 182, 0.1);
-          --tone-c: rgba(255, 255, 255, 0.08);
-          --tone-speed: 0.75;
-        }
-
-        .tone-restorative {
-          --tone-a: rgba(167, 139, 250, 0.14);
-          --tone-b: rgba(14, 165, 233, 0.09);
-          --tone-c: rgba(226, 232, 240, 0.06);
-          --tone-speed: 1.25;
-        }
-
-        .sky-trigger {
+        .sky-base,
+        .emotional-wash,
+        .cloud-veil,
+        .ascent-column,
+        .transition-vignette {
           position: absolute;
           inset: 0;
-          z-index: 10;
-          cursor: zoom-in;
-          border: 0;
-          background: transparent;
-        }
-
-        .sky-trigger:disabled {
-          cursor: progress;
-        }
-
-        .emotional-wash,
-        .ambient-drift,
-        .sky-breath,
-        .cloud-veil,
-        .ascent-column {
-          position: absolute;
-          inset: -8%;
           pointer-events: none;
-          will-change: transform, opacity;
+        }
+
+        .sky-base {
+          z-index: 0;
+          background: radial-gradient(circle at 50% 20%, #283777, #080b18 54%, #000 100%);
         }
 
         .emotional-wash {
-          z-index: 7;
+          z-index: 3;
           background:
             radial-gradient(circle at 28% 22%, var(--tone-a), transparent 24%),
             radial-gradient(circle at 74% 36%, var(--tone-b), transparent 26%),
             linear-gradient(180deg, transparent 20%, var(--tone-c) 100%);
           mix-blend-mode: screen;
-          opacity: 0.78;
-          transition:
-            opacity 900ms ease,
-            transform 1200ms ease;
-        }
-
-        .ambient-drift {
-          z-index: 4;
-          background:
-            radial-gradient(circle at 18% 22%, var(--tone-a), transparent 18%),
-            radial-gradient(circle at 78% 30%, var(--tone-b), transparent 22%),
-            radial-gradient(circle at 50% 70%, var(--tone-c), transparent 26%);
-          mix-blend-mode: screen;
-          opacity: 0.75;
-          animation: ambientDrift calc(18s * var(--tone-speed)) ease-in-out infinite alternate;
-        }
-
-        .sky-breath {
-          z-index: 5;
-          background: radial-gradient(
-            circle at 50% 35%,
-            rgba(255, 255, 255, 0.13),
-            transparent 18%
-          );
-          mix-blend-mode: screen;
-          opacity: 0.32;
-          animation: skyBreath calc(6.5s * var(--tone-speed)) ease-in-out infinite;
+          opacity: .82;
+          transition: opacity 900ms ease, transform 1200ms ease;
         }
 
         .cloud-veil {
-          z-index: 6;
-          opacity: 0.32;
+          z-index: 5;
+          inset: -8%;
+          opacity: .3;
           filter: blur(18px);
           mix-blend-mode: screen;
           background:
             radial-gradient(ellipse at 20% 64%, rgba(255,255,255,.12), transparent 22%),
             radial-gradient(ellipse at 58% 58%, rgba(125,211,252,.12), transparent 26%),
             radial-gradient(ellipse at 84% 70%, rgba(196,181,253,.1), transparent 22%);
-          transition:
-            opacity 1100ms ease,
-            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1);
+          transition: opacity 1100ms ease, transform 1450ms cubic-bezier(.16,1,.3,1);
         }
 
-        .cloud-high {
-          opacity: 0.18;
-          transform: translateY(-16%) scale(1.1);
-        }
+        .cloud-high { opacity: .18; transform: translateY(-16%) scale(1.1); }
 
-        .parallax-field {
+        .sky-trigger {
           position: absolute;
           inset: 0;
-          z-index: 6;
-          pointer-events: none;
-          opacity: 0.65;
-          overflow: hidden;
+          z-index: 10;
+          border: 0;
+          background: transparent;
+          cursor: zoom-in;
         }
 
-        .parallax-field span {
-          position: absolute;
-          border-radius: 999px;
-          background: rgba(255, 255, 255, 0.9);
-          box-shadow:
-            0 0 16px rgba(255, 255, 255, 0.7),
-            0 0 32px var(--tone-a);
-        }
-
-        .parallax-near span:nth-child(1) {
-          left: 18%;
-          top: 26%;
-          width: 0.22rem;
-          height: 0.22rem;
-          animation: nearDrift calc(11s * var(--tone-speed)) ease-in-out infinite alternate;
-        }
-
-        .parallax-near span:nth-child(2) {
-          left: 72%;
-          top: 38%;
-          width: 0.18rem;
-          height: 0.18rem;
-          animation: nearDrift calc(13s * var(--tone-speed)) ease-in-out infinite alternate-reverse;
-        }
-
-        .parallax-near span:nth-child(3) {
-          left: 52%;
-          top: 16%;
-          width: 0.16rem;
-          height: 0.16rem;
-          animation: nearDrift calc(10s * var(--tone-speed)) ease-in-out infinite alternate;
-        }
-
-        .parallax-far span:nth-child(1) {
-          left: 28%;
-          top: 14%;
-          width: 0.12rem;
-          height: 0.12rem;
-          animation: farDrift calc(18s * var(--tone-speed)) ease-in-out infinite alternate;
-        }
-
-        .parallax-far span:nth-child(2) {
-          left: 80%;
-          top: 22%;
-          width: 0.1rem;
-          height: 0.1rem;
-          animation: farDrift calc(20s * var(--tone-speed)) ease-in-out infinite alternate-reverse;
-        }
-
-        .parallax-far span:nth-child(3) {
-          left: 64%;
-          top: 62%;
-          width: 0.11rem;
-          height: 0.11rem;
-          animation: farDrift calc(17s * var(--tone-speed)) ease-in-out infinite alternate;
-        }
-
-        .parallax-far span:nth-child(4) {
-          left: 12%;
-          top: 58%;
-          width: 0.09rem;
-          height: 0.09rem;
-          animation: farDrift calc(21s * var(--tone-speed)) ease-in-out infinite alternate-reverse;
-        }
+        .home-ground { z-index: 8; }
 
         .soul-anchor {
           position: absolute;
@@ -447,22 +286,17 @@ export default function HomeScene() {
           height: min(42vh, 440px);
           transform: translateX(-50%);
           pointer-events: none;
-          opacity: 0.78;
-          transition:
-            opacity 900ms ease,
-            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1),
-            filter 900ms ease;
+          opacity: .78;
+          transition: opacity 900ms ease, transform 1450ms cubic-bezier(.16,1,.3,1), filter 900ms ease;
         }
 
         .avatar-halo {
           position: absolute;
           inset: 6% 12% 2%;
           border-radius: 999px 999px 48% 48%;
-          background:
-            radial-gradient(ellipse at 50% 28%, rgba(255,255,255,.16), transparent 22%),
-            radial-gradient(ellipse at 50% 58%, var(--tone-a), transparent 48%);
+          background: radial-gradient(ellipse at 50% 28%, rgba(255,255,255,.16), transparent 22%), radial-gradient(ellipse at 50% 58%, var(--tone-a), transparent 48%);
           filter: blur(18px);
-          opacity: 0.62;
+          opacity: .62;
         }
 
         .avatar-silhouette {
@@ -472,51 +306,43 @@ export default function HomeScene() {
           width: 42%;
           height: 80%;
           transform: translateX(-50%);
-          opacity: 0.74;
+          opacity: .74;
           filter: drop-shadow(0 0 22px rgba(125,211,252,.22));
         }
 
-        .avatar-head {
+        .avatar-head,
+        .avatar-body,
+        .avatar-heart {
           position: absolute;
           left: 50%;
+          transform: translateX(-50%);
+        }
+
+        .avatar-head {
           top: 3%;
           width: 42%;
           aspect-ratio: 1;
-          transform: translateX(-50%);
           border-radius: 999px;
-          background:
-            radial-gradient(circle at 45% 35%, rgba(255,255,255,.42), rgba(255,255,255,.12) 42%, rgba(255,255,255,.03) 72%, transparent 100%);
+          background: radial-gradient(circle at 45% 35%, rgba(255,255,255,.42), rgba(255,255,255,.12) 42%, transparent 100%);
           border: 1px solid rgba(255,255,255,.12);
         }
 
         .avatar-body {
-          position: absolute;
-          left: 50%;
           top: 27%;
           width: 62%;
           height: 65%;
-          transform: translateX(-50%);
           border-radius: 52% 52% 40% 40%;
-          background:
-            linear-gradient(180deg, rgba(255,255,255,.13), rgba(125,211,252,.07) 48%, rgba(0,0,0,.02)),
-            radial-gradient(ellipse at 50% 28%, rgba(255,255,255,.2), transparent 42%);
+          background: linear-gradient(180deg, rgba(255,255,255,.13), rgba(125,211,252,.07) 48%, rgba(0,0,0,.02));
           border: 1px solid rgba(255,255,255,.1);
         }
 
         .avatar-heart {
-          position: absolute;
-          left: 50%;
           top: 43%;
-          width: 0.9rem;
-          height: 0.9rem;
-          transform: translateX(-50%);
+          width: .9rem;
+          height: .9rem;
           border-radius: 999px;
           background: rgba(255,255,255,.92);
-          box-shadow:
-            0 0 18px rgba(255,255,255,.9),
-            0 0 44px var(--tone-a),
-            0 0 80px var(--tone-b);
-          animation: orbPulse calc(4.8s * var(--tone-speed)) ease-in-out infinite;
+          box-shadow: 0 0 18px rgba(255,255,255,.9), 0 0 44px var(--tone-a), 0 0 80px var(--tone-b);
         }
 
         .companion-orb {
@@ -531,14 +357,7 @@ export default function HomeScene() {
           border-radius: 999px;
           background: transparent;
           cursor: zoom-in;
-          transition:
-            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1),
-            opacity 800ms ease,
-            filter 800ms ease;
-        }
-
-        .companion-orb:disabled {
-          cursor: progress;
+          transition: transform 1450ms cubic-bezier(.16,1,.3,1), opacity 800ms ease, filter 800ms ease;
         }
 
         .orb-core,
@@ -550,38 +369,20 @@ export default function HomeScene() {
 
         .orb-core {
           inset: 22%;
-          background:
-            radial-gradient(circle at 40% 35%, #fff, rgba(255,255,255,.82) 22%, rgba(125,211,252,.45) 50%, rgba(196,181,253,.08) 76%, transparent 100%);
-          box-shadow:
-            0 0 18px rgba(255,255,255,.9),
-            0 0 58px var(--tone-a),
-            0 0 112px var(--tone-b);
-          animation: orbPulse calc(5.5s * var(--tone-speed)) ease-in-out infinite;
+          background: radial-gradient(circle at 40% 35%, #fff, rgba(255,255,255,.82) 22%, rgba(125,211,252,.45) 50%, rgba(196,181,253,.08) 76%, transparent 100%);
+          box-shadow: 0 0 18px rgba(255,255,255,.9), 0 0 58px var(--tone-a), 0 0 112px var(--tone-b);
         }
 
-        .orb-ring-one {
-          border: 1px solid rgba(255,255,255,.2);
-          box-shadow: 0 0 38px rgba(125,211,252,.18) inset;
-          animation: orbOrbit calc(13s * var(--tone-speed)) linear infinite;
-        }
-
-        .orb-ring-two {
-          inset: 10%;
-          border: 1px solid rgba(196,181,253,.18);
-          transform: rotate(32deg) scaleX(.72);
-          animation: orbOrbit calc(16s * var(--tone-speed)) linear infinite reverse;
-        }
+        .orb-ring-one { border: 1px solid rgba(255,255,255,.2); animation: orbOrbit calc(13s * var(--tone-speed)) linear infinite; }
+        .orb-ring-two { inset: 10%; border: 1px solid rgba(196,181,253,.18); transform: rotate(32deg) scaleX(.72); animation: orbOrbit calc(16s * var(--tone-speed)) linear infinite reverse; }
 
         .ascent-column {
           z-index: 12;
-          background:
-            radial-gradient(ellipse at 50% 58%, rgba(255,255,255,.13), transparent 16%),
-            linear-gradient(180deg, transparent 0%, rgba(125,211,252,.08) 42%, rgba(196,181,253,.07) 70%, transparent 100%);
-          opacity: 0.16;
+          inset: -8%;
+          background: radial-gradient(ellipse at 50% 58%, rgba(255,255,255,.13), transparent 16%), linear-gradient(180deg, transparent 0%, rgba(125,211,252,.08) 42%, rgba(196,181,253,.07) 70%, transparent 100%);
+          opacity: .16;
           filter: blur(4px);
-          transition:
-            opacity 1000ms ease,
-            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1);
+          transition: opacity 1000ms ease, transform 1450ms cubic-bezier(.16,1,.3,1);
         }
 
         .star-tunnel {
@@ -589,291 +390,87 @@ export default function HomeScene() {
           inset: 0;
           z-index: 18;
           opacity: 0;
-          transform: scale(0.85);
+          transform: scale(.85);
           pointer-events: none;
-          background:
-            radial-gradient(circle at 50% 32%, rgba(205, 225, 255, 0.45), transparent 6%),
-            radial-gradient(circle at 42% 44%, var(--tone-b), transparent 12%),
-            radial-gradient(circle at 58% 48%, var(--tone-a), transparent 14%);
-          transition:
-            opacity 800ms ease,
-            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1);
+          background: radial-gradient(circle at 50% 32%, rgba(205,225,255,.45), transparent 6%), radial-gradient(circle at 42% 44%, var(--tone-b), transparent 12%), radial-gradient(circle at 58% 48%, var(--tone-a), transparent 14%);
+          transition: opacity 800ms ease, transform 1450ms cubic-bezier(.16,1,.3,1);
         }
 
-        .star {
-          position: absolute;
-          width: 0.42rem;
-          height: 0.42rem;
-          border-radius: 999px;
-          background: white;
-          box-shadow:
-            0 0 18px rgba(255, 255, 255, 0.95),
-            0 0 42px var(--tone-a);
-          opacity: 0.85;
-        }
-
-        .star-one {
-          left: 30%;
-          top: 24%;
-        }
-
-        .star-two {
-          left: 45%;
-          top: 18%;
-          width: 0.32rem;
-          height: 0.32rem;
-        }
-
-        .star-three {
-          left: 58%;
-          top: 31%;
-          width: 0.5rem;
-          height: 0.5rem;
-        }
-
-        .star-four {
-          left: 66%;
-          top: 43%;
-          width: 0.28rem;
-          height: 0.28rem;
-        }
-
-        .star-five {
-          left: 38%;
-          top: 52%;
-          width: 0.24rem;
-          height: 0.24rem;
-        }
+        .star { position: absolute; width: .42rem; height: .42rem; border-radius: 999px; background: white; box-shadow: 0 0 18px rgba(255,255,255,.95), 0 0 42px var(--tone-a); opacity: .85; }
+        .star-one { left: 30%; top: 24%; }
+        .star-two { left: 45%; top: 18%; width: .32rem; height: .32rem; }
+        .star-three { left: 58%; top: 31%; width: .5rem; height: .5rem; }
+        .star-four { left: 66%; top: 43%; width: .28rem; height: .28rem; }
+        .star-five { left: 38%; top: 52%; width: .24rem; height: .24rem; }
 
         .transition-vignette {
-          position: absolute;
-          inset: 0;
           z-index: 19;
           opacity: 0;
-          pointer-events: none;
-          background: radial-gradient(
-            circle at 50% 35%,
-            transparent 0%,
-            rgba(5, 8, 22, 0.25) 35%,
-            rgba(0, 0, 0, 0.92) 100%
-          );
+          background: radial-gradient(circle at 50% 35%, transparent 0%, rgba(5,8,22,.25) 35%, rgba(0,0,0,.92) 100%);
           transition: opacity 1200ms ease;
         }
+
+        .content-stage {
+          position: relative;
+          z-index: 20;
+          min-height: 100dvh;
+          width: 100%;
+          max-width: 72rem;
+          margin: 0 auto;
+          padding: 2rem 1.25rem;
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          transition: opacity 900ms ease, transform 1450ms cubic-bezier(.16,1,.3,1), filter 900ms ease;
+        }
+
+        .hero-copy { max-width: 48rem; padding-top: 2.5rem; }
+        .demo-card-grid { transition: opacity 900ms ease, transform 1450ms cubic-bezier(.16,1,.3,1); }
 
         .tone-chip,
         .tap-hint {
           position: absolute;
           z-index: 30;
-          border: 1px solid rgba(255, 255, 255, 0.2);
-          background: rgba(0, 0, 0, 0.4);
-          color: rgba(255, 255, 255, 0.85);
+          border: 1px solid rgba(255,255,255,.2);
+          background: rgba(0,0,0,.4);
+          color: rgba(255,255,255,.85);
           backdrop-filter: blur(8px);
           pointer-events: none;
         }
 
-        .tone-chip {
-          top: 1rem;
-          right: 1rem;
-          border-radius: 999px;
-          padding: 0.35rem 0.75rem;
-          font-size: 0.7rem;
-          letter-spacing: 0.18em;
-          text-transform: uppercase;
-          opacity: 0.62;
-        }
+        .tone-chip { top: 1rem; right: 1rem; border-radius: 999px; padding: .35rem .75rem; font-size: .7rem; letter-spacing: .18em; text-transform: uppercase; opacity: .62; }
+        .tap-hint { bottom: 1.5rem; left: 50%; transform: translateX(-50%); border-radius: 999px; padding: .5rem 1rem; font-size: .875rem; transition: opacity 500ms ease, transform 500ms ease; }
 
-        .tap-hint {
-          bottom: 1.5rem;
-          left: 50%;
-          transform: translateX(-50%);
-          border-radius: 999px;
-          padding: 0.5rem 1rem;
-          font-size: 0.875rem;
-          transition:
-            opacity 500ms ease,
-            transform 500ms ease;
-        }
+        .home-scene.is-transitioning .content-stage { opacity: .42; transform: translateY(2.5rem) scale(.985); filter: blur(1.5px); }
+        .home-scene.is-transitioning .demo-card-grid { opacity: .18; transform: translateY(4rem) scale(.96); }
+        .home-scene.is-transitioning .soul-anchor { opacity: .96; transform: translateX(-50%) translateY(-9vh) scale(1.08); filter: drop-shadow(0 0 42px var(--tone-a)); }
+        .home-scene.is-transitioning .companion-orb { transform: translate(-50%, -74%) scale(1.72); opacity: 1; filter: drop-shadow(0 0 54px rgba(255,255,255,.5)); }
+        .home-scene.is-transitioning .ascent-column { opacity: .72; transform: translateY(-12%) scaleY(1.2); }
+        .home-scene.is-transitioning .cloud-low { opacity: .52; transform: translateY(-8%) scale(1.18); }
+        .home-scene.is-transitioning .cloud-high { opacity: .44; transform: translateY(-30%) scale(1.32); }
+        .home-scene.is-transitioning .emotional-wash { opacity: 1; transform: scale(1.18); }
+        .home-scene.is-transitioning .star-tunnel { opacity: 1; transform: scale(1.9) translateY(-5%); }
+        .home-scene.is-transitioning .transition-vignette { opacity: 1; }
+        .home-scene.is-transitioning .tap-hint { transform: translateX(-50%) translateY(-.35rem); opacity: .92; }
 
-        .content-stage,
-        .demo-card-grid {
-          transition:
-            opacity 900ms ease,
-            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1),
-            filter 900ms ease;
-        }
-
-        .home-scene.is-transitioning .content-stage {
-          opacity: 0.42;
-          transform: translateY(2.5rem) scale(0.985);
-          filter: blur(1.5px);
-        }
-
-        .home-scene.is-transitioning .demo-card-grid {
-          opacity: 0.18;
-          transform: translateY(4rem) scale(0.96);
-        }
-
-        .home-scene.is-transitioning .soul-anchor {
-          opacity: 0.96;
-          transform: translateX(-50%) translateY(-9vh) scale(1.08);
-          filter: drop-shadow(0 0 42px var(--tone-a));
-        }
-
-        .home-scene.is-transitioning .companion-orb {
-          transform: translate(-50%, -74%) scale(1.72);
-          opacity: 1;
-          filter: drop-shadow(0 0 54px rgba(255,255,255,.5));
-        }
-
-        .home-scene.is-transitioning .ascent-column {
-          opacity: 0.72;
-          transform: translateY(-12%) scaleY(1.2);
-        }
-
-        .home-scene.is-transitioning .cloud-low {
-          opacity: 0.52;
-          transform: translateY(-8%) scale(1.18);
-        }
-
-        .home-scene.is-transitioning .cloud-high {
-          opacity: 0.44;
-          transform: translateY(-30%) scale(1.32);
-        }
-
-        .home-scene.is-transitioning .emotional-wash,
-        .home-scene.is-transitioning .ambient-drift,
-        .home-scene.is-transitioning .sky-breath {
-          opacity: 1;
-          transform: scale(1.18);
-        }
-
-        .home-scene.is-transitioning .parallax-near {
-          opacity: 1;
-          transform: scale(1.5) translateY(-5%);
-          transition:
-            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1),
-            opacity 800ms ease;
-        }
-
-        .home-scene.is-transitioning .parallax-far {
-          opacity: 1;
-          transform: scale(1.25) translateY(-2%);
-          transition:
-            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1),
-            opacity 800ms ease;
-        }
-
-        .home-scene.is-transitioning .star-tunnel {
-          opacity: 1;
-          transform: scale(1.9) translateY(-5%);
-        }
-
-        .home-scene.is-transitioning .transition-vignette {
-          opacity: 1;
-        }
-
-        .home-scene.is-transitioning .tap-hint {
-          transform: translateX(-50%) translateY(-0.35rem);
-          opacity: 0.92;
-        }
-
-        @keyframes ambientDrift {
-          from {
-            transform: translate3d(-1.5%, -0.8%, 0) scale(1);
-            opacity: 0.52;
-          }
-
-          to {
-            transform: translate3d(1.2%, 0.9%, 0) scale(1.08);
-            opacity: 0.78;
-          }
-        }
-
-        @keyframes skyBreath {
-          0%,
-          100% {
-            transform: scale(0.92);
-            opacity: 0.22;
-          }
-
-          50% {
-            transform: scale(1.08);
-            opacity: 0.38;
-          }
-        }
-
-        @keyframes nearDrift {
-          from {
-            transform: translate3d(-0.35rem, -0.25rem, 0);
-            opacity: 0.55;
-          }
-
-          to {
-            transform: translate3d(0.45rem, 0.3rem, 0);
-            opacity: 0.95;
-          }
-        }
-
-        @keyframes farDrift {
-          from {
-            transform: translate3d(0.2rem, -0.18rem, 0);
-            opacity: 0.35;
-          }
-
-          to {
-            transform: translate3d(-0.18rem, 0.22rem, 0);
-            opacity: 0.7;
-          }
-        }
-
-        @keyframes orbPulse {
-          0%,
-          100% {
-            transform: translateX(-50%) scale(0.96);
-            opacity: 0.78;
-          }
-
-          50% {
-            transform: translateX(-50%) scale(1.08);
-            opacity: 1;
-          }
-        }
-
-        @keyframes orbOrbit {
-          to {
-            transform: rotate(360deg) scaleX(.82);
-          }
-        }
+        @keyframes orbOrbit { to { transform: rotate(360deg) scaleX(.82); } }
 
         @media (max-width: 900px) {
-          .soul-anchor {
-            width: min(52vw, 280px);
-            height: min(36vh, 360px);
-            bottom: 22%;
-            opacity: 0.5;
-          }
-
-          .companion-orb {
-            top: 44%;
-          }
+          .soul-anchor { width: min(52vw, 280px); height: min(36vh, 360px); bottom: 22%; opacity: .5; }
+          .companion-orb { top: 44%; }
         }
 
         @media (prefers-reduced-motion: reduce) {
           .emotional-wash,
-          .ambient-drift,
-          .sky-breath,
           .cloud-veil,
-          .parallax-field,
           .star-tunnel,
           .transition-vignette,
           .tap-hint,
           .soul-anchor,
           .companion-orb,
           .ascent-column,
-          .avatar-heart,
-          .orb-core,
           .orb-ring {
-            transition-duration: 0.01ms !important;
+            transition-duration: .01ms !important;
             animation: none !important;
           }
         }

--- a/src/components/HomeScene.tsx
+++ b/src/components/HomeScene.tsx
@@ -17,20 +17,20 @@ type HomeMode = "home" | "transitioning" | "lifemap";
 
 const TONE_COPY = {
   calm: {
-    idle: "Tap the sky to open the demo Life Map",
-    opening: "Softening into the Life Map...",
+    idle: "Tap the orb or sky to open the demo Life Map",
+    opening: "The orb is lifting you into the Life Map...",
   },
   focused: {
-    idle: "Tap the sky to trace the demo pattern",
-    opening: "Focusing the constellation...",
+    idle: "Tap the orb to trace the demo pattern",
+    opening: "The constellation is focusing around you...",
   },
   charged: {
-    idle: "Tap the sky to see what is lighting up",
-    opening: "Opening the active pattern...",
+    idle: "Tap the orb to see what is lighting up",
+    opening: "The active pattern is opening...",
   },
   restorative: {
-    idle: "Tap the sky to enter quiet memory space",
-    opening: "Entering gently...",
+    idle: "Tap the orb to enter quiet memory space",
+    opening: "Entering gently through the sky...",
   },
 };
 
@@ -56,10 +56,10 @@ export default function HomeScene() {
 
   const transitionDuration = useMemo(() => {
     if (reduceMotion) return 0;
-    if (emotionalTone === "restorative") return 1700;
-    if (emotionalTone === "charged") return 1150;
-    if (emotionalTone === "focused") return 1325;
-    return 1450;
+    if (emotionalTone === "restorative") return 1850;
+    if (emotionalTone === "charged") return 1280;
+    if (emotionalTone === "focused") return 1450;
+    return 1580;
   }, [emotionalTone, reduceMotion]);
 
   useEffect(() => {
@@ -122,6 +122,7 @@ export default function HomeScene() {
       <AncientSignalAmbientLayer result={ancientResult} source={source} loading={loading} />
 
       <GroundLayer
+        className="home-ground"
         state={{
           moodScore: ancientResult.auraAtmosphere.warmth,
           rhythmState:
@@ -140,6 +141,8 @@ export default function HomeScene() {
       <div className="emotional-wash" aria-hidden />
       <div className="ambient-drift" aria-hidden />
       <div className="sky-breath" aria-hidden />
+      <div className="cloud-veil cloud-low" aria-hidden />
+      <div className="cloud-veil cloud-high" aria-hidden />
 
       <div className="parallax-field parallax-near" aria-hidden>
         <span />
@@ -154,6 +157,29 @@ export default function HomeScene() {
         <span />
       </div>
 
+      <div className="soul-anchor" aria-hidden>
+        <div className="avatar-halo" />
+        <div className="avatar-silhouette">
+          <span className="avatar-head" />
+          <span className="avatar-body" />
+          <span className="avatar-heart" />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="companion-orb"
+        onClick={openLifeMap}
+        disabled={isTransitioning}
+        aria-label="Open Life Map through the companion orb"
+      >
+        <span className="orb-core" />
+        <span className="orb-ring orb-ring-one" />
+        <span className="orb-ring orb-ring-two" />
+      </button>
+
+      <div className="ascent-column" aria-hidden />
+
       <div className="star-tunnel" aria-hidden>
         <span className="star star-one" />
         <span className="star star-two" />
@@ -164,7 +190,7 @@ export default function HomeScene() {
 
       <div className="transition-vignette" aria-hidden />
 
-      <section className="relative z-20 mx-auto flex min-h-dvh w-full max-w-6xl flex-col justify-between px-5 py-8">
+      <section className="content-stage relative z-20 mx-auto flex min-h-dvh w-full max-w-6xl flex-col justify-between px-5 py-8">
         <div className="max-w-3xl pt-10">
           <div className="flex flex-wrap items-center gap-3">
             <p className="text-xs uppercase tracking-[0.45em] text-white/50">
@@ -208,7 +234,7 @@ export default function HomeScene() {
           </div>
         </div>
 
-        <div className="grid gap-4 pb-4 md:grid-cols-2 lg:grid-cols-4">
+        <div className="demo-card-grid grid gap-4 pb-4 md:grid-cols-2 lg:grid-cols-4">
           <ForecastCard forecast={profile.moodForecast} />
           <WeeklyReflectionCard reflection={profile.weeklyReflection} />
           <CompanionChat />
@@ -274,7 +300,9 @@ export default function HomeScene() {
 
         .emotional-wash,
         .ambient-drift,
-        .sky-breath {
+        .sky-breath,
+        .cloud-veil,
+        .ascent-column {
           position: absolute;
           inset: -8%;
           pointer-events: none;
@@ -315,6 +343,25 @@ export default function HomeScene() {
           mix-blend-mode: screen;
           opacity: 0.32;
           animation: skyBreath calc(6.5s * var(--tone-speed)) ease-in-out infinite;
+        }
+
+        .cloud-veil {
+          z-index: 6;
+          opacity: 0.32;
+          filter: blur(18px);
+          mix-blend-mode: screen;
+          background:
+            radial-gradient(ellipse at 20% 64%, rgba(255,255,255,.12), transparent 22%),
+            radial-gradient(ellipse at 58% 58%, rgba(125,211,252,.12), transparent 26%),
+            radial-gradient(ellipse at 84% 70%, rgba(196,181,253,.1), transparent 22%);
+          transition:
+            opacity 1100ms ease,
+            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1);
+        }
+
+        .cloud-high {
+          opacity: 0.18;
+          transform: translateY(-16%) scale(1.1);
         }
 
         .parallax-field {
@@ -391,10 +438,156 @@ export default function HomeScene() {
           animation: farDrift calc(21s * var(--tone-speed)) ease-in-out infinite alternate-reverse;
         }
 
+        .soul-anchor {
+          position: absolute;
+          left: 50%;
+          bottom: 18%;
+          z-index: 11;
+          width: min(32vw, 340px);
+          height: min(42vh, 440px);
+          transform: translateX(-50%);
+          pointer-events: none;
+          opacity: 0.78;
+          transition:
+            opacity 900ms ease,
+            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1),
+            filter 900ms ease;
+        }
+
+        .avatar-halo {
+          position: absolute;
+          inset: 6% 12% 2%;
+          border-radius: 999px 999px 48% 48%;
+          background:
+            radial-gradient(ellipse at 50% 28%, rgba(255,255,255,.16), transparent 22%),
+            radial-gradient(ellipse at 50% 58%, var(--tone-a), transparent 48%);
+          filter: blur(18px);
+          opacity: 0.62;
+        }
+
+        .avatar-silhouette {
+          position: absolute;
+          left: 50%;
+          bottom: 4%;
+          width: 42%;
+          height: 80%;
+          transform: translateX(-50%);
+          opacity: 0.74;
+          filter: drop-shadow(0 0 22px rgba(125,211,252,.22));
+        }
+
+        .avatar-head {
+          position: absolute;
+          left: 50%;
+          top: 3%;
+          width: 42%;
+          aspect-ratio: 1;
+          transform: translateX(-50%);
+          border-radius: 999px;
+          background:
+            radial-gradient(circle at 45% 35%, rgba(255,255,255,.42), rgba(255,255,255,.12) 42%, rgba(255,255,255,.03) 72%, transparent 100%);
+          border: 1px solid rgba(255,255,255,.12);
+        }
+
+        .avatar-body {
+          position: absolute;
+          left: 50%;
+          top: 27%;
+          width: 62%;
+          height: 65%;
+          transform: translateX(-50%);
+          border-radius: 52% 52% 40% 40%;
+          background:
+            linear-gradient(180deg, rgba(255,255,255,.13), rgba(125,211,252,.07) 48%, rgba(0,0,0,.02)),
+            radial-gradient(ellipse at 50% 28%, rgba(255,255,255,.2), transparent 42%);
+          border: 1px solid rgba(255,255,255,.1);
+        }
+
+        .avatar-heart {
+          position: absolute;
+          left: 50%;
+          top: 43%;
+          width: 0.9rem;
+          height: 0.9rem;
+          transform: translateX(-50%);
+          border-radius: 999px;
+          background: rgba(255,255,255,.92);
+          box-shadow:
+            0 0 18px rgba(255,255,255,.9),
+            0 0 44px var(--tone-a),
+            0 0 80px var(--tone-b);
+          animation: orbPulse calc(4.8s * var(--tone-speed)) ease-in-out infinite;
+        }
+
+        .companion-orb {
+          position: absolute;
+          left: 50%;
+          top: 48%;
+          z-index: 23;
+          width: clamp(72px, 11vw, 132px);
+          height: clamp(72px, 11vw, 132px);
+          transform: translate(-50%, -50%);
+          border: 0;
+          border-radius: 999px;
+          background: transparent;
+          cursor: zoom-in;
+          transition:
+            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1),
+            opacity 800ms ease,
+            filter 800ms ease;
+        }
+
+        .companion-orb:disabled {
+          cursor: progress;
+        }
+
+        .orb-core,
+        .orb-ring {
+          position: absolute;
+          inset: 0;
+          border-radius: 999px;
+        }
+
+        .orb-core {
+          inset: 22%;
+          background:
+            radial-gradient(circle at 40% 35%, #fff, rgba(255,255,255,.82) 22%, rgba(125,211,252,.45) 50%, rgba(196,181,253,.08) 76%, transparent 100%);
+          box-shadow:
+            0 0 18px rgba(255,255,255,.9),
+            0 0 58px var(--tone-a),
+            0 0 112px var(--tone-b);
+          animation: orbPulse calc(5.5s * var(--tone-speed)) ease-in-out infinite;
+        }
+
+        .orb-ring-one {
+          border: 1px solid rgba(255,255,255,.2);
+          box-shadow: 0 0 38px rgba(125,211,252,.18) inset;
+          animation: orbOrbit calc(13s * var(--tone-speed)) linear infinite;
+        }
+
+        .orb-ring-two {
+          inset: 10%;
+          border: 1px solid rgba(196,181,253,.18);
+          transform: rotate(32deg) scaleX(.72);
+          animation: orbOrbit calc(16s * var(--tone-speed)) linear infinite reverse;
+        }
+
+        .ascent-column {
+          z-index: 12;
+          background:
+            radial-gradient(ellipse at 50% 58%, rgba(255,255,255,.13), transparent 16%),
+            linear-gradient(180deg, transparent 0%, rgba(125,211,252,.08) 42%, rgba(196,181,253,.07) 70%, transparent 100%);
+          opacity: 0.16;
+          filter: blur(4px);
+          transition:
+            opacity 1000ms ease,
+            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1);
+        }
+
         .star-tunnel {
           position: absolute;
           inset: 0;
-          z-index: 8;
+          z-index: 18;
           opacity: 0;
           transform: scale(0.85);
           pointer-events: none;
@@ -455,7 +648,7 @@ export default function HomeScene() {
         .transition-vignette {
           position: absolute;
           inset: 0;
-          z-index: 9;
+          z-index: 19;
           opacity: 0;
           pointer-events: none;
           background: radial-gradient(
@@ -501,6 +694,52 @@ export default function HomeScene() {
             transform 500ms ease;
         }
 
+        .content-stage,
+        .demo-card-grid {
+          transition:
+            opacity 900ms ease,
+            transform 1450ms cubic-bezier(0.16, 1, 0.3, 1),
+            filter 900ms ease;
+        }
+
+        .home-scene.is-transitioning .content-stage {
+          opacity: 0.42;
+          transform: translateY(2.5rem) scale(0.985);
+          filter: blur(1.5px);
+        }
+
+        .home-scene.is-transitioning .demo-card-grid {
+          opacity: 0.18;
+          transform: translateY(4rem) scale(0.96);
+        }
+
+        .home-scene.is-transitioning .soul-anchor {
+          opacity: 0.96;
+          transform: translateX(-50%) translateY(-9vh) scale(1.08);
+          filter: drop-shadow(0 0 42px var(--tone-a));
+        }
+
+        .home-scene.is-transitioning .companion-orb {
+          transform: translate(-50%, -74%) scale(1.72);
+          opacity: 1;
+          filter: drop-shadow(0 0 54px rgba(255,255,255,.5));
+        }
+
+        .home-scene.is-transitioning .ascent-column {
+          opacity: 0.72;
+          transform: translateY(-12%) scaleY(1.2);
+        }
+
+        .home-scene.is-transitioning .cloud-low {
+          opacity: 0.52;
+          transform: translateY(-8%) scale(1.18);
+        }
+
+        .home-scene.is-transitioning .cloud-high {
+          opacity: 0.44;
+          transform: translateY(-30%) scale(1.32);
+        }
+
         .home-scene.is-transitioning .emotional-wash,
         .home-scene.is-transitioning .ambient-drift,
         .home-scene.is-transitioning .sky-breath {
@@ -526,7 +765,7 @@ export default function HomeScene() {
 
         .home-scene.is-transitioning .star-tunnel {
           opacity: 1;
-          transform: scale(1.7);
+          transform: scale(1.9) translateY(-5%);
         }
 
         .home-scene.is-transitioning .transition-vignette {
@@ -587,14 +826,53 @@ export default function HomeScene() {
           }
         }
 
+        @keyframes orbPulse {
+          0%,
+          100% {
+            transform: translateX(-50%) scale(0.96);
+            opacity: 0.78;
+          }
+
+          50% {
+            transform: translateX(-50%) scale(1.08);
+            opacity: 1;
+          }
+        }
+
+        @keyframes orbOrbit {
+          to {
+            transform: rotate(360deg) scaleX(.82);
+          }
+        }
+
+        @media (max-width: 900px) {
+          .soul-anchor {
+            width: min(52vw, 280px);
+            height: min(36vh, 360px);
+            bottom: 22%;
+            opacity: 0.5;
+          }
+
+          .companion-orb {
+            top: 44%;
+          }
+        }
+
         @media (prefers-reduced-motion: reduce) {
           .emotional-wash,
           .ambient-drift,
           .sky-breath,
+          .cloud-veil,
           .parallax-field,
           .star-tunnel,
           .transition-vignette,
-          .tap-hint {
+          .tap-hint,
+          .soul-anchor,
+          .companion-orb,
+          .ascent-column,
+          .avatar-heart,
+          .orb-core,
+          .orb-ring {
             transition-duration: 0.01ms !important;
             animation: none !important;
           }

--- a/src/components/HomeWebGLSky.tsx
+++ b/src/components/HomeWebGLSky.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+const PARTICLE_COUNT = 520;
+const FLOATS_PER_PARTICLE = 7;
+
+const VERTEX_SHADER = `
+attribute vec3 a_position;
+attribute float a_size;
+attribute vec3 a_color;
+uniform float u_time;
+uniform vec2 u_resolution;
+varying vec3 v_color;
+varying float v_alpha;
+
+void main() {
+  float lift = mod(a_position.y + u_time * 0.000035, 2.4) - 1.2;
+  float sway = sin(u_time * 0.00016 + a_position.z * 8.0 + a_position.x * 2.0) * 0.055;
+  vec3 position = vec3(a_position.x + sway, lift, a_position.z);
+  float depth = 1.0 / (1.58 - position.z);
+  vec2 projected = position.xy * depth;
+  gl_Position = vec4(projected, position.z * 0.32, 1.0);
+  gl_PointSize = a_size * depth * min(u_resolution.x, u_resolution.y) * 0.021;
+  v_color = a_color;
+  v_alpha = clamp(depth * 0.55, 0.08, 0.78);
+}
+`;
+
+const FRAGMENT_SHADER = `
+precision mediump float;
+varying vec3 v_color;
+varying float v_alpha;
+
+void main() {
+  vec2 uv = gl_PointCoord - vec2(0.5);
+  float d = length(uv);
+  float core = smoothstep(0.18, 0.0, d);
+  float halo = smoothstep(0.5, 0.08, d) * 0.34;
+  float alpha = (core + halo) * v_alpha;
+  if (alpha < 0.015) discard;
+  gl_FragColor = vec4(v_color, alpha);
+}
+`;
+
+function compileShader(gl: WebGLRenderingContext, type: number, source: string) {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function createProgram(gl: WebGLRenderingContext) {
+  const vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+  const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+  if (!vertexShader || !fragmentShader) return null;
+
+  const program = gl.createProgram();
+  if (!program) return null;
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.linkProgram(program);
+
+  gl.deleteShader(vertexShader);
+  gl.deleteShader(fragmentShader);
+
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    gl.deleteProgram(program);
+    return null;
+  }
+
+  return program;
+}
+
+function createParticleData() {
+  const data = new Float32Array(PARTICLE_COUNT * FLOATS_PER_PARTICLE);
+
+  for (let i = 0; i < PARTICLE_COUNT; i += 1) {
+    const offset = i * FLOATS_PER_PARTICLE;
+    const ring = i / PARTICLE_COUNT;
+    const angle = i * 2.399963229728653;
+    const radius = 0.18 + Math.sqrt(ring) * 1.22;
+    const colorShift = Math.random();
+
+    data[offset] = Math.cos(angle) * radius + (Math.random() - 0.5) * 0.22;
+    data[offset + 1] = Math.sin(angle) * radius * 0.82 + (Math.random() - 0.5) * 0.32;
+    data[offset + 2] = -1.0 + Math.random() * 1.82;
+    data[offset + 3] = 2.8 + Math.random() * 5.4;
+    data[offset + 4] = 0.52 + colorShift * 0.38;
+    data[offset + 5] = 0.66 + colorShift * 0.24;
+    data[offset + 6] = 1.0;
+  }
+
+  return data;
+}
+
+export default function HomeWebGLSky() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || typeof window === 'undefined') return undefined;
+
+    const gl = canvas.getContext('webgl', {
+      alpha: true,
+      antialias: true,
+      depth: false,
+      powerPreference: 'high-performance',
+    });
+
+    if (!gl) return undefined;
+
+    const program = createProgram(gl);
+    const buffer = gl.createBuffer();
+    if (!program || !buffer) return undefined;
+
+    const data = createParticleData();
+    const stride = FLOATS_PER_PARTICLE * Float32Array.BYTES_PER_ELEMENT;
+    const positionLocation = gl.getAttribLocation(program, 'a_position');
+    const sizeLocation = gl.getAttribLocation(program, 'a_size');
+    const colorLocation = gl.getAttribLocation(program, 'a_color');
+    const timeLocation = gl.getUniformLocation(program, 'u_time');
+    const resolutionLocation = gl.getUniformLocation(program, 'u_resolution');
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    let animationFrame = 0;
+    let disposed = false;
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+    gl.disable(gl.DEPTH_TEST);
+
+    gl.enableVertexAttribArray(positionLocation);
+    gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, stride, 0);
+
+    gl.enableVertexAttribArray(sizeLocation);
+    gl.vertexAttribPointer(sizeLocation, 1, gl.FLOAT, false, stride, 3 * Float32Array.BYTES_PER_ELEMENT);
+
+    gl.enableVertexAttribArray(colorLocation);
+    gl.vertexAttribPointer(colorLocation, 3, gl.FLOAT, false, stride, 4 * Float32Array.BYTES_PER_ELEMENT);
+
+    const resize = () => {
+      const ratio = Math.min(window.devicePixelRatio || 1, 2);
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = Math.max(1, Math.floor(rect.width * ratio));
+      canvas.height = Math.max(1, Math.floor(rect.height * ratio));
+      gl.viewport(0, 0, canvas.width, canvas.height);
+    };
+
+    const render = (time: number) => {
+      if (disposed) return;
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.useProgram(program);
+      gl.uniform1f(timeLocation, reduceMotion ? 0 : time);
+      gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+      gl.drawArrays(gl.POINTS, 0, PARTICLE_COUNT);
+      animationFrame = window.requestAnimationFrame(render);
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+    animationFrame = window.requestAnimationFrame(render);
+
+    return () => {
+      disposed = true;
+      window.removeEventListener('resize', resize);
+      window.cancelAnimationFrame(animationFrame);
+      gl.deleteBuffer(buffer);
+      gl.deleteProgram(program);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="home-webgl-sky" aria-hidden />;
+}

--- a/src/components/lifemap/LifeMapScene.tsx
+++ b/src/components/lifemap/LifeMapScene.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useReducer, useRef, type CSSProperties } from 'react';
 import NarratorPanel from './NarratorPanel';
+import WebGLLifeMapField from './WebGLLifeMapField';
 import { buildPatternClusters } from './patternClusteringEngine';
 import { useMemoryStars, type MemoryStar } from './useMemoryStars';
 import {
@@ -255,6 +256,7 @@ export default function LifeMapScene() {
 
   return (
     <main className="life-map-shell" aria-label="URAI Spatial Life Map scene">
+      <WebGLLifeMapField />
       <section className={`lifemap-space ${activeStar ? 'is-focused' : ''}`}>
         <div className="starfield" style={starfieldStyle}>
           <svg className="connections" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden>
@@ -320,7 +322,7 @@ export default function LifeMapScene() {
       </nav>
       <style jsx>{`
         .life-map-shell { min-height: 100vh; background: radial-gradient(circle at 50% 28%, #26366d, #0a0f20 58%, #05060f 100%); color: #eef3ff; position: relative; padding: 1rem; overflow: hidden; }
-        .lifemap-space { position: absolute; inset: 0 0 120px; }
+        .lifemap-space { position: absolute; inset: 0 0 120px; z-index: 1; }
         .starfield { position: absolute; inset: 0; transform: translate(calc(50% - var(--camera-x)), calc(50% - var(--camera-y))) scale(var(--camera-zoom)); transition: transform 700ms cubic-bezier(0.22, 1, 0.36, 1); }
         .connections { position: absolute; inset: 0; width: 100%; height: 100%; }
         .connection-line { stroke: rgba(190, 220, 255, 0.22); stroke-width: 0.2; stroke-dasharray: 1 1.8; }
@@ -334,7 +336,7 @@ export default function LifeMapScene() {
         .memory-star.is-dimmed { opacity: .34; }
         .memory-star.is-chapter-focused { box-shadow: 0 0 16px rgba(255,255,255,.9), 0 0 44px rgba(196,181,253,.65); }
         .memory-star.is-pattern-focused { box-shadow: 0 0 18px rgba(255,255,255,.95), 0 0 54px rgba(251,191,36,.55), 0 0 90px rgba(251,191,36,.28); }
-        .panel { position: absolute; background: rgba(7,10,25,.75); border: 1px solid rgba(157,196,255,.32); border-radius: 12px; padding: .8rem; backdrop-filter: blur(6px); }
+        .panel { position: absolute; z-index: 4; background: rgba(7,10,25,.75); border: 1px solid rgba(157,196,255,.32); border-radius: 12px; padding: .8rem; backdrop-filter: blur(6px); }
         .export-panel { left: 1rem; top: 1rem; display: flex; gap: .5rem; }
         .pattern-panel { left: 1rem; top: 74px; width: 320px; border-color: rgba(251,191,36,.42); animation: patternPanelIn 520ms ease both; }
         .pattern-panel h2 { margin: 0 0 .4rem; font-size: .95rem; }
@@ -346,7 +348,7 @@ export default function LifeMapScene() {
         button { font: inherit; }
         .panel button, .chapter-pill { border: 1px solid rgba(157,196,255,.4); background: rgba(13,20,45,.85); color: #edf4ff; }
         .panel button { border-radius: 999px; padding: .45rem .7rem; cursor: pointer; }
-        .chapter-row { position: absolute; left: 1rem; right: 1rem; bottom: 1rem; display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .5rem; }
+        .chapter-row { position: absolute; z-index: 4; left: 1rem; right: 1rem; bottom: 1rem; display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .5rem; }
         .chapter-pill { border-radius: 999px; padding: .5rem .7rem; text-align: left; cursor: pointer; }
         .chapter-pill.active { border-color: #b9d7ff; box-shadow: 0 0 18px rgba(125,211,252,.35); }
         .chapter-pill small { display: block; opacity: .8; }

--- a/src/components/lifemap/WebGLLifeMapField.tsx
+++ b/src/components/lifemap/WebGLLifeMapField.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type Star = {
+  x: number;
+  y: number;
+  z: number;
+  size: number;
+  hue: number;
+  speed: number;
+};
+
+const STAR_COUNT = 420;
+const DEPTH = 900;
+
+function createStars(): Star[] {
+  return Array.from({ length: STAR_COUNT }, (_, index) => {
+    const ring = index / STAR_COUNT;
+    const angle = index * 2.399963229728653;
+    const radius = 0.16 + Math.sqrt(ring) * 0.84;
+    return {
+      x: Math.cos(angle) * radius * 620 + (Math.random() - 0.5) * 120,
+      y: Math.sin(angle) * radius * 360 + (Math.random() - 0.5) * 90,
+      z: -Math.random() * DEPTH,
+      size: 1.1 + Math.random() * 3.4,
+      hue: 195 + Math.random() * 72,
+      speed: 0.22 + Math.random() * 0.72,
+    };
+  });
+}
+
+function drawStar(ctx: CanvasRenderingContext2D, x: number, y: number, size: number, alpha: number, hue: number) {
+  const glow = ctx.createRadialGradient(x, y, 0, x, y, size * 6.5);
+  glow.addColorStop(0, `hsla(${hue}, 100%, 92%, ${alpha})`);
+  glow.addColorStop(0.28, `hsla(${hue}, 96%, 72%, ${alpha * 0.42})`);
+  glow.addColorStop(1, `hsla(${hue}, 90%, 55%, 0)`);
+  ctx.fillStyle = glow;
+  ctx.beginPath();
+  ctx.arc(x, y, size * 6.5, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = `hsla(${hue}, 100%, 96%, ${Math.min(1, alpha + 0.18)})`;
+  ctx.beginPath();
+  ctx.arc(x, y, Math.max(0.7, size * 0.78), 0, Math.PI * 2);
+  ctx.fill();
+}
+
+export default function WebGLLifeMapField() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const starsRef = useRef<Star[] | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || typeof window === 'undefined') return undefined;
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const ctx = canvas.getContext('2d', { alpha: true });
+    if (!ctx) return undefined;
+
+    starsRef.current = createStars();
+    let animationFrame = 0;
+    let disposed = false;
+
+    const resize = () => {
+      const ratio = Math.min(window.devicePixelRatio || 1, 2);
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = Math.max(1, Math.floor(rect.width * ratio));
+      canvas.height = Math.max(1, Math.floor(rect.height * ratio));
+      ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+    };
+
+    const render = (time: number) => {
+      if (disposed || !starsRef.current) return;
+
+      const width = canvas.clientWidth;
+      const height = canvas.clientHeight;
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const driftX = Math.sin(time * 0.00012) * 28;
+      const driftY = Math.cos(time * 0.0001) * 18;
+
+      ctx.clearRect(0, 0, width, height);
+
+      const gradient = ctx.createRadialGradient(centerX, centerY * 0.55, 0, centerX, centerY * 0.55, Math.max(width, height) * 0.72);
+      gradient.addColorStop(0, 'rgba(80, 112, 220, 0.22)');
+      gradient.addColorStop(0.36, 'rgba(26, 38, 84, 0.16)');
+      gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, width, height);
+
+      for (const star of starsRef.current) {
+        if (!reduceMotion) {
+          star.z += star.speed;
+          if (star.z > 18) {
+            star.z = -DEPTH;
+            star.x = (Math.random() - 0.5) * 980;
+            star.y = (Math.random() - 0.5) * 620;
+          }
+        }
+
+        const perspective = 520 / (520 - star.z);
+        const x = centerX + (star.x + driftX) * perspective;
+        const y = centerY + (star.y + driftY) * perspective;
+        const alpha = Math.max(0.08, Math.min(0.95, perspective * 0.62));
+        const size = star.size * Math.max(0.42, perspective);
+
+        if (x < -40 || x > width + 40 || y < -40 || y > height + 40) continue;
+        drawStar(ctx, x, y, size, alpha, star.hue);
+      }
+
+      ctx.save();
+      ctx.globalAlpha = 0.36;
+      ctx.strokeStyle = 'rgba(190, 220, 255, 0.15)';
+      ctx.lineWidth = 1;
+      for (let i = 0; i < 4; i += 1) {
+        const radiusX = width * (0.18 + i * 0.095);
+        const radiusY = height * (0.055 + i * 0.032);
+        ctx.beginPath();
+        ctx.ellipse(centerX, height * 0.73, radiusX, radiusY, 0, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+      ctx.restore();
+
+      animationFrame = window.requestAnimationFrame(render);
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+    animationFrame = window.requestAnimationFrame(render);
+
+    return () => {
+      disposed = true;
+      window.removeEventListener('resize', resize);
+      window.cancelAnimationFrame(animationFrame);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="webgl-life-map-field" aria-hidden />;
+}

--- a/src/components/lifemap/WebGLLifeMapField.tsx
+++ b/src/components/lifemap/WebGLLifeMapField.tsx
@@ -2,126 +2,175 @@
 
 import { useEffect, useRef } from 'react';
 
-type Star = {
-  x: number;
-  y: number;
-  z: number;
-  size: number;
-  hue: number;
-  speed: number;
-};
+const STAR_COUNT = 700;
+const FLOATS_PER_STAR = 7;
+const VERTEX_SHADER = `
+attribute vec3 a_position;
+attribute float a_size;
+attribute vec3 a_color;
+uniform float u_time;
+uniform vec2 u_resolution;
+varying vec3 v_color;
+varying float v_alpha;
 
-const STAR_COUNT = 420;
-const DEPTH = 900;
+void main() {
+  float drift = sin(u_time * 0.00018 + a_position.z * 0.008) * 0.045;
+  vec3 position = a_position;
+  position.x += drift;
+  position.y += cos(u_time * 0.00014 + a_position.x * 2.0) * 0.035;
 
-function createStars(): Star[] {
-  return Array.from({ length: STAR_COUNT }, (_, index) => {
-    const ring = index / STAR_COUNT;
-    const angle = index * 2.399963229728653;
-    const radius = 0.16 + Math.sqrt(ring) * 0.84;
-    return {
-      x: Math.cos(angle) * radius * 620 + (Math.random() - 0.5) * 120,
-      y: Math.sin(angle) * radius * 360 + (Math.random() - 0.5) * 90,
-      z: -Math.random() * DEPTH,
-      size: 1.1 + Math.random() * 3.4,
-      hue: 195 + Math.random() * 72,
-      speed: 0.22 + Math.random() * 0.72,
-    };
-  });
+  float depth = 1.0 / (1.65 - position.z);
+  vec2 projected = position.xy * depth;
+  gl_Position = vec4(projected, position.z * 0.38, 1.0);
+  gl_PointSize = a_size * depth * min(u_resolution.x, u_resolution.y) * 0.026;
+  v_color = a_color;
+  v_alpha = clamp(depth * 0.72, 0.16, 0.95);
+}
+`;
+
+const FRAGMENT_SHADER = `
+precision mediump float;
+varying vec3 v_color;
+varying float v_alpha;
+
+void main() {
+  vec2 uv = gl_PointCoord - vec2(0.5);
+  float d = length(uv);
+  float core = smoothstep(0.24, 0.0, d);
+  float halo = smoothstep(0.5, 0.08, d) * 0.46;
+  float alpha = (core + halo) * v_alpha;
+  if (alpha < 0.02) discard;
+  gl_FragColor = vec4(v_color, alpha);
+}
+`;
+
+function compileShader(gl: WebGLRenderingContext, type: number, source: string) {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
 }
 
-function drawStar(ctx: CanvasRenderingContext2D, x: number, y: number, size: number, alpha: number, hue: number) {
-  const glow = ctx.createRadialGradient(x, y, 0, x, y, size * 6.5);
-  glow.addColorStop(0, `hsla(${hue}, 100%, 92%, ${alpha})`);
-  glow.addColorStop(0.28, `hsla(${hue}, 96%, 72%, ${alpha * 0.42})`);
-  glow.addColorStop(1, `hsla(${hue}, 90%, 55%, 0)`);
-  ctx.fillStyle = glow;
-  ctx.beginPath();
-  ctx.arc(x, y, size * 6.5, 0, Math.PI * 2);
-  ctx.fill();
+function createProgram(gl: WebGLRenderingContext) {
+  const vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+  const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+  if (!vertexShader || !fragmentShader) return null;
 
-  ctx.fillStyle = `hsla(${hue}, 100%, 96%, ${Math.min(1, alpha + 0.18)})`;
-  ctx.beginPath();
-  ctx.arc(x, y, Math.max(0.7, size * 0.78), 0, Math.PI * 2);
-  ctx.fill();
+  const program = gl.createProgram();
+  if (!program) return null;
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.linkProgram(program);
+
+  gl.deleteShader(vertexShader);
+  gl.deleteShader(fragmentShader);
+
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    gl.deleteProgram(program);
+    return null;
+  }
+
+  return program;
+}
+
+function createStarData() {
+  const data = new Float32Array(STAR_COUNT * FLOATS_PER_STAR);
+
+  for (let i = 0; i < STAR_COUNT; i += 1) {
+    const offset = i * FLOATS_PER_STAR;
+    const ring = i / STAR_COUNT;
+    const angle = i * 2.399963229728653;
+    const radius = 0.08 + Math.sqrt(ring) * 1.05;
+    const wobble = (Math.random() - 0.5) * 0.28;
+    const x = Math.cos(angle) * radius + wobble;
+    const y = Math.sin(angle) * radius * 0.68 + (Math.random() - 0.5) * 0.22;
+    const z = -1.0 + Math.random() * 1.8;
+    const size = 4.0 + Math.random() * 7.5;
+    const colorShift = Math.random();
+
+    data[offset] = x;
+    data[offset + 1] = y;
+    data[offset + 2] = z;
+    data[offset + 3] = size;
+    data[offset + 4] = 0.62 + colorShift * 0.28;
+    data[offset + 5] = 0.78 + colorShift * 0.18;
+    data[offset + 6] = 1.0;
+  }
+
+  return data;
 }
 
 export default function WebGLLifeMapField() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const starsRef = useRef<Star[] | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || typeof window === 'undefined') return undefined;
 
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    const ctx = canvas.getContext('2d', { alpha: true });
-    if (!ctx) return undefined;
+    const gl = canvas.getContext('webgl', {
+      alpha: true,
+      antialias: true,
+      depth: false,
+      powerPreference: 'high-performance',
+    });
 
-    starsRef.current = createStars();
+    if (!gl) return undefined;
+
+    const program = createProgram(gl);
+    if (!program) return undefined;
+
+    const buffer = gl.createBuffer();
+    if (!buffer) return undefined;
+
+    const data = createStarData();
+    const stride = FLOATS_PER_STAR * Float32Array.BYTES_PER_ELEMENT;
+    const positionLocation = gl.getAttribLocation(program, 'a_position');
+    const sizeLocation = gl.getAttribLocation(program, 'a_size');
+    const colorLocation = gl.getAttribLocation(program, 'a_color');
+    const timeLocation = gl.getUniformLocation(program, 'u_time');
+    const resolutionLocation = gl.getUniformLocation(program, 'u_resolution');
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     let animationFrame = 0;
     let disposed = false;
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+    gl.disable(gl.DEPTH_TEST);
+
+    gl.enableVertexAttribArray(positionLocation);
+    gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, stride, 0);
+
+    gl.enableVertexAttribArray(sizeLocation);
+    gl.vertexAttribPointer(sizeLocation, 1, gl.FLOAT, false, stride, 3 * Float32Array.BYTES_PER_ELEMENT);
+
+    gl.enableVertexAttribArray(colorLocation);
+    gl.vertexAttribPointer(colorLocation, 3, gl.FLOAT, false, stride, 4 * Float32Array.BYTES_PER_ELEMENT);
 
     const resize = () => {
       const ratio = Math.min(window.devicePixelRatio || 1, 2);
       const rect = canvas.getBoundingClientRect();
       canvas.width = Math.max(1, Math.floor(rect.width * ratio));
       canvas.height = Math.max(1, Math.floor(rect.height * ratio));
-      ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+      gl.viewport(0, 0, canvas.width, canvas.height);
     };
 
     const render = (time: number) => {
-      if (disposed || !starsRef.current) return;
-
-      const width = canvas.clientWidth;
-      const height = canvas.clientHeight;
-      const centerX = width / 2;
-      const centerY = height / 2;
-      const driftX = Math.sin(time * 0.00012) * 28;
-      const driftY = Math.cos(time * 0.0001) * 18;
-
-      ctx.clearRect(0, 0, width, height);
-
-      const gradient = ctx.createRadialGradient(centerX, centerY * 0.55, 0, centerX, centerY * 0.55, Math.max(width, height) * 0.72);
-      gradient.addColorStop(0, 'rgba(80, 112, 220, 0.22)');
-      gradient.addColorStop(0.36, 'rgba(26, 38, 84, 0.16)');
-      gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
-      ctx.fillStyle = gradient;
-      ctx.fillRect(0, 0, width, height);
-
-      for (const star of starsRef.current) {
-        if (!reduceMotion) {
-          star.z += star.speed;
-          if (star.z > 18) {
-            star.z = -DEPTH;
-            star.x = (Math.random() - 0.5) * 980;
-            star.y = (Math.random() - 0.5) * 620;
-          }
-        }
-
-        const perspective = 520 / (520 - star.z);
-        const x = centerX + (star.x + driftX) * perspective;
-        const y = centerY + (star.y + driftY) * perspective;
-        const alpha = Math.max(0.08, Math.min(0.95, perspective * 0.62));
-        const size = star.size * Math.max(0.42, perspective);
-
-        if (x < -40 || x > width + 40 || y < -40 || y > height + 40) continue;
-        drawStar(ctx, x, y, size, alpha, star.hue);
-      }
-
-      ctx.save();
-      ctx.globalAlpha = 0.36;
-      ctx.strokeStyle = 'rgba(190, 220, 255, 0.15)';
-      ctx.lineWidth = 1;
-      for (let i = 0; i < 4; i += 1) {
-        const radiusX = width * (0.18 + i * 0.095);
-        const radiusY = height * (0.055 + i * 0.032);
-        ctx.beginPath();
-        ctx.ellipse(centerX, height * 0.73, radiusX, radiusY, 0, 0, Math.PI * 2);
-        ctx.stroke();
-      }
-      ctx.restore();
-
+      if (disposed) return;
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.useProgram(program);
+      gl.uniform1f(timeLocation, reduceMotion ? 0 : time);
+      gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+      gl.drawArrays(gl.POINTS, 0, STAR_COUNT);
       animationFrame = window.requestAnimationFrame(render);
     };
 
@@ -133,6 +182,8 @@ export default function WebGLLifeMapField() {
       disposed = true;
       window.removeEventListener('resize', resize);
       window.cancelAnimationFrame(animationFrame);
+      gl.deleteBuffer(buffer);
+      gl.deleteProgram(program);
     };
   }, []);
 


### PR DESCRIPTION
Adds the next visual polish layer without changing launch-critical backend behavior.

Changes:
- Adds a real WebGL shader-backed ambient sky to `/home`.
- Adds visible companion orb anchor on the home scene.
- Adds subtle avatar/body silhouette and heart glow.
- Strengthens the living ground layer with roots, bloom motion, aura, and particles.
- Improves sky-to-Life-Map ascent with cloud veil, ascent column, orb expansion, and card fade-down choreography.
- Adds a real WebGL shader-backed 3D point-cloud starfield behind `/life-map`.
- Keeps the existing DOM constellation, panels, and controls on top for accessibility and stability.
- Adds nebula wash, horizon glow, and depth rings around the Life Map WebGL field.

Notes:
- `/home` now has a lightweight WebGL emotional sky behind the DOM orb/avatar/ground/cards.
- `/life-map` now has a true WebGL 3D spatial background layer, while the clickable memory stars remain DOM elements for launch stability.
- Reduced-motion guards are preserved.
- Public-safe demo route behavior and launch gates should remain unchanged.