### PR TITLE
Clean up WebGL home and Life Map visuals

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,36 +20,11 @@ body {
 }
 
 .home-webgl-sky {
-  opacity: 0.72;
+  opacity: 0.58;
 }
 
 .webgl-life-map-field {
-  opacity: 0.92;
-}
-
-.lifemap-space::before,
-.lifemap-space::after {
-  content: "";
-  position: absolute;
-  inset: 8% 10% 18%;
-  pointer-events: none;
-  border-radius: 999px;
-  z-index: 0;
-}
-
-.lifemap-space::before {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow:
-    0 0 60px rgba(125, 211, 252, 0.12),
-    inset 0 0 80px rgba(196, 181, 253, 0.08);
-  transform: perspective(900px) rotateX(62deg) scale(0.92);
-}
-
-.lifemap-space::after {
-  inset: 16% 18% 26%;
-  border: 1px dashed rgba(255, 255, 255, 0.1);
-  transform: perspective(900px) rotateX(62deg) scale(1.18);
-  animation: uraiDepthRing 18s linear infinite;
+  opacity: 0.7;
 }
 
 .starfield,
@@ -64,12 +39,6 @@ body {
 
 .avatar-heart {
   animation: uraiAvatarHeartPulse 4.8s ease-in-out infinite !important;
-}
-
-@keyframes uraiDepthRing {
-  to {
-    transform: perspective(900px) rotateX(62deg) scale(1.18) rotateZ(360deg);
-  }
 }
 
 @keyframes uraiOrbCorePulse {
@@ -95,7 +64,6 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .lifemap-space::after,
   .companion-orb .orb-core,
   .avatar-heart {
     animation: none !important;

--- a/src/app/life-map/page.tsx
+++ b/src/app/life-map/page.tsx
@@ -2,9 +2,9 @@ import Link from "next/link";
 import LifeMapScene from "@/components/lifemap/LifeMapScene";
 
 export const metadata = {
-  title: "URAI Sky Map V1",
+  title: "URAI WebGL Life Map",
   description:
-    "A lightweight 2.5D URAI Life Map demo with constellation memories, narrator cues, and weekly-scroll proof points.",
+    "A WebGL-backed URAI Life Map with spatial memory constellations, narrator cues, and accessible controls.",
 };
 
 export default function LifeMapPage() {
@@ -12,48 +12,12 @@ export default function LifeMapPage() {
     <main className="relative h-dvh w-full overflow-hidden bg-black text-white">
       <LifeMapScene />
 
-      <div className="pointer-events-none absolute inset-x-0 top-0 z-40 bg-gradient-to-b from-black/80 via-black/35 to-transparent px-4 py-4">
-        <div className="mx-auto flex max-w-6xl items-center justify-between gap-3">
-          <div>
-            <p className="text-[0.65rem] uppercase tracking-[0.35em] text-white/45">
-              URAI Sky Map V1
-            </p>
-            <h1 className="mt-1 text-lg font-semibold tracking-tight text-white md:text-2xl">
-              Flat magical Life Map, not blocked by 3D.
-            </h1>
-          </div>
-
-          <Link
-            href="/"
-            className="pointer-events-auto rounded-full border border-white/25 bg-black/55 px-4 py-2 text-sm font-medium text-white backdrop-blur transition hover:bg-white/10"
-          >
-            Return home
-          </Link>
-        </div>
-      </div>
-
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 z-40 bg-gradient-to-t from-black/90 via-black/35 to-transparent px-4 pb-4 pt-16">
-        <div className="mx-auto grid max-w-6xl gap-3 md:grid-cols-3">
-          <div className="rounded-2xl border border-white/10 bg-white/10 p-4 backdrop-blur">
-            <p className="text-xs uppercase tracking-[0.25em] text-white/45">Proof</p>
-            <p className="mt-2 text-sm leading-6 text-white/75">
-              Stars are tappable memory moments with narrator reflections and connected emotional arcs.
-            </p>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-white/10 p-4 backdrop-blur">
-            <p className="text-xs uppercase tracking-[0.25em] text-white/45">Build order</p>
-            <p className="mt-2 text-sm leading-6 text-white/75">
-              This route proves the 2.5D sky timeline before any heavy spatial, AR, or WebGL world returns.
-            </p>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-white/10 p-4 backdrop-blur">
-            <p className="text-xs uppercase tracking-[0.25em] text-white/45">Demo data</p>
-            <p className="mt-2 text-sm leading-6 text-white/75">
-              Public-safe sample memories keep the emotional loop visible without exposing private capture data.
-            </p>
-          </div>
-        </div>
-      </div>
+      <Link
+        href="/"
+        className="absolute left-4 top-4 z-50 rounded-full border border-white/25 bg-black/55 px-4 py-2 text-sm font-medium text-white backdrop-blur transition hover:bg-white/10"
+      >
+        Return home
+      </Link>
     </main>
   );
 }


### PR DESCRIPTION
Hard visual cleanup based on latest Firebase Studio screenshots.

Fixes:
- Removes noisy global Life Map ring/dome pseudo-layers from `globals.css`.
- Lowers `/home` and `/life-map` WebGL canvas opacity so the scenes are less blown out.
- Removes stale `/life-map` route wrapper chrome that still said “Flat magical Life Map, not blocked by 3D.”
- Removes bottom proof cards that cluttered the Life Map scene.
- Updates `/life-map` metadata to WebGL-backed spatial wording.
- Leaves the Life Map component-owned DOM header, narrator, export controls, stars, and chapter controls intact.

Validation target:
- `/home` should remain readable and calmer.
- `/life-map` should no longer show stale 2.5D copy, bottom proof cards, giant dome/ring geometry, or diagonal visual junk.