### PR TITLE
Fix WebGL home route and Life Map exposure

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,30 +1,5 @@
-"use client";
-import React from 'react';
-import Button from '@/components/ui/Button';
-import Chip from '@/components/ui/Chip';
+import HomeScene from "@/components/HomeScene";
 
 export default function HomePage() {
-  return (
-    <div className="relative flex min-h-screen flex-col items-center justify-center text-center">
-      <div className="absolute left-0 right-0 top-0 flex items-center justify-between p-4">
-        <span className="text-sm">URAI companion listening locally</span>
-        <Button variant="secondary">Local-Only</Button>
-      </div>
-
-      <div className="flex flex-1 flex-col items-center justify-center">
-        <div className="mb-4 h-60 w-40 rounded-full bg-white/10"></div>
-        <div className="mb-8 h-16 w-16 rounded-full bg-blue-500 shadow-lg"></div>
-
-        <Button variant="primary" onClick={() => (window.location.href = '/life-map')}>
-          Tap the sky
-        </Button>
-      </div>
-
-      <div className="mb-24 flex space-x-4">
-        <Chip>Mirror</Chip>
-        <Chip>Narrator</Chip>
-        <Chip>Life Map</Chip>
-      </div>
-    </div>
-  );
+  return <HomeScene />;
 }

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,5 +1,9 @@
 import HomeScene from "@/components/HomeScene";
 
+export const metadata = {
+  description: "URAI companion shell with WebGL sky, narrator, aura, early access, and Life Map preview.",
+};
+
 export default function HomePage() {
   return <HomeScene />;
 }

--- a/src/components/lifemap/WebGLLifeMapField.tsx
+++ b/src/components/lifemap/WebGLLifeMapField.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 
-const STAR_COUNT = 700;
+const STAR_COUNT = 220;
 const FLOATS_PER_STAR = 7;
 const VERTEX_SHADER = `
 attribute vec3 a_position;
@@ -14,17 +14,17 @@ varying vec3 v_color;
 varying float v_alpha;
 
 void main() {
-  float drift = sin(u_time * 0.00018 + a_position.z * 0.008) * 0.045;
+  float drift = sin(u_time * 0.00012 + a_position.z * 0.008) * 0.035;
   vec3 position = a_position;
   position.x += drift;
-  position.y += cos(u_time * 0.00014 + a_position.x * 2.0) * 0.035;
+  position.y += cos(u_time * 0.00010 + a_position.x * 2.0) * 0.025;
 
-  float depth = 1.0 / (1.65 - position.z);
+  float depth = 1.0 / (1.85 - position.z);
   vec2 projected = position.xy * depth;
-  gl_Position = vec4(projected, position.z * 0.38, 1.0);
-  gl_PointSize = a_size * depth * min(u_resolution.x, u_resolution.y) * 0.026;
+  gl_Position = vec4(projected, position.z * 0.34, 1.0);
+  gl_PointSize = a_size * depth * min(u_resolution.x, u_resolution.y) * 0.010;
   v_color = a_color;
-  v_alpha = clamp(depth * 0.72, 0.16, 0.95);
+  v_alpha = clamp(depth * 0.22, 0.04, 0.36);
 }
 `;
 
@@ -36,10 +36,10 @@ varying float v_alpha;
 void main() {
   vec2 uv = gl_PointCoord - vec2(0.5);
   float d = length(uv);
-  float core = smoothstep(0.24, 0.0, d);
-  float halo = smoothstep(0.5, 0.08, d) * 0.46;
+  float core = smoothstep(0.12, 0.0, d);
+  float halo = smoothstep(0.44, 0.10, d) * 0.16;
   float alpha = (core + halo) * v_alpha;
-  if (alpha < 0.02) discard;
+  if (alpha < 0.012) discard;
   gl_FragColor = vec4(v_color, alpha);
 }
 `;
@@ -85,21 +85,17 @@ function createStarData() {
     const offset = i * FLOATS_PER_STAR;
     const ring = i / STAR_COUNT;
     const angle = i * 2.399963229728653;
-    const radius = 0.08 + Math.sqrt(ring) * 1.05;
-    const wobble = (Math.random() - 0.5) * 0.28;
-    const x = Math.cos(angle) * radius + wobble;
-    const y = Math.sin(angle) * radius * 0.68 + (Math.random() - 0.5) * 0.22;
-    const z = -1.0 + Math.random() * 1.8;
-    const size = 4.0 + Math.random() * 7.5;
+    const radius = 0.12 + Math.sqrt(ring) * 0.96;
+    const wobble = (Math.random() - 0.5) * 0.16;
     const colorShift = Math.random();
 
-    data[offset] = x;
-    data[offset + 1] = y;
-    data[offset + 2] = z;
-    data[offset + 3] = size;
-    data[offset + 4] = 0.62 + colorShift * 0.28;
-    data[offset + 5] = 0.78 + colorShift * 0.18;
-    data[offset + 6] = 1.0;
+    data[offset] = Math.cos(angle) * radius + wobble;
+    data[offset + 1] = Math.sin(angle) * radius * 0.58 + (Math.random() - 0.5) * 0.16;
+    data[offset + 2] = -1.0 + Math.random() * 1.72;
+    data[offset + 3] = 2.0 + Math.random() * 3.2;
+    data[offset + 4] = 0.42 + colorShift * 0.22;
+    data[offset + 5] = 0.62 + colorShift * 0.18;
+    data[offset + 6] = 0.95;
   }
 
   return data;
@@ -143,7 +139,7 @@ export default function WebGLLifeMapField() {
     gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
     gl.useProgram(program);
     gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
     gl.disable(gl.DEPTH_TEST);
 
     gl.enableVertexAttribArray(positionLocation);


### PR DESCRIPTION
Hotfixes two visual regressions seen after the V1.1 WebGL visual merge.

Fixes:
- `/home` was still rendering the old local-only shell; it now renders the upgraded `HomeScene` with WebGL sky, orb, avatar, ground, cards, and ascent.
- `/life-map` WebGL point cloud was overexposed and washing out the DOM constellation; this reduces particle count, point size, alpha, and halo strength, and switches to standard alpha blending.

Validation target:
- `/home` should visually match the upgraded WebGL public home scene.
- `/life-map` should show atmospheric WebGL depth without blowing out labels, stars, cards, or panels.