### PR TITLE
Connect Life Map layers to Firestore node data

### DIFF
--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -15,6 +15,158 @@ const daysAgo = (days) => {
 
 const owned = () => ({ ownerUid, userId: ownerUid });
 
+const lifeMapNodes = {
+  "lifemap-blueprint-locked": {
+    ...owned(),
+    type: "becoming",
+    title: "Blueprint Locked",
+    subtitle: "foundation",
+    timestamp: daysAgo(10),
+    chapterId: "season-of-becoming",
+    emotionalTone: "focus",
+    auraColor: "205deg",
+    intensity: 0.86,
+    confidence: 0.92,
+    x: 38,
+    y: 39,
+    z: 150,
+    size: 17,
+    glow: 0.92,
+    isBrightMemory: true,
+    isClickable: true,
+    connectedTo: ["lifemap-demo-spine", "lifemap-mirror-pattern"],
+    linkedThreadIds: ["thread-buildable-system"],
+    sourceEventIds: ["bloom-001"],
+    sourceSignalIds: ["bloom-001"],
+    narratorLine: "You stopped carrying the whole system in your head and gave it a foundation."
+  },
+  "lifemap-threshold-edge": {
+    ...owned(),
+    type: "threshold",
+    title: "Launch Edge",
+    subtitle: "threshold",
+    timestamp: daysAgo(5),
+    chapterId: "threshold",
+    emotionalTone: "threshold",
+    auraColor: "285deg",
+    intensity: 0.9,
+    confidence: 0.84,
+    unresolvedWeight: 0.78,
+    x: 50,
+    y: 31,
+    z: 175,
+    size: 18,
+    glow: 0.95,
+    isBrightMemory: true,
+    isClickable: true,
+    connectedTo: ["lifemap-recovery-return", "lifemap-blueprint-locked"],
+    linkedThreadIds: ["thread-threshold-to-recovery"],
+    sourceEventIds: ["bloom-003"],
+    sourceSignalIds: ["bloom-003"],
+    narratorLine: "This is the edge where vision has to become rhythm."
+  },
+  "lifemap-recovery-return": {
+    ...owned(),
+    type: "recovery",
+    title: "Quiet Return",
+    subtitle: "softening",
+    timestamp: daysAgo(3),
+    chapterId: "recovery-arc",
+    emotionalTone: "recovery",
+    auraColor: "158deg",
+    intensity: 0.82,
+    confidence: 0.88,
+    unresolvedWeight: 0.22,
+    x: 62,
+    y: 43,
+    z: 140,
+    size: 16,
+    glow: 0.86,
+    isBrightMemory: true,
+    isClickable: true,
+    connectedTo: ["lifemap-threshold-edge", "lifemap-demo-spine"],
+    linkedThreadIds: ["thread-threshold-to-recovery"],
+    sourceEventIds: ["bloom-002"],
+    sourceSignalIds: ["bloom-002"],
+    narratorLine: "A quieter rhythm returned after the pressure softened."
+  },
+  "lifemap-dream-symbols": {
+    ...owned(),
+    type: "dream",
+    title: "Dream Field Opens",
+    subtitle: "symbols",
+    timestamp: daysAgo(8),
+    chapterId: "purple-dream-field",
+    emotionalTone: "dream",
+    auraColor: "248deg",
+    intensity: 0.74,
+    confidence: 0.76,
+    unresolvedWeight: 0.42,
+    x: 41,
+    y: 61,
+    z: 90,
+    size: 14,
+    glow: 0.72,
+    isBrightMemory: true,
+    isClickable: true,
+    connectedTo: ["lifemap-mirror-pattern"],
+    linkedThreadIds: ["thread-symbolic-identity"],
+    sourceEventIds: ["symbolic-demo-adam"],
+    sourceSignalIds: ["symbolic-demo-adam"],
+    narratorLine: "Symbolic echoes are gathering into a visual language."
+  },
+  "lifemap-mirror-pattern": {
+    ...owned(),
+    type: "mirror",
+    title: "Mirror Pattern",
+    subtitle: "identity",
+    timestamp: daysAgo(1),
+    chapterId: "mirror-of-becoming",
+    emotionalTone: "mirror",
+    auraColor: "42deg",
+    intensity: 0.88,
+    confidence: 0.9,
+    unresolvedWeight: 0.3,
+    x: 64,
+    y: 61,
+    z: 165,
+    size: 18,
+    glow: 0.9,
+    isBrightMemory: true,
+    isClickable: true,
+    connectedTo: ["lifemap-blueprint-locked", "lifemap-dream-symbols"],
+    linkedThreadIds: ["thread-symbolic-identity"],
+    sourceEventIds: ["weekly-demo-adam"],
+    sourceSignalIds: ["weekly-demo-adam"],
+    narratorLine: "This pattern has appeared before. Not as failure, as rehearsal."
+  },
+  "lifemap-demo-spine": {
+    ...owned(),
+    type: "breakthrough",
+    title: "Demo Spine Chosen",
+    subtitle: "clarity",
+    timestamp: daysAgo(6),
+    chapterId: "season-of-becoming",
+    emotionalTone: "joy",
+    auraColor: "42deg",
+    intensity: 0.76,
+    confidence: 0.86,
+    unresolvedWeight: 0.18,
+    x: 55,
+    y: 50,
+    z: 110,
+    size: 14,
+    glow: 0.78,
+    isBrightMemory: true,
+    isClickable: true,
+    connectedTo: ["lifemap-blueprint-locked", "lifemap-recovery-return"],
+    linkedThreadIds: ["thread-buildable-system"],
+    sourceEventIds: ["bloom-002"],
+    sourceSignalIds: ["bloom-002"],
+    narratorLine: "A product becomes real when a stranger can feel it in one minute."
+  }
+};
+
 const seed = {
   users: {
     [ownerUid]: {
@@ -84,7 +236,12 @@ const seed = {
       narratorLine: "This is the edge where vision has to become rhythm."
     }
   },
-  waitlistSignups: {}
+  waitlistSignups: {},
+  userSubcollections: {
+    [ownerUid]: {
+      lifeMapNodes
+    }
+  }
 };
 
 fs.mkdirSync(outputDir, { recursive: true });
@@ -113,9 +270,19 @@ if (shouldWriteFirestore) {
 
   const db = getFirestore();
   for (const [collectionName, docs] of Object.entries(seed)) {
+    if (collectionName === "userSubcollections") continue;
     for (const [docId, value] of Object.entries(docs)) {
       await db.collection(collectionName).doc(docId).set(value, { merge: true });
       console.log(`Seeded ${collectionName}/${docId}`);
+    }
+  }
+
+  for (const [uid, subcollections] of Object.entries(seed.userSubcollections)) {
+    for (const [subcollectionName, docs] of Object.entries(subcollections)) {
+      for (const [docId, value] of Object.entries(docs)) {
+        await db.collection("users").doc(uid).collection(subcollectionName).doc(docId).set(value, { merge: true });
+        console.log(`Seeded users/${uid}/${subcollectionName}/${docId}`);
+      }
     }
   }
 }

--- a/src/components/lifemap/useMemoryStars.ts
+++ b/src/components/lifemap/useMemoryStars.ts
@@ -11,8 +11,10 @@ import { enrichMemorySignal } from "./memoryIntelligenceEngine";
 export type MemoryStar = {
   id: string;
   title: string;
+  subtitle?: string;
   x: number;
   y: number;
+  z?: number;
   size: number;
   emotion: MemoryEmotion;
   chapterId: ChapterId;
@@ -23,6 +25,38 @@ export type MemoryStar = {
   lastActivatedAt: number | null;
   narratorLine: string;
   connectedTo: string[];
+  sourceSignalIds?: string[];
+  timestamp?: string | number | Date | null;
+};
+
+const CHAPTER_ALIASES: Record<string, ChapterId> = {
+  becoming: "season-of-becoming",
+  growth: "season-of-becoming",
+  "season-of-becoming": "season-of-becoming",
+  threshold: "threshold",
+  recovery: "recovery-arc",
+  "recovery-arc": "recovery-arc",
+  "dream-field": "purple-dream-field",
+  dream: "purple-dream-field",
+  "purple-dream-field": "purple-dream-field",
+  mirror: "mirror-of-becoming",
+  "mirror-of-becoming": "mirror-of-becoming",
+};
+
+const EMOTION_ALIASES: Record<string, MemoryEmotion> = {
+  stress: "threshold",
+  rebirth: "recovery",
+  connection: "calm",
+  clarity: "focus",
+  threshold: "threshold",
+  grief: "grief",
+  recovery: "recovery",
+  shadow: "shadow",
+  mirror: "mirror",
+  dream: "dream",
+  calm: "calm",
+  joy: "joy",
+  focus: "focus",
 };
 
 function positionForIndex(index: number) {
@@ -32,6 +66,38 @@ function positionForIndex(index: number) {
     x: Math.max(26, Math.min(74, 50 + Math.cos(angle) * radius)),
     y: Math.max(25, Math.min(72, 48 + Math.sin(angle) * radius * 0.78)),
   };
+}
+
+function numberBetween(value: unknown, min: number, max: number, fallback: number) {
+  const numeric = typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  return Math.max(min, Math.min(max, numeric));
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function normalizeChapter(value: unknown, fallback: ChapterId): ChapterId {
+  if (typeof value !== "string") return fallback;
+  return CHAPTER_ALIASES[value] ?? fallback;
+}
+
+function normalizeEmotion(value: unknown, fallback: MemoryEmotion): MemoryEmotion {
+  if (typeof value !== "string") return fallback;
+  return EMOTION_ALIASES[value] ?? fallback;
+}
+
+function timestampToRecency(value: unknown, fallback: number) {
+  const millis =
+    value instanceof Date ? value.getTime() :
+    typeof value === "number" ? value :
+    typeof value === "string" ? Date.parse(value) :
+    typeof value === "object" && value && "toMillis" in value && typeof value.toMillis === "function" ? value.toMillis() :
+    Number.NaN;
+
+  if (!Number.isFinite(millis)) return fallback;
+  const ageDays = Math.max(0, (Date.now() - millis) / 86400000);
+  return numberBetween(1 - ageDays / 90, 0.08, 1, fallback);
 }
 
 function toMemoryStar(id: string, data: DocumentData, index: number): MemoryStar {
@@ -52,7 +118,54 @@ function toMemoryStar(id: string, data: DocumentData, index: number): MemoryStar
     unresolvedWeight: enriched.unresolvedWeight,
     lastActivatedAt: null,
     narratorLine: enriched.narratorLine,
-    connectedTo: [],
+    connectedTo: stringArray(data.connectedTo),
+    sourceSignalIds: stringArray(data.sourceSignalIds),
+    timestamp: data.createdAt ?? data.timestamp ?? null,
+  };
+}
+
+function toLifeMapNodeStar(id: string, data: DocumentData, index: number): MemoryStar {
+  const fallbackPosition = positionForIndex(index);
+  const rawPosition = typeof data.position === "object" && data.position ? data.position as Record<string, unknown> : null;
+  const intensity = numberBetween(data.intensity ?? data.emotionalIntensity ?? data.importanceScore, 0, 1, 0.62);
+  const confidence = numberBetween(data.confidence, 0, 1, 0.72);
+  const recency = timestampToRecency(data.timestamp ?? data.createdAt, numberBetween(data.recency, 0, 1, 0.58));
+  const unresolvedWeight = numberBetween(data.unresolvedWeight ?? data.shadowWeight ?? (data.safetySensitive === true ? 0.82 : 1 - confidence), 0, 1, 0.28);
+  const emotion = normalizeEmotion(data.emotionalTone ?? data.dominantEmotion ?? data.emotion, intensity > 0.82 ? "threshold" : "focus");
+  const chapterId = normalizeChapter(data.chapterId ?? data.categoryId, emotion === "recovery" ? "recovery-arc" : emotion === "dream" ? "purple-dream-field" : emotion === "mirror" ? "mirror-of-becoming" : emotion === "threshold" || emotion === "shadow" ? "threshold" : "season-of-becoming");
+  const x = numberBetween(data.x ?? rawPosition?.x, 20, 80, fallbackPosition.x);
+  const y = numberBetween(data.y ?? rawPosition?.y, 22, 78, fallbackPosition.y);
+  const z = numberBetween(data.z ?? rawPosition?.z, -220, 260, Math.round(intensity * 160));
+  const title = typeof data.title === "string" && data.title.trim() ? data.title : `Memory signal ${index + 1}`;
+  const narratorLine = typeof data.narratorLine === "string" && data.narratorLine.trim()
+    ? data.narratorLine
+    : typeof data.summary === "string" && data.summary.trim()
+      ? data.summary
+      : "This memory has enough signal strength to appear in the Life Map.";
+
+  return {
+    id,
+    title,
+    subtitle: typeof data.subtitle === "string" ? data.subtitle : undefined,
+    x,
+    y,
+    z,
+    size: numberBetween(data.size, 6, 24, 8 + Math.round(intensity * 10)),
+    emotion,
+    chapterId,
+    state: data.resolved === true ? "resolved" : "idle",
+    intensity,
+    recency,
+    unresolvedWeight,
+    lastActivatedAt: null,
+    narratorLine,
+    connectedTo: [
+      ...stringArray(data.connectedTo),
+      ...stringArray(data.relatedNodeIds),
+      ...stringArray(data.relatedStarIds),
+    ],
+    sourceSignalIds: stringArray(data.sourceSignalIds ?? data.sourceEventIds),
+    timestamp: data.timestamp ?? data.createdAt ?? null,
   };
 }
 
@@ -65,11 +178,16 @@ export function useMemoryStars(fallbackStars: MemoryStar[]) {
       return undefined;
     }
 
+    let unsubscribeNodes: (() => void) | null = null;
     let unsubscribeMemories: (() => void) | null = null;
     let unsubscribeAuth: (() => void) | null = null;
 
     try {
       unsubscribeAuth = onAuthStateChanged(auth(), (user) => {
+        if (unsubscribeNodes) {
+          unsubscribeNodes();
+          unsubscribeNodes = null;
+        }
         if (unsubscribeMemories) {
           unsubscribeMemories();
           unsubscribeMemories = null;
@@ -80,6 +198,23 @@ export function useMemoryStars(fallbackStars: MemoryStar[]) {
           return;
         }
 
+        let nodeStars: MemoryStar[] = [];
+        let memoryStars: MemoryStar[] = [];
+        const publish = () => setStars(nodeStars.length ? nodeStars : memoryStars.length ? memoryStars : fallbackStars);
+
+        const nodesQuery = query(collection(db(), "users", user.uid, "lifeMapNodes"), limit(48));
+        unsubscribeNodes = onSnapshot(
+          nodesQuery,
+          (snapshot) => {
+            nodeStars = snapshot.docs.map((docSnap, index) => toLifeMapNodeStar(docSnap.id, docSnap.data(), index));
+            publish();
+          },
+          () => {
+            nodeStars = [];
+            publish();
+          },
+        );
+
         const memoriesQuery = query(
           collection(db(), "users", user.uid, "memories"),
           orderBy("createdAt", "desc"),
@@ -89,13 +224,13 @@ export function useMemoryStars(fallbackStars: MemoryStar[]) {
         unsubscribeMemories = onSnapshot(
           memoriesQuery,
           (snapshot) => {
-            const next = snapshot.docs.map((docSnap, index) =>
-              toMemoryStar(docSnap.id, docSnap.data(), index),
-            );
-
-            setStars(next.length ? next : fallbackStars);
+            memoryStars = snapshot.docs.map((docSnap, index) => toMemoryStar(docSnap.id, docSnap.data(), index));
+            publish();
           },
-          () => setStars(fallbackStars),
+          () => {
+            memoryStars = [];
+            publish();
+          },
         );
       }, () => setStars(fallbackStars));
     } catch {
@@ -104,6 +239,7 @@ export function useMemoryStars(fallbackStars: MemoryStar[]) {
     }
 
     return () => {
+      if (unsubscribeNodes) unsubscribeNodes();
       if (unsubscribeMemories) unsubscribeMemories();
       if (unsubscribeAuth) unsubscribeAuth();
     };


### PR DESCRIPTION
## Summary
- Updates `useMemoryStars` to prefer `users/{uid}/lifeMapNodes` before falling back to the existing `memories` collection.
- Normalizes layered Life Map node fields for chapter IDs, emotions, positions, z-depth, intensity, recency, unresolved weight, linked nodes, and source signals.
- Extends the demo seed with a realistic `lifeMapNodes` subcollection so the immersive Life Map has meaningful layered node data in demo mode.
- Updates the Firestore seeding path to write nested user subcollections when `--firestore` is used.

## Testing
- Not run in this environment; no CI status checks are configured for the previous Life Map commit.