### PR TITLE
Polish WebGL home and Life Map readability

### DIFF
--- a/src/components/HomeWebGLSky.tsx
+++ b/src/components/HomeWebGLSky.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 
-const PARTICLE_COUNT = 520;
+const PARTICLE_COUNT = 280;
 const FLOATS_PER_PARTICLE = 7;
 
 const VERTEX_SHADER = `
@@ -15,15 +15,15 @@ varying vec3 v_color;
 varying float v_alpha;
 
 void main() {
-  float lift = mod(a_position.y + u_time * 0.000035, 2.4) - 1.2;
-  float sway = sin(u_time * 0.00016 + a_position.z * 8.0 + a_position.x * 2.0) * 0.055;
+  float lift = mod(a_position.y + u_time * 0.000026, 2.4) - 1.2;
+  float sway = sin(u_time * 0.00012 + a_position.z * 8.0 + a_position.x * 2.0) * 0.038;
   vec3 position = vec3(a_position.x + sway, lift, a_position.z);
-  float depth = 1.0 / (1.58 - position.z);
+  float depth = 1.0 / (1.7 - position.z);
   vec2 projected = position.xy * depth;
-  gl_Position = vec4(projected, position.z * 0.32, 1.0);
-  gl_PointSize = a_size * depth * min(u_resolution.x, u_resolution.y) * 0.021;
+  gl_Position = vec4(projected, position.z * 0.3, 1.0);
+  gl_PointSize = a_size * depth * min(u_resolution.x, u_resolution.y) * 0.014;
   v_color = a_color;
-  v_alpha = clamp(depth * 0.55, 0.08, 0.78);
+  v_alpha = clamp(depth * 0.24, 0.035, 0.34);
 }
 `;
 
