### PR TITLE
Implement demo-ready companion schema spine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,20 @@ tmp/
 test-results/
 playwright-report/
 tsconfig.tsbuildinfo
+*.zip
 
 # Firebase local/debug
 .firebase/
 firebase-debug.log
 firestore-debug.log
+
+# Heavy media assets stay in CDN/storage, not Git
+public/assets/sky/**/*.mp4
+public/assets/ground/**/*.mp4
+public/assets/avatar/**/*.mp4
+public/assets/**/*.mov
+*.mp4
+*.mov
 
 # OS
 .DS_Store

--- a/src/ai/schemas/chat.ts
+++ b/src/ai/schemas/chat.ts
@@ -1,0 +1,78 @@
+export type ChatRole = "system" | "user" | "assistant";
+
+export type ChatMessage = {
+  role: ChatRole;
+  content: string;
+  timestamp?: number;
+  meta?: Record<string, unknown>;
+};
+
+export type CompanionChatOutput = {
+  reply: string;
+  moodTag?: string;
+  insights?: string[];
+};
+
+export function isChatRole(value: unknown): value is ChatRole {
+  return value === "system" || value === "user" || value === "assistant";
+}
+
+export function isChatMessage(value: unknown): value is ChatMessage {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<ChatMessage>;
+  return isChatRole(candidate.role) && typeof candidate.content === "string";
+}
+
+export function normalizeChatMessage(value: unknown): ChatMessage | null {
+  if (!isChatMessage(value)) return null;
+
+  const timestamp = typeof value.timestamp === "number" && Number.isFinite(value.timestamp)
+    ? value.timestamp
+    : undefined;
+
+  const meta = value.meta && typeof value.meta === "object" && !Array.isArray(value.meta)
+    ? value.meta
+    : undefined;
+
+  return {
+    role: value.role,
+    content: value.content.trim().slice(0, 4000),
+    ...(timestamp ? { timestamp } : {}),
+    ...(meta ? { meta } : {}),
+  };
+}
+
+export function normalizeChatHistory(history: unknown, maxMessages = 12): ChatMessage[] {
+  if (!Array.isArray(history)) return [];
+
+  return history
+    .map(normalizeChatMessage)
+    .filter((message): message is ChatMessage => Boolean(message && message.content))
+    .slice(-maxMessages);
+}
+
+export function normalizeCompanionChatOutput(value: unknown): CompanionChatOutput {
+  if (!value || typeof value !== "object") {
+    return { reply: "I am listening. Keep it simple and tell me the next visible step." };
+  }
+
+  const candidate = value as Partial<CompanionChatOutput>;
+  const reply = typeof candidate.reply === "string" && candidate.reply.trim()
+    ? candidate.reply.trim()
+    : "I am listening. Keep it simple and tell me the next visible step.";
+
+  const moodTag = typeof candidate.moodTag === "string" && candidate.moodTag.trim()
+    ? candidate.moodTag.trim()
+    : undefined;
+
+  const insights = Array.isArray(candidate.insights)
+    ? candidate.insights.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).slice(0, 5)
+    : undefined;
+
+  return {
+    reply,
+    ...(moodTag ? { moodTag } : {}),
+    ...(insights?.length ? { insights } : {}),
+  };
+}

