### PR TITLE
Integrate cohesive cinematic URAI home and Memory Galaxy redesign

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,7 +1,9 @@
-import HomeScene from "@/components/HomeScene";
+import { HomeScene } from "@/components/urai/home/HomeScene";
 
 export const metadata = {
-  description: "URAI companion shell with WebGL sky, narrator, aura, early access, and Life Map preview.",
+  title: "URAI Inner Sky Shrine",
+  description:
+    "The cinematic URAI home shrine: orb, avatar, symbolic ground, ascent transition, and Memory Galaxy gateway.",
 };
 
 export default function HomePage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import './lifemap-polish.css';
+import '../styles/urai-cinematic.css';
 import React from 'react';
 import AppProviders from './providers';
 import type { Metadata } from 'next';

--- a/src/app/life-map/page.tsx
+++ b/src/app/life-map/page.tsx
@@ -1,11 +1,11 @@
-import FullLifeMapScene from "@/components/lifemap/FullLifeMapScene";
+import { LifeMapPage } from "@/components/urai/life-map/LifeMapPage";
 
 export const metadata = {
-  title: "URAI Life Map",
+  title: "URAI Memory Galaxy",
   description:
-    "The full URAI Life Map: passive memory stars, symbolic constellations, narrator insights, rituals, recovery arcs, relationship orbits, and scroll exports.",
+    "The cinematic URAI Memory Galaxy: zoomable life map, selected-star memory portals, replay, mirror, recenter, and narrator insight.",
 };
 