@@ -35,10 +35,10 @@ varying float v_alpha;
 void main() {
   vec2 uv = gl_PointCoord - vec2(0.5);
   float d = length(uv);
-  float core = smoothstep(0.18, 0.0, d);
-  float halo = smoothstep(0.5, 0.08, d) * 0.34;
+  float core = smoothstep(0.14, 0.0, d);
+  float halo = smoothstep(0.48, 0.12, d) * 0.16;
   float alpha = (core + halo) * v_alpha;
-  if (alpha < 0.015) discard;
+  if (alpha < 0.012) discard;
   gl_FragColor = vec4(v_color, alpha);
 }
 `;
@@ -84,16 +84,16 @@ function createParticleData() {
     const offset = i * FLOATS_PER_PARTICLE;
     const ring = i / PARTICLE_COUNT;
     const angle = i * 2.399963229728653;
-    const radius = 0.18 + Math.sqrt(ring) * 1.22;
+    const radius = 0.22 + Math.sqrt(ring) * 1.12;
     const colorShift = Math.random();
 
-    data[offset] = Math.cos(angle) * radius + (Math.random() - 0.5) * 0.22;
-    data[offset + 1] = Math.sin(angle) * radius * 0.82 + (Math.random() - 0.5) * 0.32;
-    data[offset + 2] = -1.0 + Math.random() * 1.82;
-    data[offset + 3] = 2.8 + Math.random() * 5.4;
-    data[offset + 4] = 0.52 + colorShift * 0.38;
-    data[offset + 5] = 0.66 + colorShift * 0.24;
-    data[offset + 6] = 1.0;
+    data[offset] = Math.cos(angle) * radius + (Math.random() - 0.5) * 0.16;
+    data[offset + 1] = Math.sin(angle) * radius * 0.74 + (Math.random() - 0.5) * 0.22;
+    data[offset + 2] = -1.0 + Math.random() * 1.76;
+    data[offset + 3] = 2.0 + Math.random() * 3.6;
+    data[offset + 4] = 0.46 + colorShift * 0.3;
+    data[offset + 5] = 0.62 + colorShift * 0.2;
+    data[offset + 6] = 0.95;
   }
 
   return data;
@@ -135,7 +135,7 @@ export default function HomeWebGLSky() {
     gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
     gl.useProgram(program);
     gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
     gl.disable(gl.DEPTH_TEST);
 
     gl.enableVertexAttribArray(positionLocation);

--- a/src/components/lifemap/LifeMapScene.tsx
+++ b/src/components/lifemap/LifeMapScene.tsx
@@ -255,7 +255,7 @@ export default function LifeMapScene() {
   }, [topCluster]);
 
   return (
-    <main className="life-map-shell" aria-label="URAI Spatial Life Map scene">
+    <main className="life-map-shell" aria-label="URAI WebGL Spatial Life Map scene">
       <WebGLLifeMapField />
       <section className={`lifemap-space ${activeStar ? 'is-focused' : ''}`}>
         <div className="starfield" style={starfieldStyle}>
@@ -322,6 +322,8 @@ export default function LifeMapScene() {
       </nav>
       <style jsx>{`
         .life-map-shell { min-height: 100vh; background: radial-gradient(circle at 50% 28%, #26366d, #0a0f20 58%, #05060f 100%); color: #eef3ff; position: relative; padding: 1rem; overflow: hidden; }
+        .life-map-shell::before { content: 'URAI Sky Map V1 · WebGL spatial'; position: absolute; z-index: 5; left: 29%; top: 1rem; color: rgba(238, 243, 255, 0.55); font-size: 0.64rem; letter-spacing: 0.32em; text-transform: uppercase; }
+        .life-map-shell::after { content: 'WebGL Life Map with accessible constellation controls'; position: absolute; z-index: 5; left: 29%; top: 2rem; color: rgba(255, 255, 255, 0.94); font-size: 1rem; font-weight: 700; }
         .lifemap-space { position: absolute; inset: 0 0 120px; z-index: 1; }
         .starfield { position: absolute; inset: 0; transform: translate(calc(50% - var(--camera-x)), calc(50% - var(--camera-y))) scale(var(--camera-zoom)); transition: transform 700ms cubic-bezier(0.22, 1, 0.36, 1); }
         .connections { position: absolute; inset: 0; width: 100%; height: 100%; }
@@ -336,7 +338,7 @@ export default function LifeMapScene() {
         .memory-star.is-dimmed { opacity: .34; }
         .memory-star.is-chapter-focused { box-shadow: 0 0 16px rgba(255,255,255,.9), 0 0 44px rgba(196,181,253,.65); }
         .memory-star.is-pattern-focused { box-shadow: 0 0 18px rgba(255,255,255,.95), 0 0 54px rgba(251,191,36,.55), 0 0 90px rgba(251,191,36,.28); }
-        .panel { position: absolute; z-index: 4; background: rgba(7,10,25,.75); border: 1px solid rgba(157,196,255,.32); border-radius: 12px; padding: .8rem; backdrop-filter: blur(6px); }
+        .panel { position: absolute; z-index: 6; background: rgba(7,10,25,.75); border: 1px solid rgba(157,196,255,.32); border-radius: 12px; padding: .8rem; backdrop-filter: blur(6px); }
         .export-panel { left: 1rem; top: 1rem; display: flex; gap: .5rem; }
         .pattern-panel { left: 1rem; top: 74px; width: 320px; border-color: rgba(251,191,36,.42); animation: patternPanelIn 520ms ease both; }
         .pattern-panel h2 { margin: 0 0 .4rem; font-size: .95rem; }
@@ -355,7 +357,7 @@ export default function LifeMapScene() {
         @keyframes constellationFlow { to { stroke-dashoffset: -80; } }
         @keyframes starPulse { 0%, 100% { transform: translate(-50%, -50%) scale(1); } 50% { transform: translate(-50%, -50%) scale(1.12); } }
         @keyframes patternPanelIn { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: translateY(0) scale(1); } }
-        @media (max-width: 760px) { .companion-panel, .detail, .pattern-panel { left: 1rem; right: 1rem; width: auto; } .pattern-panel { top: 4.5rem; } .detail { top: auto; bottom: 7.5rem; } .chapter-row { grid-template-columns: 1fr; max-height: 6.5rem; overflow: auto; } }
+        @media (max-width: 760px) { .life-map-shell::before, .life-map-shell::after { left: 1rem; } .companion-panel, .detail, .pattern-panel { left: 1rem; right: 1rem; width: auto; } .pattern-panel { top: 4.5rem; } .detail { top: auto; bottom: 7.5rem; } .chapter-row { grid-template-columns: 1fr; max-height: 6.5rem; overflow: auto; } }
         @media (prefers-reduced-motion: reduce) { .memory-star, .connection-line, .starfield, .pattern-panel { animation: none !important; transition-duration: .01ms !important; } }
       `}</style>
     </main>


### PR DESCRIPTION
Polishes the screenshots from the latest Firebase Studio preview.

Changes:
- Softens `/home` WebGL sky density so hero text and demo cards breathe.
- Reduces home particle count, point size, alpha, halo, and uses standard alpha blending.
- Updates `/life-map` labeling from the old flat/2.5D wording to WebGL spatial copy.
- Keeps DOM stars, cards, panels, and controls stable.

Validation target:
- `/home` should still feel spatial but less busy behind the hero/cards.
- `/life-map` should describe the current WebGL implementation accurately.