--- a/src/components/CompanionChat.tsx
+++ b/src/components/CompanionChat.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import type { CompanionChatOutput } from "@/lib/urai-v1-schemas";
+import type { CompanionChatOutput } from "@/ai/schemas/chat";
 
 const suggestedPrompts = [
   "Explain this mood",
   "What should I protect?",
-  "What pattern is repeating?"
+  "What pattern is repeating?",
 ];
 
 export default function CompanionChat() {
@@ -33,7 +33,7 @@ export default function CompanionChat() {
       const response = await fetch("/api/companion", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ history: [], message: trimmedMessage })
+        body: JSON.stringify({ history: [], message: trimmedMessage }),
       });
 
       if (!response.ok) {
@@ -113,7 +113,14 @@ export default function CompanionChat() {
       {reply && (
         <div id="companion-reply" className="mt-4 rounded-2xl border border-white/10 bg-white/[0.07] p-3" aria-live="polite">
           <p className="text-sm leading-6 text-white/90">{reply.reply}</p>
-          <p className="mt-2 text-xs uppercase tracking-[0.2em] text-white/50">Mood tag · {reply.moodTag}</p>
+          {reply.moodTag && <p className="mt-2 text-xs uppercase tracking-[0.2em] text-white/50">Mood tag · {reply.moodTag}</p>}
+          {reply.insights?.length ? (
+            <ul className="mt-3 space-y-1 text-xs text-white/60">
+              {reply.insights.map((insight) => (
+                <li key={insight}>• {insight}</li>
+              ))}
+            </ul>
+          ) : null}
         </div>
       )}
     </section>

--- a/src/lib/companion-engine.ts
+++ b/src/lib/companion-engine.ts
@@ -1,4 +1,8 @@
-import { isChatMessage, type ChatMessage, type CompanionChatOutput } from "@/lib/urai-v1-schemas";
+import {
+  normalizeChatHistory,
+  type ChatMessage,
+  type CompanionChatOutput,
+} from "@/ai/schemas/chat";
 
 export type CompanionRequestBody = {
   history?: unknown;
@@ -6,8 +10,7 @@ export type CompanionRequestBody = {
 };
 
 export function normalizeCompanionHistory(history: unknown): ChatMessage[] {
-  if (!Array.isArray(history)) return [];
-  return history.filter(isChatMessage).slice(-12);
+  return normalizeChatHistory(history, 12);
 }
 
 export function normalizeCompanionMessage(message: unknown): string {
@@ -25,7 +28,7 @@ export function buildCompanionReply(message: string, history: ChatMessage[] = []
       reply:
         "I hear the weight in that. Make the next step small enough to move: name the one thing that would make today feel less tangled, then build from there.",
       moodTag: "tender",
-      insights: ["Reduce scope before adding pressure.", "Use one visible next action as the recovery anchor."]
+      insights: ["Reduce scope before adding pressure.", "Use one visible next action as the recovery anchor."],
     };
   }
 
@@ -34,7 +37,7 @@ export function buildCompanionReply(message: string, history: ChatMessage[] = []
       reply:
         "Good. This is build energy. Keep it narrow: one route, one schema, one visible user moment. The constellation becomes real when someone can open it and feel it.",
       moodTag: "focused",
-      insights: ["Implementation energy is rising.", "Ship the demo spine before expanding the symbolic layer."]
+      insights: ["Implementation energy is rising.", "Ship the demo spine before expanding the symbolic layer."],
     };
   }
 
@@ -43,7 +46,7 @@ export function buildCompanionReply(message: string, history: ChatMessage[] = []
       reply:
         "The vision is strong. Anchor it to one proof point: a person opens URAI, recognizes a pattern, and joins the waitlist because it feels personal.",
       moodTag: "threshold",
-      insights: ["Translate vision into proof.", "A demo loop is stronger than another abstract layer."]
+      insights: ["Translate vision into proof.", "A demo loop is stronger than another abstract layer."],
     };
   }
 
@@ -53,6 +56,6 @@ export function buildCompanionReply(message: string, history: ChatMessage[] = []
         ? "I am still with you. The pattern I see is continuity: keep turning the idea into something visible, one calm layer at a time."
         : "I am listening. Start with what feels most alive right now, and I will help turn it into a clear next step.",
     moodTag: "calm",
-    insights: ["Calm focus is the default state for this session.", "The next best move is one concrete implementation step."]
+    insights: ["Calm focus is the default state for this session.", "The next best move is one concrete implementation step."],
   };
 }


### PR DESCRIPTION
## What changed

- Added centralized companion chat schema utilities at `src/ai/schemas/chat.ts`.
- Routed the companion engine through the shared schema normalizers.
- Updated the CompanionChat UI to consume the shared output type and render insights safely.
- Expanded `.gitignore` to keep heavyweight generated media/assets out of Git.

## Why

This implements the safest repo-wide spine from the existing `.copilot-instructions.md` without blasting `main`: shared message contracts, a stable companion response surface, and demo-friendly asset hygiene.

## Notes

The repo already had major parts of the requested demo path implemented before this branch: public `/u/[handle]` constellation, companion API route, demo data, home scene, and CI. This PR tightens the missing connective layer rather than duplicating those systems.

## Validation

Not run locally in this environment. CI should run `typecheck`, lint, tests, and build on PR.