-export default function LifeMapPage() {
-  return <FullLifeMapScene />;
+export default function Page() {
+  return <LifeMapPage />;
 }

--- a/src/components/urai/home/HomeScene.tsx
+++ b/src/components/urai/home/HomeScene.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+
+type AscentPhase = "idle" | "ignition" | "lift" | "portal" | "emergence" | "settle";
+
+const cinematicEase = [0.16, 1, 0.3, 1] as const;
+const softEase = [0.22, 0.86, 0.18, 1] as const;
+
+function useReducedMotionSafe() {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setReduced(mq.matches);
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+
+  return reduced;
+}
+
+function StarParticleField({ density = 1, className = "" }: { density?: number; className?: string }) {
+  const reduced = useReducedMotionSafe();
+  const stars = useMemo(() => {
+    const count = reduced ? Math.round(36 * density) : Math.round(110 * density);
+    return Array.from({ length: count }, (_, index) => ({
+      id: index,
+      x: (index * 73) % 100,
+      y: (index * 41) % 100,
+      size: 1 + ((index * 17) % 28) / 18,
+      delay: ((index * 11) % 40) / 10,
+      opacity: 0.18 + ((index * 19) % 62) / 100,
+    }));
+  }, [density, reduced]);
+
+  return (
+    <div className={`urai-star-field ${className}`} aria-hidden>
+      {stars.map((star) => (
+        <span
+          key={star.id}
+          style={{
+            left: `${star.x}%`,
+            top: `${star.y}%`,
+            width: star.size,
+            height: star.size,
+            opacity: star.opacity,
+            animationDelay: `${star.delay}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AvatarSilhouette({ phase }: { phase: AscentPhase }) {
+  return (
+    <motion.div
+      className="urai-avatar-wrap"
+      animate={
+        phase === "portal"
+          ? { y: "22vh", opacity: 0.08, filter: "blur(10px)" }
+          : phase === "lift"
+            ? { y: "5vh", opacity: 0.72, filter: "blur(0px)" }
+            : { y: "0vh", opacity: 1, filter: "blur(0px)" }
+      }
+      transition={{ duration: 0.5, ease: cinematicEase }}
+      aria-hidden
+    >
+      <div className="urai-avatar-aura" />
+      <svg className="urai-avatar-silhouette" viewBox="0 0 260 420" role="img" aria-label="URAI symbolic avatar silhouette">
+        <defs>
+          <linearGradient id="uraiAvatarGradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0" stopColor="#bffaff" stopOpacity="0.28" />
+            <stop offset="0.46" stopColor="#4ee8f2" stopOpacity="0.21" />
+            <stop offset="1" stopColor="#4e6caa" stopOpacity="0" />
+          </linearGradient>
+          <filter id="softAvatarGlow">
+            <feGaussianBlur stdDeviation="7" result="blur" />
+            <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+        </defs>
+        <path d="M130 18 C82 58 68 124 84 190 C93 229 112 248 92 306 C78 346 88 391 130 412 C172 391 182 346 168 306 C148 248 167 229 176 190 C192 124 178 58 130 18Z" fill="url(#uraiAvatarGradient)" filter="url(#softAvatarGlow)" />
+        <path d="M130 44 C104 82 100 134 112 184 C119 214 132 234 122 282" fill="none" stroke="rgba(218,250,255,.22)" strokeWidth="1.6" strokeLinecap="round" />
+        <circle cx="130" cy="172" r="7" fill="rgba(225,255,255,.38)" />
+      </svg>
+    </motion.div>
+  );
+}
+
+function GroundSystem({ phase }: { phase: AscentPhase }) {
+  return (
+    <motion.div
+      className="urai-ground-system"
+      animate={
+        phase === "portal"
+          ? { y: "28vh", opacity: 0.2, filter: "blur(8px)" }
+          : phase === "lift"
+            ? { y: "8vh", opacity: 1, filter: "blur(0px)" }
+            : { y: "0vh", opacity: 1, filter: "blur(0px)" }
+      }
+      transition={{ duration: 0.5, ease: cinematicEase }}
+      aria-hidden
+    >
+      <div className="urai-horizon-mist" />
+      <div className="urai-ground-back" />
+      <div className="urai-ground-mid" />
+      <div className="urai-ground-light-spill" />
+      <div className="urai-ground-front" />
+      <div className="urai-foreground-fog" />
+    </motion.div>
+  );
+}
+
+function MemoryOrb({ phase }: { phase: AscentPhase }) {
+  return (
+    <motion.div
+      className="urai-memory-orb-wrap"
+      animate={
+        phase === "portal"
+          ? { y: "-4vh", scale: 8.5, opacity: 0.92 }
+          : phase === "lift"
+            ? { y: "-4vh", scale: 1.18, opacity: 1 }
+            : phase === "ignition"
+              ? { y: "0vh", scale: 1.08, opacity: 1 }
+              : { y: "0vh", scale: 1, opacity: 1 }
+      }
+      transition={{ duration: phase === "portal" ? 0.5 : 0.42, ease: cinematicEase }}
+      aria-hidden
+    >
+      <div className="urai-orb-beam" />
+      <div className="urai-orb-halo" />
+      <div className="urai-orb-ring urai-orb-ring-one" />
+      <div className="urai-orb-ring urai-orb-ring-two" />
+      <div className="urai-orb-core"><span className="urai-orb-highlight" /><span className="urai-orb-shadow" /></div>
+      <div className="urai-orb-spark" />
+    </motion.div>
+  );
+}
+
+export function HomeScene() {
+  const router = useRouter();
+  const reduced = useReducedMotionSafe();
+  const [phase, setPhase] = useState<AscentPhase>("idle");
+
+  const beginAscent = () => {
+    if (phase !== "idle") return;
+    if (reduced) {
+      router.push("/life-map");
+      return;
+    }
+    setPhase("ignition");
+    window.setTimeout(() => setPhase("lift"), 220);
+    window.setTimeout(() => setPhase("portal"), 620);
+    window.setTimeout(() => setPhase("emergence"), 1120);
+    window.setTimeout(() => setPhase("settle"), 1650);
+    window.setTimeout(() => router.push("/life-map"), 2100);
+  };
+
+  const inTransition = phase !== "idle";
+
+  return (
+    <main className={`urai-screen urai-home-screen phase-${phase}`} onClick={beginAscent}>
+      <button className="urai-fullscreen-button" aria-label="Enter Memory Galaxy" disabled={inTransition} />
+      <motion.div className="urai-home-camera" animate={{ scale: phase === "ignition" ? 1.025 : 1 }} transition={{ duration: 0.22, ease: softEase }}>
+        <div className="urai-cosmic-sky" aria-hidden>
+          <div className="urai-sky-gradient" />
+          <StarParticleField density={0.88} className="urai-stars-far" />
+          <StarParticleField density={0.32} className="urai-stars-near" />
+          <div className="urai-sky-vignette" />
+        </div>
+        <motion.div className="urai-nebula-layer" animate={{ opacity: phase === "portal" ? 0.9 : 0.62, y: phase === "lift" ? -18 : 0 }} transition={{ duration: 0.8, ease: softEase }} aria-hidden>
+          <div className="urai-nebula urai-nebula-cyan" />
+          <div className="urai-nebula urai-nebula-violet" />
+          <div className="urai-nebula urai-nebula-gold" />
+        </motion.div>
+        <GroundSystem phase={phase} />
+        <AvatarSilhouette phase={phase} />
+        <MemoryOrb phase={phase} />
+      </motion.div>
+      <motion.div className="urai-ascent-bloom" animate={{ opacity: phase === "portal" ? 0.86 : phase === "emergence" ? 0.34 : 0 }} transition={{ duration: 0.5, ease: cinematicEase }} aria-hidden />
+      <motion.div className="urai-star-emergence" animate={{ opacity: phase === "emergence" || phase === "settle" ? 1 : 0, scale: phase === "emergence" ? 1 : 0.92 }} transition={{ duration: 0.54, ease: cinematicEase }} aria-hidden />
+      <div className="urai-home-label" aria-hidden>
+        <span>URAI</span>
+        <strong>Inner Sky Shrine</strong>
+        <em>Tap the sky to enter memory</em>
+      </div>
+    </main>
+  );
+}

--- a/src/components/urai/life-map/LifeMapPage.tsx
+++ b/src/components/urai/life-map/LifeMapPage.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+type MemoryCategory = "becoming" | "threshold" | "recovery" | "relationship" | "dream" | "mirror";
+type PrivacyState = "private" | "local" | "shareable";
+
+interface MemoryStar {
+  id: string;
+  title: string;
+  subtitle: string;
+  category: MemoryCategory;
+  x: number;
+  y: number;
+  z: number;
+  magnitude: number;
+  confidence: number;
+  privacy: PrivacyState;
+  narratorText: string;
+  dateLabel: string;
+  signalCount: number;
+  threadIds: string[];
+  memoryImageUrl?: string;
+  symbolicImageUrl?: string;
+}
+
+const cinematicEase = [0.16, 1, 0.3, 1] as const;
+
+const PALETTE: Record<MemoryCategory, { label: string; core: string; halo: string; nebula: string; border: string }> = {
+  becoming: { label: "Becoming", core: "#9BE7FF", halo: "rgba(155,231,255,.58)", nebula: "rgba(90,210,255,.13)", border: "rgba(155,231,255,.38)" },
+  threshold: { label: "Threshold", core: "#C7A0FF", halo: "rgba(199,160,255,.58)", nebula: "rgba(140,90,255,.14)", border: "rgba(199,160,255,.38)" },
+  recovery: { label: "Recovery", core: "#B8FFD8", halo: "rgba(184,255,216,.56)", nebula: "rgba(80,255,170,.13)", border: "rgba(184,255,216,.36)" },
+  relationship: { label: "Relationships", core: "#FFB7D6", halo: "rgba(255,183,214,.53)", nebula: "rgba(255,110,180,.13)", border: "rgba(255,183,214,.34)" },
+  dream: { label: "Dream Field", core: "#FFE58A", halo: "rgba(255,229,138,.52)", nebula: "rgba(255,202,70,.13)", border: "rgba(255,229,138,.34)" },
+  mirror: { label: "Mirror", core: "#E8F2FF", halo: "rgba(232,242,255,.55)", nebula: "rgba(190,220,255,.11)", border: "rgba(232,242,255,.32)" },
+};
+
+const MEMORY_STARS: MemoryStar[] = [
+  { id: "blue-fog-memory", title: "Blue Fog Memory", subtitle: "quiet grief marker", category: "threshold", x: -310, y: -18, z: 0.44, magnitude: 1.18, confidence: 72, privacy: "private", narratorText: "A soft weather system formed around this moment. URAI marked it as grief, but not collapse.", dateLabel: "Winter thread · inferred", signalCount: 4, threadIds: ["winter-threshold", "soft-recovery"] },
+  { id: "protected-hour", title: "Protected Hour", subtitle: "became returned", category: "becoming", x: 76, y: -94, z: 0.8, magnitude: 1.34, confidence: 70, privacy: "local", narratorText: "A protected hour became a small doorway back into clarity.", dateLabel: "Today · focus signal", signalCount: 1, threadIds: ["clarity-thread", "winter-threshold"] },
+  { id: "morning-return", title: "Morning Return", subtitle: "body rhythm stabilized", category: "recovery", x: 218, y: -62, z: 0.68, magnitude: 1.08, confidence: 81, privacy: "local", narratorText: "Your rhythm steadied here; URAI saw recovery as an ordinary morning, not a performance.", dateLabel: "Recent week", signalCount: 5, threadIds: ["soft-recovery"] },
+  { id: "relationship-spark", title: "Warm Thread", subtitle: "contact felt safe", category: "relationship", x: 308, y: 30, z: 0.58, magnitude: 0.92, confidence: 64, privacy: "private", narratorText: "A familiar signal softened the field. The relationship thread brightened without demanding action.", dateLabel: "Social echo", signalCount: 3, threadIds: ["social-orbit"] },
+  { id: "dream-door", title: "Dream Door", subtitle: "symbolic image surfaced", category: "dream", x: -92, y: 104, z: 0.52, magnitude: 0.88, confidence: 58, privacy: "private", narratorText: "A dream symbol repeated. URAI preserved it as image-language, not a conclusion.", dateLabel: "Night field", signalCount: 2, threadIds: ["dream-field"] },
+  { id: "mirror-line", title: "Mirror Line", subtitle: "pattern reflected back", category: "mirror", x: 4, y: -12, z: 0.95, magnitude: 1.42, confidence: 88, privacy: "local", narratorText: "This is a mirror moment: not a diagnosis, just a pattern with enough signal to deserve tenderness.", dateLabel: "Pattern index", signalCount: 7, threadIds: ["clarity-thread", "social-orbit", "dream-field"] },
+  { id: "golden-pause", title: "Golden Pause", subtitle: "nervous system exhaled", category: "recovery", x: 176, y: 116, z: 0.5, magnitude: 0.82, confidence: 76, privacy: "shareable", narratorText: "The field became less sharp. URAI marked a small restoration bloom.", dateLabel: "Recovery arc", signalCount: 4, threadIds: ["soft-recovery"] },
+  { id: "threshold-flare", title: "Threshold Flare", subtitle: "transition pressure rose", category: "threshold", x: -42, y: -142, z: 0.72, magnitude: 1.05, confidence: 69, privacy: "private", narratorText: "A threshold appeared as pressure, not failure. URAI kept the context around it.", dateLabel: "Life shift", signalCount: 6, threadIds: ["winter-threshold"] },
+  { id: "soft-laugh", title: "Soft Laugh", subtitle: "relational weather cleared", category: "relationship", x: 382, y: -82, z: 0.4, magnitude: 0.72, confidence: 61, privacy: "shareable", narratorText: "A small laugh changed the social weather more than the transcript alone could show.", dateLabel: "Ambient social", signalCount: 2, threadIds: ["social-orbit"] },
+  { id: "future-self", title: "Future Self", subtitle: "becoming thread strengthened", category: "becoming", x: -178, y: 86, z: 0.62, magnitude: 1.0, confidence: 79, privacy: "local", narratorText: "A becoming thread strengthened. URAI marked this as direction without forcing a plan.", dateLabel: "Purpose signal", signalCount: 5, threadIds: ["clarity-thread"] },
+];
+
+const THREADS = [
+  ["blue-fog-memory", "threshold-flare", "mirror-line", "protected-hour"],
+  ["blue-fog-memory", "dream-door", "golden-pause", "morning-return"],
+  ["mirror-line", "relationship-spark", "soft-laugh"],
+  ["future-self", "mirror-line", "protected-hour", "morning-return"],
+];
+
+function useReducedMotionSafe() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setReduced(mq.matches);
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+  return reduced;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function fallbackStyle(star: MemoryStar) {
+  const palette = PALETTE[star.category];
+  return {
+    background:
+      `radial-gradient(circle at 38% 32%, rgba(255,255,255,.72), transparent 7%), ` +
+      `radial-gradient(circle at 50% 48%, ${palette.halo}, transparent 32%), ` +
+      `radial-gradient(circle at 50% 80%, ${palette.nebula}, transparent 44%), ` +
+      `linear-gradient(145deg, rgba(3,10,25,.88), rgba(8,20,45,.62))`,
+  };
+}
+
+function GalaxyParticles() {
+  const reduced = useReducedMotionSafe();
+  const stars = useMemo(() => {
+    const count = reduced ? 70 : 180;
+    return Array.from({ length: count }, (_, index) => ({
+      id: index,
+      x: (index * 83) % 100,
+      y: (index * 47) % 100,
+      size: 0.7 + ((index * 13) % 26) / 15,
+      opacity: 0.14 + ((index * 17) % 72) / 100,
+      delay: ((index * 7) % 50) / 10,
+    }));
+  }, [reduced]);
+
+  return (
+    <div className="urai-galaxy-particles" aria-hidden>
+      {stars.map((star) => <span key={star.id} style={{ left: `${star.x}%`, top: `${star.y}%`, width: star.size, height: star.size, opacity: star.opacity, animationDelay: `${star.delay}s` }} />)}
+    </div>
+  );
+}
+
+export function LifeMapPage() {
+  const [activeCategory, setActiveCategory] = useState<MemoryCategory | "all">("all");
+  const [selectedId, setSelectedId] = useState<string | null>("blue-fog-memory");
+  const [camera, setCamera] = useState({ x: 0, y: 0, scale: 1 });
+  const [dragging, setDragging] = useState(false);
+  const [mode, setMode] = useState<"default" | "replay" | "mirror">("default");
+  const drag = useRef({ x: 0, y: 0, cameraX: 0, cameraY: 0 });
+  const selected = MEMORY_STARS.find((star) => star.id === selectedId) ?? null;
+
+  const relatedIds = useMemo(() => {
+    if (!selected) return new Set<string>();
+    const ids = new Set<string>([selected.id]);
+    selected.threadIds.forEach((threadId) => MEMORY_STARS.filter((star) => star.threadIds.includes(threadId)).forEach((star) => ids.add(star.id)));
+    return ids;
+  }, [selected]);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setSelectedId(null);
+      if (event.key.toLowerCase() === "r") setCamera({ x: 0, y: 0, scale: 1 });
+      if (event.key === "+" || event.key === "=") setCamera((c) => ({ ...c, scale: clamp(c.scale + 0.15, 0.62, 2.85) }));
+      if (event.key === "-") setCamera((c) => ({ ...c, scale: clamp(c.scale - 0.15, 0.62, 2.85) }));
+      if (event.key === "ArrowLeft") setCamera((c) => ({ ...c, x: c.x + 36 }));
+      if (event.key === "ArrowRight") setCamera((c) => ({ ...c, x: c.x - 36 }));
+      if (event.key === "ArrowUp") setCamera((c) => ({ ...c, y: c.y + 36 }));
+      if (event.key === "ArrowDown") setCamera((c) => ({ ...c, y: c.y - 36 }));
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const zoom = (delta: number) => setCamera((c) => ({ ...c, scale: clamp(c.scale - delta * 0.0012, 0.62, 2.85) }));
+  const recenter = () => setCamera({ x: 0, y: 0, scale: 1 });
+  const replay = () => {
+    setMode("replay");
+    let i = 0;
+    const sequence = ["blue-fog-memory", "threshold-flare", "mirror-line", "protected-hour", "morning-return"];
+    const timer = window.setInterval(() => {
+      const id = sequence[i % sequence.length];
+      const star = MEMORY_STARS.find((item) => item.id === id);
+      if (star) {
+        setSelectedId(star.id);
+        setCamera({ x: -star.x * 0.22, y: -star.y * 0.22, scale: 1.28 });
+      }
+      i += 1;
+      if (i > sequence.length) {
+        window.clearInterval(timer);
+        setMode("default");
+      }
+    }, 960);
+  };
+
+  return (
+    <main className={`urai-screen urai-life-map-screen ${mode === "mirror" ? "is-mirror-mode" : ""} ${selected ? "has-selected-star" : ""}`}>
+      <GalaxyParticles />
+      <div className="urai-galaxy-bg" aria-hidden><div className="urai-galaxy-core" /><div className="urai-galaxy-band" /></div>
+      <header className="urai-life-title"><span>URAI LIFE MAP</span><strong>Memory Galaxy</strong><em>{MEMORY_STARS.length} Memory Stars · {THREADS.length} Timeline Constellations · {mode}</em></header>
+      <section
+        className="urai-galaxy-viewport"
+        onWheel={(event) => { event.preventDefault(); zoom(event.deltaY); }}
+        onPointerDown={(event) => { setDragging(true); drag.current = { x: event.clientX, y: event.clientY, cameraX: camera.x, cameraY: camera.y }; }}
+        onPointerMove={(event) => { if (!dragging) return; setCamera((c) => ({ ...c, x: drag.current.cameraX + event.clientX - drag.current.x, y: drag.current.cameraY + event.clientY - drag.current.y })); }}
+        onPointerUp={() => setDragging(false)}
+        onPointerCancel={() => setDragging(false)}
+      >
+        <motion.div className="urai-galaxy-camera" animate={{ x: camera.x, y: camera.y, scale: camera.scale }} transition={{ duration: dragging ? 0 : 0.42, ease: cinematicEase }}>
+          <div className="urai-galaxy-world">
+            <div className="urai-nebula-zones" aria-hidden>
+              {Object.entries(PALETTE).map(([category, palette], index) => (
+                <div key={category} className="urai-galaxy-nebula-zone" style={{ left: `${18 + index * 13}%`, top: `${30 + (index % 3) * 16}%`, width: `${42 + (index % 2) * 18}%`, height: `${22 + (index % 3) * 5}%`, transform: `translate(-50%, -50%) rotate(${index % 2 ? 14 : -14}deg)`, background: `radial-gradient(ellipse at center, ${palette.nebula}, transparent 68%)`, opacity: activeCategory === "all" || activeCategory === category ? 1 : 0.24 }} />
+              ))}
+            </div>
+            <svg className="urai-orbit-rings" viewBox="-600 -360 1200 720" aria-hidden>
+              {[1, 2, 3, 4].map((ring) => <ellipse key={ring} cx="0" cy="0" rx={220 + ring * 86} ry={70 + ring * 32} transform={`rotate(${ring % 2 ? -14 : 16})`} fill="none" stroke="rgba(155,231,255,.18)" strokeWidth={ring === 3 ? 1.4 : 0.9} strokeDasharray={ring % 2 ? "12 18" : ""} />)}
+              {mode === "mirror" && <line x1="0" x2="0" y1="-310" y2="310" stroke="rgba(232,242,255,.2)" />}
+            </svg>
+            <svg className="urai-thread-layer" viewBox="-600 -360 1200 720" aria-hidden>
+              {THREADS.map((thread, index) => thread.slice(1).map((id, pointIndex) => {
+                const from = MEMORY_STARS.find((star) => star.id === thread[pointIndex]);
+                const to = MEMORY_STARS.find((star) => star.id === id);
+                if (!from || !to) return null;
+                const active = selected ? relatedIds.has(from.id) && relatedIds.has(to.id) : true;
+                return <line key={`${index}-${id}`} x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke={active ? "rgba(155,231,255,.48)" : "rgba(155,231,255,.12)"} strokeWidth={active ? 1.2 : 0.6} />;
+              }))}
+            </svg>
+            <div className="urai-memory-star-layer">
+              {MEMORY_STARS.map((star) => {
+                const palette = PALETTE[star.category];
+                const selectedStar = star.id === selectedId;
+                const filteredOut = activeCategory !== "all" && star.category !== activeCategory;
+                return (
+                  <motion.button
+                    key={star.id}
+                    className={`urai-memory-star ${selectedStar ? "is-selected" : ""} ${selected && !relatedIds.has(star.id) ? "is-dimmed" : ""} ${filteredOut ? "is-filtered-out" : ""}`}
+                    style={{ left: `calc(50% + ${star.x}px)`, top: `calc(50% + ${star.y}px)`, zIndex: Math.round(20 + star.z * 20) }}
+                    onClick={(event) => { event.stopPropagation(); setSelectedId(star.id); }}
+                    whileHover={{ scale: 1.18 }}
+                    animate={{ scale: selectedStar ? 1.18 : 1, opacity: filteredOut ? 0.18 : 1 }}
+                    transition={{ duration: 0.22 }}
+                    aria-label={`Open ${star.title}`}
+                  >
+                    <span className="urai-star-halo" style={{ background: `radial-gradient(circle, ${palette.halo}, transparent 70%)` }} />
+                    <span className="urai-star-core" style={{ background: palette.core, boxShadow: `0 0 ${18 + star.magnitude * 10}px ${palette.halo}` }} />
+                    <span className="urai-star-label"><strong>{star.title}</strong><em>{star.subtitle}</em></span>
+                  </motion.button>
+                );
+              })}
+            </div>
+            <AnimatePresence>
+              {selected && (
+                <motion.div className="urai-selected-star-focus" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                  <button className="urai-focus-scrim" onClick={() => setSelectedId(null)} aria-label="Close memory focus" />
+                  <motion.div className="urai-memory-portal-anchor" style={{ left: `calc(50% + ${selected.x}px)`, top: `calc(50% + ${selected.y}px)` }} initial={{ scale: 0.18, opacity: 0, x: "-50%", y: "-50%" }} animate={{ scale: 1, opacity: 1, x: "-50%", y: "-50%" }} exit={{ scale: 0.28, opacity: 0, x: "-50%", y: "-50%" }} transition={{ duration: 0.52, ease: cinematicEase }}>
+                    <div className="urai-portal-thread-tether" />
+                    <div className="urai-memory-portal" style={{ borderColor: PALETTE[selected.category].border }}>
+                      <div className="urai-portal-image" style={selected.memoryImageUrl || selected.symbolicImageUrl ? { backgroundImage: `url(${selected.memoryImageUrl ?? selected.symbolicImageUrl})` } : fallbackStyle(selected)} />
+                      <div className="urai-portal-ring" />
+                      <div className="urai-confidence-ring" style={{ background: `conic-gradient(${PALETTE[selected.category].core} ${selected.confidence * 3.6}deg, rgba(255,255,255,.08) 0deg)` }} />
+                    </div>
+                  </motion.div>
+                  <motion.aside className="urai-memory-detail glass-panel" initial={{ opacity: 0, y: 14, scale: 0.97 }} animate={{ opacity: 1, y: 0, scale: 1 }} exit={{ opacity: 0, y: 8, scale: 0.96 }} transition={{ duration: 0.34, delay: 0.2, ease: cinematicEase }}>
+                    <div className="urai-detail-kicker">{PALETTE[selected.category].label} · {selected.dateLabel}</div>
+                    <h2>{selected.title}</h2>
+                    <p>{selected.narratorText}</p>
+                    <div className="urai-detail-meta"><span>Confidence {selected.confidence}%</span><span>{selected.signalCount} passive signals</span><span>{selected.privacy}</span></div>
+                    {mode === "mirror" && <div className="urai-mirror-note">What this reflects: this memory is acting as a pattern mirror, not a diagnosis.</div>}
+                    <div className="urai-detail-actions"><button onClick={replay}>Replay</button><button onClick={() => setMode(mode === "mirror" ? "default" : "mirror")}>Mirror</button><button>Recount</button><button>Create Ritual</button><button>Private</button></div>
+                  </motion.aside>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </motion.div>
+      </section>
+      <aside className="urai-companion-card glass-panel"><span>COMPANION</span><p>{selected ? `This memory carries ${PALETTE[selected.category].label.toLowerCase()} weight, so URAI rendered it softly.` : "Narration ready."}</p><em>Narration ready.</em></aside>
+      <div className="urai-galaxy-actions glass-panel"><button onClick={() => setSelectedId(null)}>Hide thread</button><button onClick={replay}>Replay</button><button>Create scroll</button><button onClick={() => setMode(mode === "mirror" ? "default" : "mirror")}>Mirror</button><button onClick={recenter}>Recenter</button></div>
+      <nav className="urai-category-dock glass-panel" aria-label="Memory filters"><button className={activeCategory === "all" ? "is-active" : ""} onClick={() => setActiveCategory("all")}>All</button>{(Object.keys(PALETTE) as MemoryCategory[]).map((category) => <button key={category} className={activeCategory === category ? "is-active" : ""} onClick={() => setActiveCategory(category)}>{PALETTE[category].label}</button>)}</nav>
+      <div className="urai-zoom-minimap glass-panel"><span>Zoom</span><strong>{Math.round(camera.scale * 100)}%</strong><em>x {Math.round(camera.x)} · y {Math.round(camera.y)}</em></div>
+    </main>
+  );
+}

--- a/src/styles/urai-cinematic.css
+++ b/src/styles/urai-cinematic.css
@@ -1,0 +1,166 @@
+:root {
+  --urai-bg-a: #020713;
+  --urai-bg-b: #061426;
+  --urai-bg-c: #01040a;
+  --urai-cyan: #9BE7FF;
+  --urai-teal: #4EE8F2;
+  --urai-gold: #FFE58A;
+  --urai-violet: #C7A0FF;
+  --urai-recovery: #B8FFD8;
+  --urai-relationship: #FFB7D6;
+  --cinematic-ease: cubic-bezier(.16,1,.3,1);
+}
+
+.urai-screen {
+  position: relative;
+  min-height: 100svh;
+  width: 100%;
+  overflow: hidden;
+  color: rgba(239, 250, 255, .96);
+  background: var(--urai-bg-c);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  user-select: none;
+  touch-action: none;
+}
+
+.glass-panel {
+  background: linear-gradient(180deg, rgba(8,17,34,.74), rgba(4,8,18,.58));
+  border: 1px solid rgba(185,230,255,.16);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.08), 0 18px 70px rgba(0,0,0,.42), 0 0 42px rgba(95,220,255,.08);
+  backdrop-filter: blur(18px);
+}
+
+.urai-fullscreen-button { position:absolute; inset:0; opacity:0; z-index:30; cursor:pointer; }
+.urai-home-camera { position:absolute; inset:0; transform-origin:50% 42%; }
+.urai-cosmic-sky, .urai-sky-gradient, .urai-nebula-layer, .urai-ground-system, .urai-avatar-wrap, .urai-memory-orb-wrap { position:absolute; inset:0; }
+.urai-sky-gradient {
+  background:
+    radial-gradient(circle at 50% 35%, rgba(78,232,242,.13), transparent 23%),
+    radial-gradient(circle at 62% 48%, rgba(255,210,105,.07), transparent 24%),
+    radial-gradient(circle at 38% 52%, rgba(199,160,255,.08), transparent 30%),
+    linear-gradient(180deg, #020713 0%, #061426 44%, #020610 100%);
+}
+.urai-sky-vignette { position:absolute; inset:0; background:radial-gradient(ellipse at center, transparent 30%, rgba(0,0,0,.56) 88%); }
+.urai-star-field { position:absolute; inset:0; overflow:hidden; }
+.urai-star-field span, .urai-galaxy-particles span { position:absolute; border-radius:999px; background:#fff; box-shadow:0 0 10px rgba(255,255,255,.8), 0 0 24px rgba(155,231,255,.38); animation:uraiStarTwinkle 4.8s ease-in-out infinite; }
+.urai-stars-far { opacity:.72; }
+.urai-stars-near { opacity:.92; transform:scale(1.04); filter:blur(.2px); }
+.urai-nebula-layer { z-index:4; pointer-events:none; mix-blend-mode:screen; }
+.urai-nebula { position:absolute; border-radius:999px; filter:blur(34px); opacity:.72; }
+.urai-nebula-cyan { left:30%; top:35%; width:36%; height:26%; background:rgba(78,232,242,.12); }
+.urai-nebula-violet { right:16%; top:30%; width:30%; height:32%; background:rgba(199,160,255,.09); }
+.urai-nebula-gold { right:24%; bottom:20%; width:26%; height:18%; background:rgba(255,229,138,.1); }
+
+.urai-ground-system { z-index:8; top:50%; pointer-events:none; transform-origin:50% 70%; }
+.urai-horizon-mist { position:absolute; left:14%; right:14%; top:9%; height:120px; background:radial-gradient(ellipse at center, rgba(96,219,225,.16), transparent 68%); filter:blur(24px); }
+.urai-horizon-mist::after { content:""; position:absolute; left:8%; right:8%; top:49%; height:1px; background:linear-gradient(90deg, transparent, rgba(174,235,255,.28), transparent); filter:blur(.3px); }
+.urai-ground-back, .urai-ground-mid, .urai-ground-front, .urai-ground-light-spill, .urai-foreground-fog { position:absolute; left:-10%; right:-10%; bottom:0; }
+.urai-ground-back { height:48%; clip-path:polygon(0 58%, 13% 43%, 24% 49%, 35% 31%, 45% 36%, 54% 18%, 64% 35%, 77% 21%, 88% 44%, 100% 35%, 100% 100%, 0 100%); background:linear-gradient(180deg, rgba(30,54,110,.42), rgba(3,8,22,.82)); filter:blur(.2px); opacity:.72; }
+.urai-ground-mid { height:38%; clip-path:polygon(0 62%, 18% 42%, 35% 58%, 49% 28%, 61% 51%, 77% 36%, 92% 62%, 100% 55%, 100% 100%, 0 100%); background:radial-gradient(circle at 50% 20%, rgba(78,232,242,.17), transparent 24%), linear-gradient(180deg, rgba(13,38,78,.65), rgba(1,3,9,.94)); opacity:.88; }
+.urai-ground-light-spill { height:36%; background:radial-gradient(ellipse at 50% 16%, rgba(155,231,255,.2), transparent 36%), radial-gradient(ellipse at 62% 20%, rgba(255,229,138,.12), transparent 28%); filter:blur(14px); mix-blend-mode:screen; }
+.urai-ground-front { height:28%; border-radius:50% 50% 0 0 / 28% 28% 0 0; background:linear-gradient(180deg, rgba(2,13,28,.82), #000 80%); box-shadow:0 -30px 90px rgba(0,0,0,.44); }
+.urai-foreground-fog { height:36%; background:radial-gradient(ellipse at 50% 55%, rgba(155,231,255,.07), transparent 54%); filter:blur(22px); }
+
+.urai-avatar-wrap { z-index:11; display:grid; place-items:center; pointer-events:none; }
+.urai-avatar-wrap::before { content:""; position:absolute; left:50%; top:52%; width:150px; height:340px; transform:translate(-50%,-6%); background:linear-gradient(180deg, rgba(155,231,255,.18), rgba(155,231,255,.04), transparent); filter:blur(28px); }
+.urai-avatar-aura { position:absolute; left:50%; top:58%; width:260px; height:390px; transform:translate(-50%,-50%); border-radius:999px; background:radial-gradient(ellipse, rgba(155,231,255,.11), transparent 72%); filter:blur(16px); }
+.urai-avatar-silhouette { position:absolute; left:50%; top:59%; width:min(18vw,230px); min-width:150px; transform:translate(-50%,-50%); opacity:.9; }
+
+.urai-memory-orb-wrap { z-index:14; display:grid; place-items:center; pointer-events:none; transform-origin:50% 43%; }
+.urai-orb-beam { position:absolute; left:50%; top:45%; width:112px; height:340px; transform:translateX(-50%); background:linear-gradient(180deg, rgba(155,231,255,.3), rgba(78,232,242,.11), transparent); clip-path:polygon(42% 0,58% 0,78% 100%,22% 100%); filter:blur(8px); opacity:.56; }
+.urai-orb-halo { position:absolute; left:50%; top:43%; width:360px; height:360px; transform:translate(-50%,-50%); border-radius:999px; background:radial-gradient(circle, rgba(255,255,255,.2), rgba(155,231,255,.22) 24%, rgba(255,229,138,.11) 44%, transparent 72%); filter:blur(18px); animation:uraiOrbBreath 7.5s ease-in-out infinite; }
+.urai-orb-core { position:absolute; left:50%; top:43%; width:132px; height:132px; transform:translate(-50%,-50%); border-radius:999px; background:radial-gradient(circle at 35% 28%, rgba(255,255,255,.98), rgba(190,255,255,.9) 18%, rgba(35,189,210,.7) 44%, rgba(2,22,45,.94) 76%); box-shadow:0 0 38px rgba(155,231,255,.62), 0 0 115px rgba(78,232,242,.22); overflow:hidden; }
+.urai-orb-highlight { position:absolute; left:29%; top:22%; width:38%; height:28%; border-radius:999px; background:rgba(255,255,255,.48); filter:blur(10px); }
+.urai-orb-shadow { position:absolute; right:-10%; bottom:-12%; width:80%; height:78%; border-radius:999px; background:radial-gradient(circle, rgba(0,9,26,.88), transparent 65%); }
+.urai-orb-ring { position:absolute; left:50%; top:43%; width:220px; height:104px; border:1px solid rgba(213,248,255,.2); border-radius:999px; transform:translate(-50%,-50%) rotate(-14deg); box-shadow:0 0 26px rgba(155,231,255,.08); }
+.urai-orb-ring-two { transform:translate(-50%,-50%) rotate(18deg) scaleX(.78); opacity:.62; border-color:rgba(255,229,138,.14); }
+.urai-orb-spark { position:absolute; left:calc(50% + 54px); top:calc(43% + 8px); width:14px; height:14px; border-radius:999px; background:rgba(209,255,255,.8); box-shadow:0 0 18px rgba(155,231,255,.82); }
+
+.urai-ascent-bloom, .urai-star-emergence { position:absolute; inset:0; pointer-events:none; z-index:40; }
+.urai-ascent-bloom { background:radial-gradient(circle at 50% 43%, rgba(235,255,255,.88), rgba(155,231,255,.5) 18%, rgba(255,229,138,.23) 38%, transparent 72%); mix-blend-mode:screen; }
+.urai-star-emergence { background:radial-gradient(circle at 50% 42%, rgba(255,255,255,.18), transparent 9%), radial-gradient(circle at 38% 32%, rgba(155,231,255,.34), transparent 2px), radial-gradient(circle at 62% 28%, rgba(255,229,138,.28), transparent 2px), radial-gradient(circle at 56% 56%, rgba(199,160,255,.35), transparent 2px), linear-gradient(180deg, rgba(1,4,14,.25), rgba(1,4,14,.92)); }
+.urai-home-label { position:absolute; z-index:50; left:50%; bottom:2rem; transform:translateX(-50%); text-align:center; color:rgba(239,250,255,.74); pointer-events:none; }
+.urai-home-label span { display:block; font-size:.62rem; letter-spacing:.3em; opacity:.48; }
+.urai-home-label strong { display:block; margin-top:.3rem; font-size:1.05rem; }
+.urai-home-label em { display:block; margin-top:.2rem; font-style:normal; font-size:.74rem; opacity:.52; }
+
+.urai-life-map-screen { background:radial-gradient(circle at 50% 44%, rgba(15,36,72,.8), transparent 34%), linear-gradient(180deg, #01030c, #040819 52%, #01030a); }
+.urai-galaxy-bg, .urai-galaxy-particles, .urai-galaxy-viewport, .urai-galaxy-camera, .urai-galaxy-world { position:absolute; inset:0; }
+.urai-galaxy-core { position:absolute; left:50%; top:50%; width:min(74vw,940px); height:min(45vw,540px); transform:translate(-50%,-50%); border-radius:999px; background:radial-gradient(ellipse at center, rgba(155,231,255,.12), rgba(199,160,255,.08) 35%, transparent 72%); filter:blur(24px); }
+.urai-galaxy-band { position:absolute; left:50%; top:50%; width:min(100vw,1180px); height:min(48vw,520px); transform:translate(-50%,-50%) rotate(-10deg); border-radius:999px; background:linear-gradient(90deg, transparent, rgba(74,120,210,.13), rgba(199,160,255,.1), transparent); box-shadow:inset 0 0 80px rgba(155,231,255,.06); }
+.urai-galaxy-particles { z-index:1; }
+.urai-life-title { position:absolute; z-index:70; left:50%; top:1.25rem; transform:translateX(-50%); text-align:center; pointer-events:none; }
+.urai-life-title span { display:block; font-size:.55rem; letter-spacing:.22em; opacity:.45; }
+.urai-life-title strong { display:block; margin-top:.2rem; font-size:1.15rem; }
+.urai-life-title em { display:block; margin-top:.15rem; font-size:.62rem; opacity:.52; font-style:normal; }
+.urai-galaxy-viewport { z-index:10; cursor:grab; touch-action:none; }
+.urai-galaxy-viewport:active { cursor:grabbing; }
+.urai-galaxy-camera { transform-origin:50% 50%; }
+.urai-galaxy-world { width:1200px; height:720px; left:50%; top:50%; transform:translate(-50%,-50%); overflow:visible; }
+.urai-nebula-zones, .urai-orbit-rings, .urai-thread-layer, .urai-memory-star-layer { position:absolute; inset:0; overflow:visible; }
+.urai-galaxy-nebula-zone { position:absolute; border-radius:999px; filter:blur(26px); mix-blend-mode:screen; transition:opacity .35s ease; }
+.urai-orbit-rings, .urai-thread-layer { left:50%; top:50%; width:1200px; height:720px; transform:translate(-50%,-50%); }
+.urai-orbit-rings ellipse { filter:drop-shadow(0 0 10px rgba(155,231,255,.08)); }
+.urai-memory-star { position:absolute; width:42px; height:42px; margin:-21px 0 0 -21px; border:0; background:transparent; border-radius:999px; cursor:pointer; transition:filter .25s ease, opacity .25s ease; }
+.urai-memory-star.is-dimmed:not(.is-selected) { opacity:.42; filter:blur(1.2px); }
+.urai-memory-star.is-filtered-out { pointer-events:none; }
+.urai-star-halo, .urai-star-core { position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); border-radius:999px; }
+.urai-star-halo { width:82px; height:82px; opacity:.72; filter:blur(4px); }
+.urai-star-core { width:9px; height:9px; }
+.urai-memory-star.is-selected .urai-star-core { width:14px; height:14px; }
+.urai-star-label { position:absolute; left:50%; bottom:100%; min-width:150px; transform:translate(-50%,-8px); opacity:0; pointer-events:none; padding:.34rem .55rem; border-radius:999px; background:rgba(5,9,22,.72); border:1px solid rgba(255,255,255,.14); color:white; text-align:center; backdrop-filter:blur(12px); }
+.urai-memory-star:hover .urai-star-label, .urai-memory-star.is-selected .urai-star-label { opacity:1; }
+.urai-star-label strong { display:block; font-size:.72rem; }
+.urai-star-label em { display:block; font-size:.58rem; opacity:.62; font-style:normal; }
+
+.urai-selected-star-focus { position:absolute; inset:0; z-index:50; pointer-events:none; }
+.urai-focus-scrim { position:absolute; inset:-40vh -40vw; border:0; background:rgba(0,4,12,.2); backdrop-filter:blur(1.5px); pointer-events:auto; }
+.urai-memory-portal-anchor { position:absolute; width:260px; height:260px; pointer-events:none; }
+.urai-portal-thread-tether { position:absolute; left:-130px; right:130px; top:50%; height:1px; background:linear-gradient(90deg, transparent, rgba(155,231,255,.55)); transform:rotate(-12deg); transform-origin:right center; }
+.urai-memory-portal { position:absolute; inset:0; border-radius:999px; border:1px solid rgba(155,231,255,.38); box-shadow:0 0 70px rgba(155,231,255,.24), inset 0 0 44px rgba(255,255,255,.08); overflow:hidden; }
+.urai-portal-image { position:absolute; inset:8px; border-radius:999px; background-size:cover; background-position:center; animation:uraiPortalDrift 12s ease-in-out infinite; }
+.urai-portal-ring { position:absolute; inset:-12px; border-radius:999px; border:1px solid rgba(255,255,255,.18); transform:rotate(-18deg) scaleX(.82); }
+.urai-confidence-ring { position:absolute; inset:-3px; border-radius:999px; mask:radial-gradient(circle, transparent 64%, black 65%); opacity:.8; }
+.urai-memory-detail { position:absolute; left:calc(50% + 170px); top:50%; width:min(380px, calc(100vw - 2rem)); transform:translateY(-50%); padding:1.1rem; border-radius:24px; pointer-events:auto; }
+.urai-detail-kicker { font-size:.62rem; letter-spacing:.18em; text-transform:uppercase; color:rgba(239,250,255,.48); }
+.urai-memory-detail h2 { margin:.4rem 0 .5rem; font-size:1.55rem; }
+.urai-memory-detail p { margin:0; color:rgba(239,250,255,.76); line-height:1.55; }
+.urai-detail-meta { display:flex; flex-wrap:wrap; gap:.38rem; margin-top:.9rem; }
+.urai-detail-meta span, .urai-mirror-note { border:1px solid rgba(255,255,255,.12); border-radius:999px; padding:.36rem .55rem; background:rgba(255,255,255,.05); font-size:.68rem; color:rgba(239,250,255,.68); }
+.urai-mirror-note { border-radius:16px; margin-top:.75rem; line-height:1.35; }
+.urai-detail-actions { margin-top:.9rem; display:flex; flex-wrap:wrap; gap:.44rem; }
+.urai-detail-actions button, .urai-galaxy-actions button, .urai-category-dock button { border:1px solid rgba(255,255,255,.14); border-radius:999px; background:rgba(255,255,255,.06); color:rgba(239,250,255,.82); padding:.45rem .7rem; font-size:.72rem; cursor:pointer; }
+.urai-detail-actions button:hover, .urai-galaxy-actions button:hover, .urai-category-dock button:hover, .urai-category-dock button.is-active { background:rgba(155,231,255,.14); border-color:rgba(155,231,255,.34); color:white; }
+
+.urai-companion-card { position:absolute; z-index:72; right:1rem; top:1rem; width:min(310px, calc(100vw - 2rem)); border-radius:18px; padding:.78rem; }
+.urai-companion-card span { font-size:.56rem; letter-spacing:.18em; opacity:.48; }
+.urai-companion-card p { margin:.34rem 0; font-size:.72rem; line-height:1.4; color:rgba(239,250,255,.72); }
+.urai-companion-card em { font-style:normal; font-size:.62rem; opacity:.44; }
+.urai-galaxy-actions { position:absolute; z-index:72; left:50%; bottom:3.95rem; transform:translateX(-50%); display:flex; gap:.42rem; padding:.45rem; border-radius:999px; }
+.urai-category-dock { position:absolute; z-index:72; left:50%; bottom:1rem; transform:translateX(-50%); display:flex; gap:.45rem; padding:.48rem; border-radius:18px; max-width:min(760px, calc(100vw - 2rem)); overflow:auto; }
+.urai-zoom-minimap { position:absolute; z-index:72; left:1rem; top:1rem; border-radius:18px; padding:.65rem .75rem; min-width:110px; }
+.urai-zoom-minimap span, .urai-zoom-minimap em { display:block; font-size:.6rem; opacity:.52; font-style:normal; }
+.urai-zoom-minimap strong { display:block; font-size:1rem; }
+.is-mirror-mode .urai-galaxy-world::after { content:""; position:absolute; top:0; bottom:0; left:50%; width:1px; background:linear-gradient(180deg, transparent, rgba(232,242,255,.34), transparent); box-shadow:0 0 24px rgba(232,242,255,.28); }
+
+@keyframes uraiStarTwinkle { 0%,100% { transform:scale(.82); opacity:.34; } 50% { transform:scale(1.15); opacity:1; } }
+@keyframes uraiOrbBreath { 0%,100% { transform:translate(-50%,-50%) scale(.985); opacity:.56; } 50% { transform:translate(-50%,-50%) scale(1.025); opacity:.84; } }
+@keyframes uraiPortalDrift { 0%,100% { transform:scale(1); filter:saturate(1); } 50% { transform:scale(1.055); filter:saturate(1.25); } }
+
+@media (max-width: 760px) {
+  .urai-avatar-silhouette { width:160px; }
+  .urai-orb-core { width:96px; height:96px; }
+  .urai-orb-halo { width:280px; height:280px; }
+  .urai-galaxy-world { transform:translate(-50%,-50%) scale(.78); }
+  .urai-memory-detail { left:1rem; right:1rem; top:auto; bottom:8.2rem; transform:none; width:auto; }
+  .urai-memory-portal-anchor { width:198px; height:198px; }
+  .urai-companion-card { top:auto; right:1rem; bottom:7rem; width:230px; opacity:.9; }
+  .urai-galaxy-actions { bottom:4.8rem; max-width:calc(100vw - 2rem); overflow:auto; }
+  .urai-category-dock { bottom:1rem; }
+  .urai-zoom-minimap { display:none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .urai-star-field span, .urai-galaxy-particles span, .urai-orb-halo, .urai-portal-image { animation:none !important; }
+  * { scroll-behavior:auto !important; }
+}


### PR DESCRIPTION
## Summary

Integrates the URAI cinematic redesign directly into the repo as a cohesive route-level implementation.

### Implemented
- Rewires `/home` to a new cinematic **Inner Sky Shrine** experience under `src/components/urai/home/HomeScene.tsx`.
- Rewires `/life-map` to a new cinematic **Memory Galaxy** experience under `src/components/urai/life-map/LifeMapPage.tsx`.
- Adds shared global cinematic styling at `src/styles/urai-cinematic.css`, imported through `src/app/layout.tsx`.
- Adds a 2100ms sky-tap ascent sequence:
  - ignition
  - memory lift
  - portal pass-through
  - star emergence
  - settle into the galaxy
- Adds a finished home composition with:
  - layered cosmic sky
  - star fields
  - nebula haze
  - dimensional ground/horizon layers
  - avatar silhouette
  - connected memory orb, beam, glow, and ground light spill
- Adds a lightweight, no-heavy-3D Memory Galaxy with:
  - zoom via mouse wheel and keyboard
  - click-drag pan
  - recenter
  - replay sequence
  - mirror mode
  - category filters
  - orbit rings
  - constellation threads
  - emotional nebula zones
  - companion/narrator card
- Replaces the corner-orb focus behavior with an in-place selected-star portal:
  - selected star blooms at its galaxy coordinate
  - memory portal opens from the star
  - fallback symbolic image field appears when no memory image is available
  - related constellation thread remains visible
  - polished metadata/action panel appears with narrator text, confidence, privacy, and actions
- Preserves performance direction:
  - CSS/SVG/React/Framer Motion only
  - no Three.js or heavy 3D engine
  - reduced-motion support
  - transform/opacity/filter based motion

## Files changed
- `src/app/home/page.tsx`
- `src/app/life-map/page.tsx`
- `src/app/layout.tsx`
- `src/components/urai/home/HomeScene.tsx`
- `src/components/urai/life-map/LifeMapPage.tsx`
- `src/styles/urai-cinematic.css`

## Notes

This PR intentionally avoids the heavier React Three Fiber direction from the separate open Life Map PR. It implements the requested cinematic UI using lightweight CSS/SVG/Framer Motion so it aligns with the performance requirement: no heavy 3D engine unless optional.

## Validation

I inspected the connected repo via GitHub, branched from current `main`, patched the route entrypoints, added the cinematic components/styles, and compared the branch against `main`.

I could not run local `npm run check:types`, `npm run lint`, or `npm run build` in this connector-only environment because the repository is not mounted locally with dependencies installed. CI or a local checkout should run:

```bash
npm install
npm run check:types
npm run lint
npm run build
```

## Follow-up optional asset upgrade

The implementation uses CSS/SVG fallback art so it renders immediately. Later, final premium assets can replace the procedural layers:
- orb core PNG
- ground back/mid/front WebP layers
- horizon mist strip
- portal fallback textures
- category glyphs
- star sprites
