### PR TITLE
Final cinematic art pass for URAI home and Memory Galaxy

### DIFF
--- a/src/styles/urai-cinematic.css
+++ b/src/styles/urai-cinematic.css
@@ -1,14 +1,14 @@
 :root {
-  --urai-bg-a: #020713;
-  --urai-bg-b: #061426;
-  --urai-bg-c: #01040a;
+  --urai-black: #00040b;
+  --urai-midnight: #020816;
+  --urai-deep: #06162a;
   --urai-cyan: #9BE7FF;
   --urai-teal: #4EE8F2;
   --urai-gold: #FFE58A;
   --urai-violet: #C7A0FF;
-  --urai-recovery: #B8FFD8;
-  --urai-relationship: #FFB7D6;
-  --cinematic-ease: cubic-bezier(.16,1,.3,1);
+  --urai-green: #B8FFD8;
+  --urai-pink: #FFB7D6;
+  --ease: cubic-bezier(.16,1,.3,1);
 }
 
 .urai-screen {
@@ -17,150 +17,438 @@
   width: 100%;
   overflow: hidden;
   color: rgba(239, 250, 255, .96);
-  background: var(--urai-bg-c);
+  background: #00040b;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   user-select: none;
   touch-action: none;
+  isolation: isolate;
+}
+
+.urai-screen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 90;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 50% 42%, transparent 34%, rgba(0, 0, 0, .22) 70%, rgba(0, 0, 0, .72) 100%),
+    linear-gradient(180deg, rgba(255,255,255,.035), transparent 9%, transparent 78%, rgba(0,0,0,.52));
+  mix-blend-mode: normal;
 }
 
 .glass-panel {
-  background: linear-gradient(180deg, rgba(8,17,34,.74), rgba(4,8,18,.58));
-  border: 1px solid rgba(185,230,255,.16);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.08), 0 18px 70px rgba(0,0,0,.42), 0 0 42px rgba(95,220,255,.08);
-  backdrop-filter: blur(18px);
+  background:
+    linear-gradient(180deg, rgba(12, 27, 52, .72), rgba(3, 8, 20, .58)),
+    radial-gradient(circle at 18% 8%, rgba(155,231,255,.12), transparent 38%);
+  border: 1px solid rgba(201, 237, 255, .18);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.11),
+    inset 0 -1px 0 rgba(255,255,255,.035),
+    0 24px 90px rgba(0,0,0,.48),
+    0 0 48px rgba(95,220,255,.08);
+  backdrop-filter: blur(22px) saturate(1.18);
 }
 
-.urai-fullscreen-button { position:absolute; inset:0; opacity:0; z-index:30; cursor:pointer; }
-.urai-home-camera { position:absolute; inset:0; transform-origin:50% 42%; }
+.urai-fullscreen-button { position:absolute; inset:0; opacity:0; z-index:80; cursor:pointer; border:0; background:transparent; }
+.urai-home-camera { position:absolute; inset:0; transform-origin:50% 45%; }
 .urai-cosmic-sky, .urai-sky-gradient, .urai-nebula-layer, .urai-ground-system, .urai-avatar-wrap, .urai-memory-orb-wrap { position:absolute; inset:0; }
+
+/* HOME: final cinematic shrine */
+.urai-home-screen {
+  background: #00050d;
+}
+
 .urai-sky-gradient {
   background:
-    radial-gradient(circle at 50% 35%, rgba(78,232,242,.13), transparent 23%),
-    radial-gradient(circle at 62% 48%, rgba(255,210,105,.07), transparent 24%),
-    radial-gradient(circle at 38% 52%, rgba(199,160,255,.08), transparent 30%),
-    linear-gradient(180deg, #020713 0%, #061426 44%, #020610 100%);
+    radial-gradient(circle at 50% 36%, rgba(132, 241, 255, .18), transparent 11%),
+    radial-gradient(circle at 52% 46%, rgba(255, 229, 138, .105), transparent 22%),
+    radial-gradient(circle at 30% 48%, rgba(87, 163, 255, .13), transparent 27%),
+    radial-gradient(circle at 74% 45%, rgba(199, 160, 255, .105), transparent 31%),
+    linear-gradient(180deg, #010611 0%, #06192d 40%, #061524 57%, #020814 100%);
 }
-.urai-sky-vignette { position:absolute; inset:0; background:radial-gradient(ellipse at center, transparent 30%, rgba(0,0,0,.56) 88%); }
-.urai-star-field { position:absolute; inset:0; overflow:hidden; }
-.urai-star-field span, .urai-galaxy-particles span { position:absolute; border-radius:999px; background:#fff; box-shadow:0 0 10px rgba(255,255,255,.8), 0 0 24px rgba(155,231,255,.38); animation:uraiStarTwinkle 4.8s ease-in-out infinite; }
-.urai-stars-far { opacity:.72; }
-.urai-stars-near { opacity:.92; transform:scale(1.04); filter:blur(.2px); }
-.urai-nebula-layer { z-index:4; pointer-events:none; mix-blend-mode:screen; }
-.urai-nebula { position:absolute; border-radius:999px; filter:blur(34px); opacity:.72; }
-.urai-nebula-cyan { left:30%; top:35%; width:36%; height:26%; background:rgba(78,232,242,.12); }
-.urai-nebula-violet { right:16%; top:30%; width:30%; height:32%; background:rgba(199,160,255,.09); }
-.urai-nebula-gold { right:24%; bottom:20%; width:26%; height:18%; background:rgba(255,229,138,.1); }
 
-.urai-ground-system { z-index:8; top:50%; pointer-events:none; transform-origin:50% 70%; }
-.urai-horizon-mist { position:absolute; left:14%; right:14%; top:9%; height:120px; background:radial-gradient(ellipse at center, rgba(96,219,225,.16), transparent 68%); filter:blur(24px); }
-.urai-horizon-mist::after { content:""; position:absolute; left:8%; right:8%; top:49%; height:1px; background:linear-gradient(90deg, transparent, rgba(174,235,255,.28), transparent); filter:blur(.3px); }
-.urai-ground-back, .urai-ground-mid, .urai-ground-front, .urai-ground-light-spill, .urai-foreground-fog { position:absolute; left:-10%; right:-10%; bottom:0; }
-.urai-ground-back { height:48%; clip-path:polygon(0 58%, 13% 43%, 24% 49%, 35% 31%, 45% 36%, 54% 18%, 64% 35%, 77% 21%, 88% 44%, 100% 35%, 100% 100%, 0 100%); background:linear-gradient(180deg, rgba(30,54,110,.42), rgba(3,8,22,.82)); filter:blur(.2px); opacity:.72; }
-.urai-ground-mid { height:38%; clip-path:polygon(0 62%, 18% 42%, 35% 58%, 49% 28%, 61% 51%, 77% 36%, 92% 62%, 100% 55%, 100% 100%, 0 100%); background:radial-gradient(circle at 50% 20%, rgba(78,232,242,.17), transparent 24%), linear-gradient(180deg, rgba(13,38,78,.65), rgba(1,3,9,.94)); opacity:.88; }
-.urai-ground-light-spill { height:36%; background:radial-gradient(ellipse at 50% 16%, rgba(155,231,255,.2), transparent 36%), radial-gradient(ellipse at 62% 20%, rgba(255,229,138,.12), transparent 28%); filter:blur(14px); mix-blend-mode:screen; }
-.urai-ground-front { height:28%; border-radius:50% 50% 0 0 / 28% 28% 0 0; background:linear-gradient(180deg, rgba(2,13,28,.82), #000 80%); box-shadow:0 -30px 90px rgba(0,0,0,.44); }
-.urai-foreground-fog { height:36%; background:radial-gradient(ellipse at 50% 55%, rgba(155,231,255,.07), transparent 54%); filter:blur(22px); }
+.urai-sky-gradient::before {
+  content: "";
+  position: absolute;
+  inset: -12% -8%;
+  background:
+    radial-gradient(ellipse at 50% 50%, rgba(155,231,255,.08), transparent 36%),
+    radial-gradient(ellipse at 50% 60%, rgba(255,229,138,.055), transparent 42%);
+  filter: blur(22px);
+  opacity: .95;
+}
+
+.urai-sky-vignette {
+  position:absolute;
+  inset:0;
+  background:
+    radial-gradient(ellipse at 50% 42%, transparent 18%, rgba(0, 10, 28, .32) 58%, rgba(0,0,0,.86) 100%),
+    linear-gradient(180deg, rgba(0,0,0,.12), transparent 24%, transparent 56%, rgba(0,0,0,.64));
+}
+
+.urai-star-field { position:absolute; inset:0; overflow:hidden; }
+.urai-star-field span, .urai-galaxy-particles span {
+  position:absolute;
+  border-radius:999px;
+  background: #f3fbff;
+  box-shadow:0 0 8px rgba(255,255,255,.95), 0 0 24px rgba(155,231,255,.48);
+  animation:uraiStarTwinkle 5.8s ease-in-out infinite;
+}
+.urai-stars-far { opacity:.5; filter: blur(.2px); }
+.urai-stars-near { opacity:.9; transform:scale(1.05); filter:blur(.15px); }
+
+.urai-nebula-layer { z-index:4; pointer-events:none; mix-blend-mode:screen; }
+.urai-nebula { position:absolute; border-radius:999px; filter:blur(42px); opacity:.85; }
+.urai-nebula-cyan { left:25%; top:30%; width:50%; height:32%; background:rgba(78,232,242,.14); }
+.urai-nebula-violet { right:3%; top:25%; width:43%; height:38%; background:rgba(199,160,255,.105); }
+.urai-nebula-gold { right:16%; bottom:18%; width:36%; height:28%; background:rgba(255,229,138,.13); }
+
+.urai-ground-system {
+  z-index:8;
+  top:43%;
+  pointer-events:none;
+  transform-origin:50% 76%;
+}
+.urai-horizon-mist {
+  position:absolute;
+  left:8%;
+  right:8%;
+  top:15%;
+  height:230px;
+  background:
+    radial-gradient(ellipse at 50% 42%, rgba(190,252,255,.28), transparent 22%),
+    radial-gradient(ellipse at 50% 52%, rgba(78,232,242,.14), transparent 46%),
+    radial-gradient(ellipse at 65% 58%, rgba(255,229,138,.12), transparent 36%);
+  filter:blur(22px);
+  opacity:.98;
+}
+.urai-horizon-mist::before {
+  content:"";
+  position:absolute;
+  left:10%;
+  right:10%;
+  top:44%;
+  height:70px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at center, rgba(210,255,255,.19), rgba(130,230,255,.05) 45%, transparent 70%);
+  transform: perspective(400px) rotateX(62deg);
+}
+.urai-horizon-mist::after { display:none; }
+
+.urai-ground-back, .urai-ground-mid, .urai-ground-front, .urai-ground-light-spill, .urai-foreground-fog { position:absolute; left:-8%; right:-8%; bottom:0; }
+.urai-ground-back {
+  height:55%;
+  clip-path:polygon(0 62%, 9% 50%, 18% 56%, 27% 40%, 37% 49%, 48% 28%, 58% 40%, 68% 26%, 80% 48%, 91% 39%, 100% 48%, 100% 100%, 0 100%);
+  background:
+    radial-gradient(circle at 50% 16%, rgba(155,231,255,.18), transparent 24%),
+    linear-gradient(180deg, rgba(28, 58, 118, .52), rgba(3, 10, 28, .92));
+  filter: blur(.25px);
+  opacity:.88;
+}
+.urai-ground-mid {
+  height:44%;
+  clip-path:polygon(0 66%, 15% 48%, 29% 62%, 43% 38%, 52% 54%, 64% 34%, 78% 50%, 90% 64%, 100% 58%, 100% 100%, 0 100%);
+  background:
+    radial-gradient(circle at 49% 8%, rgba(155,231,255,.22), transparent 20%),
+    radial-gradient(circle at 67% 27%, rgba(255,229,138,.16), transparent 19%),
+    radial-gradient(circle at 36% 31%, rgba(199,160,255,.15), transparent 25%),
+    linear-gradient(180deg, rgba(11, 34, 74, .75), rgba(0, 3, 12, .98));
+  opacity:.96;
+}
+.urai-ground-light-spill {
+  height:48%;
+  background:
+    radial-gradient(ellipse at 50% 10%, rgba(195,255,255,.38), transparent 20%),
+    radial-gradient(ellipse at 50% 24%, rgba(78,232,242,.17), transparent 36%),
+    radial-gradient(ellipse at 65% 24%, rgba(255,229,138,.14), transparent 28%),
+    radial-gradient(ellipse at 35% 30%, rgba(199,160,255,.12), transparent 31%);
+  filter:blur(18px);
+  mix-blend-mode:screen;
+  opacity:.88;
+}
+.urai-ground-front {
+  height:31%;
+  border-radius:50% 50% 0 0 / 28% 28% 0 0;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(96,219,225,.16), transparent 34%),
+    linear-gradient(180deg, rgba(2,13,28,.9), #000 78%);
+  box-shadow:0 -34px 110px rgba(0,0,0,.58), inset 0 1px 0 rgba(155,231,255,.08);
+}
+.urai-foreground-fog {
+  height:54%;
+  background:
+    radial-gradient(ellipse at 50% 42%, rgba(155,231,255,.11), transparent 38%),
+    radial-gradient(ellipse at 35% 56%, rgba(199,160,255,.08), transparent 30%),
+    radial-gradient(ellipse at 65% 56%, rgba(255,229,138,.075), transparent 30%);
+  filter:blur(26px);
+  opacity:.9;
+}
 
 .urai-avatar-wrap { z-index:11; display:grid; place-items:center; pointer-events:none; }
-.urai-avatar-wrap::before { content:""; position:absolute; left:50%; top:52%; width:150px; height:340px; transform:translate(-50%,-6%); background:linear-gradient(180deg, rgba(155,231,255,.18), rgba(155,231,255,.04), transparent); filter:blur(28px); }
-.urai-avatar-aura { position:absolute; left:50%; top:58%; width:260px; height:390px; transform:translate(-50%,-50%); border-radius:999px; background:radial-gradient(ellipse, rgba(155,231,255,.11), transparent 72%); filter:blur(16px); }
-.urai-avatar-silhouette { position:absolute; left:50%; top:59%; width:min(18vw,230px); min-width:150px; transform:translate(-50%,-50%); opacity:.9; }
+.urai-avatar-wrap::before {
+  content:"";
+  position:absolute;
+  left:50%;
+  top:55%;
+  width:240px;
+  height:430px;
+  transform:translate(-50%,-10%);
+  background:
+    radial-gradient(ellipse at 50% 5%, rgba(225,255,255,.23), transparent 18%),
+    linear-gradient(180deg, rgba(155,231,255,.24), rgba(78,232,242,.08) 46%, transparent);
+  clip-path: polygon(40% 0, 60% 0, 84% 100%, 16% 100%);
+  filter:blur(24px);
+  opacity:.95;
+}
+.urai-avatar-aura {
+  position:absolute;
+  left:50%; top:59%;
+  width:360px; height:470px;
+  transform:translate(-50%,-50%);
+  border-radius:50%;
+  background:radial-gradient(ellipse, rgba(155,231,255,.14), rgba(78,232,242,.055) 42%, transparent 72%);
+  filter:blur(20px);
+}
+.urai-avatar-silhouette {
+  position:absolute;
+  left:50%; top:60%;
+  width:min(20vw,260px);
+  min-width:170px;
+  transform:translate(-50%,-50%);
+  opacity:.84;
+  filter: drop-shadow(0 0 24px rgba(155,231,255,.18));
+}
 
 .urai-memory-orb-wrap { z-index:14; display:grid; place-items:center; pointer-events:none; transform-origin:50% 43%; }
-.urai-orb-beam { position:absolute; left:50%; top:45%; width:112px; height:340px; transform:translateX(-50%); background:linear-gradient(180deg, rgba(155,231,255,.3), rgba(78,232,242,.11), transparent); clip-path:polygon(42% 0,58% 0,78% 100%,22% 100%); filter:blur(8px); opacity:.56; }
-.urai-orb-halo { position:absolute; left:50%; top:43%; width:360px; height:360px; transform:translate(-50%,-50%); border-radius:999px; background:radial-gradient(circle, rgba(255,255,255,.2), rgba(155,231,255,.22) 24%, rgba(255,229,138,.11) 44%, transparent 72%); filter:blur(18px); animation:uraiOrbBreath 7.5s ease-in-out infinite; }
-.urai-orb-core { position:absolute; left:50%; top:43%; width:132px; height:132px; transform:translate(-50%,-50%); border-radius:999px; background:radial-gradient(circle at 35% 28%, rgba(255,255,255,.98), rgba(190,255,255,.9) 18%, rgba(35,189,210,.7) 44%, rgba(2,22,45,.94) 76%); box-shadow:0 0 38px rgba(155,231,255,.62), 0 0 115px rgba(78,232,242,.22); overflow:hidden; }
-.urai-orb-highlight { position:absolute; left:29%; top:22%; width:38%; height:28%; border-radius:999px; background:rgba(255,255,255,.48); filter:blur(10px); }
-.urai-orb-shadow { position:absolute; right:-10%; bottom:-12%; width:80%; height:78%; border-radius:999px; background:radial-gradient(circle, rgba(0,9,26,.88), transparent 65%); }
-.urai-orb-ring { position:absolute; left:50%; top:43%; width:220px; height:104px; border:1px solid rgba(213,248,255,.2); border-radius:999px; transform:translate(-50%,-50%) rotate(-14deg); box-shadow:0 0 26px rgba(155,231,255,.08); }
-.urai-orb-ring-two { transform:translate(-50%,-50%) rotate(18deg) scaleX(.78); opacity:.62; border-color:rgba(255,229,138,.14); }
-.urai-orb-spark { position:absolute; left:calc(50% + 54px); top:calc(43% + 8px); width:14px; height:14px; border-radius:999px; background:rgba(209,255,255,.8); box-shadow:0 0 18px rgba(155,231,255,.82); }
+.urai-orb-beam {
+  position:absolute;
+  left:50%; top:44%;
+  width:138px; height:410px;
+  transform:translateX(-50%);
+  background:linear-gradient(180deg, rgba(225,255,255,.38), rgba(78,232,242,.16) 42%, rgba(155,231,255,.04) 74%, transparent);
+  clip-path:polygon(44% 0,56% 0,80% 100%,20% 100%);
+  filter:blur(8px);
+  opacity:.82;
+}
+.urai-orb-halo {
+  position:absolute;
+  left:50%; top:43%;
+  width:520px; height:520px;
+  transform:translate(-50%,-50%);
+  border-radius:999px;
+  background:
+    radial-gradient(circle, rgba(255,255,255,.28), rgba(155,231,255,.31) 17%, rgba(255,229,138,.16) 38%, rgba(155,231,255,.06) 56%, transparent 72%);
+  filter:blur(22px);
+  animation:uraiOrbBreath 7.5s ease-in-out infinite;
+}
+.urai-orb-core {
+  position:absolute;
+  left:50%; top:43%;
+  width:148px; height:148px;
+  transform:translate(-50%,-50%);
+  border-radius:999px;
+  background:
+    radial-gradient(circle at 34% 26%, rgba(255,255,255,1), rgba(199,255,255,.96) 17%, rgba(61,210,225,.74) 42%, rgba(2,22,45,.98) 76%);
+  box-shadow:
+    inset -20px -24px 40px rgba(0,10,30,.58),
+    inset 12px 10px 28px rgba(255,255,255,.25),
+    0 0 42px rgba(190,255,255,.72),
+    0 0 150px rgba(78,232,242,.32),
+    0 0 260px rgba(255,229,138,.16);
+  overflow:hidden;
+}
+.urai-orb-highlight { position:absolute; left:24%; top:18%; width:42%; height:30%; border-radius:999px; background:rgba(255,255,255,.58); filter:blur(12px); }
+.urai-orb-shadow { position:absolute; right:-10%; bottom:-12%; width:84%; height:78%; border-radius:999px; background:radial-gradient(circle, rgba(0,9,26,.92), transparent 66%); }
+.urai-orb-ring {
+  position:absolute;
+  left:50%; top:43%;
+  width:290px; height:134px;
+  border:1px solid rgba(213,248,255,.23);
+  border-radius:999px;
+  transform:translate(-50%,-50%) rotate(-15deg);
+  box-shadow:0 0 32px rgba(155,231,255,.1), inset 0 0 14px rgba(255,255,255,.035);
+}
+.urai-orb-ring-two { transform:translate(-50%,-50%) rotate(19deg) scaleX(.78); opacity:.7; border-color:rgba(255,229,138,.2); }
+.urai-orb-spark { position:absolute; left:calc(50% + 61px); top:calc(43% + 10px); width:16px; height:16px; border-radius:999px; background:rgba(224,255,255,.88); box-shadow:0 0 20px rgba(155,231,255,.9), 0 0 42px rgba(155,231,255,.42); }
 
 .urai-ascent-bloom, .urai-star-emergence { position:absolute; inset:0; pointer-events:none; z-index:40; }
 .urai-ascent-bloom { background:radial-gradient(circle at 50% 43%, rgba(235,255,255,.88), rgba(155,231,255,.5) 18%, rgba(255,229,138,.23) 38%, transparent 72%); mix-blend-mode:screen; }
 .urai-star-emergence { background:radial-gradient(circle at 50% 42%, rgba(255,255,255,.18), transparent 9%), radial-gradient(circle at 38% 32%, rgba(155,231,255,.34), transparent 2px), radial-gradient(circle at 62% 28%, rgba(255,229,138,.28), transparent 2px), radial-gradient(circle at 56% 56%, rgba(199,160,255,.35), transparent 2px), linear-gradient(180deg, rgba(1,4,14,.25), rgba(1,4,14,.92)); }
-.urai-home-label { position:absolute; z-index:50; left:50%; bottom:2rem; transform:translateX(-50%); text-align:center; color:rgba(239,250,255,.74); pointer-events:none; }
-.urai-home-label span { display:block; font-size:.62rem; letter-spacing:.3em; opacity:.48; }
-.urai-home-label strong { display:block; margin-top:.3rem; font-size:1.05rem; }
-.urai-home-label em { display:block; margin-top:.2rem; font-style:normal; font-size:.74rem; opacity:.52; }
+.urai-home-label {
+  position:absolute; z-index:95; left:50%; bottom:2.1rem; transform:translateX(-50%); text-align:center; color:rgba(239,250,255,.74); pointer-events:none;
+  text-shadow:0 0 18px rgba(155,231,255,.18);
+}
+.urai-home-label span { display:block; font-size:.62rem; letter-spacing:.34em; opacity:.48; }
+.urai-home-label strong { display:block; margin-top:.34rem; font-size:1.08rem; font-weight:620; }
+.urai-home-label em { display:block; margin-top:.24rem; font-style:normal; font-size:.74rem; opacity:.55; }
 
-.urai-life-map-screen { background:radial-gradient(circle at 50% 44%, rgba(15,36,72,.8), transparent 34%), linear-gradient(180deg, #01030c, #040819 52%, #01030a); }
+/* LIFE MAP: final Memory Galaxy */
+.urai-life-map-screen {
+  background:
+    radial-gradient(circle at 50% 42%, rgba(21, 54, 105, .86), transparent 32%),
+    radial-gradient(circle at 68% 38%, rgba(108, 66, 176, .28), transparent 38%),
+    radial-gradient(circle at 26% 60%, rgba(30, 118, 180, .18), transparent 34%),
+    linear-gradient(180deg, #00030b 0%, #030816 54%, #000207 100%);
+}
 .urai-galaxy-bg, .urai-galaxy-particles, .urai-galaxy-viewport, .urai-galaxy-camera, .urai-galaxy-world { position:absolute; inset:0; }
-.urai-galaxy-core { position:absolute; left:50%; top:50%; width:min(74vw,940px); height:min(45vw,540px); transform:translate(-50%,-50%); border-radius:999px; background:radial-gradient(ellipse at center, rgba(155,231,255,.12), rgba(199,160,255,.08) 35%, transparent 72%); filter:blur(24px); }
-.urai-galaxy-band { position:absolute; left:50%; top:50%; width:min(100vw,1180px); height:min(48vw,520px); transform:translate(-50%,-50%) rotate(-10deg); border-radius:999px; background:linear-gradient(90deg, transparent, rgba(74,120,210,.13), rgba(199,160,255,.1), transparent); box-shadow:inset 0 0 80px rgba(155,231,255,.06); }
-.urai-galaxy-particles { z-index:1; }
-.urai-life-title { position:absolute; z-index:70; left:50%; top:1.25rem; transform:translateX(-50%); text-align:center; pointer-events:none; }
-.urai-life-title span { display:block; font-size:.55rem; letter-spacing:.22em; opacity:.45; }
-.urai-life-title strong { display:block; margin-top:.2rem; font-size:1.15rem; }
-.urai-life-title em { display:block; margin-top:.15rem; font-size:.62rem; opacity:.52; font-style:normal; }
+.urai-galaxy-bg { z-index:0; }
+.urai-galaxy-bg::before {
+  content:"";
+  position:absolute;
+  inset:-20%;
+  background:
+    radial-gradient(circle at 18% 22%, rgba(255,255,255,.55) 0 1px, transparent 2px),
+    radial-gradient(circle at 72% 18%, rgba(155,231,255,.55) 0 1px, transparent 2px),
+    radial-gradient(circle at 45% 82%, rgba(199,160,255,.48) 0 1px, transparent 2px);
+  background-size: 92px 92px, 137px 137px, 173px 173px;
+  opacity:.38;
+}
+.urai-galaxy-core {
+  position:absolute;
+  left:50%; top:51%;
+  width:min(92vw,1100px); height:min(58vw,650px);
+  transform:translate(-50%,-50%);
+  border-radius:999px;
+  background:
+    radial-gradient(ellipse at center, rgba(255,255,255,.12), transparent 8%),
+    radial-gradient(ellipse at center, rgba(155,231,255,.22), rgba(199,160,255,.12) 28%, rgba(40,85,170,.075) 54%, transparent 74%);
+  filter:blur(20px);
+  opacity:.9;
+}
+.urai-galaxy-band {
+  position:absolute;
+  left:50%; top:51%;
+  width:min(112vw,1320px); height:min(60vw,620px);
+  transform:translate(-50%,-50%) rotate(-10deg);
+  border-radius:999px;
+  background:
+    radial-gradient(ellipse at 50% 50%, rgba(155,231,255,.10), transparent 32%),
+    linear-gradient(90deg, transparent 0%, rgba(32,88,178,.18) 24%, rgba(110,93,210,.19) 52%, rgba(255,183,214,.08) 72%, transparent 100%);
+  box-shadow:inset 0 0 110px rgba(155,231,255,.06), 0 0 90px rgba(67, 111, 231, .08);
+  animation:uraiGalaxyDrift 22s ease-in-out infinite;
+}
+.urai-galaxy-band::after {
+  content:"";
+  position:absolute;
+  inset:14% 8%;
+  border-radius:inherit;
+  border:1px solid rgba(155,231,255,.075);
+  transform:rotate(18deg) scale(.92);
+}
+.urai-galaxy-particles { z-index:1; opacity:.7; }
+.urai-life-title {
+  position:absolute; z-index:95; left:50%; top:1.4rem; transform:translateX(-50%); text-align:center; pointer-events:none;
+  text-shadow: 0 0 22px rgba(155,231,255,.22);
+}
+.urai-life-title span { display:block; font-size:.58rem; letter-spacing:.3em; opacity:.45; }
+.urai-life-title strong { display:block; margin-top:.25rem; font-size:1.55rem; font-weight:640; letter-spacing:-.03em; }
+.urai-life-title em { display:block; margin-top:.2rem; font-size:.67rem; opacity:.56; font-style:normal; }
 .urai-galaxy-viewport { z-index:10; cursor:grab; touch-action:none; }
 .urai-galaxy-viewport:active { cursor:grabbing; }
 .urai-galaxy-camera { transform-origin:50% 50%; }
-.urai-galaxy-world { width:1200px; height:720px; left:50%; top:50%; transform:translate(-50%,-50%); overflow:visible; }
+.urai-galaxy-world { width:1320px; height:820px; left:50%; top:51%; transform:translate(-50%,-50%); overflow:visible; }
 .urai-nebula-zones, .urai-orbit-rings, .urai-thread-layer, .urai-memory-star-layer { position:absolute; inset:0; overflow:visible; }
-.urai-galaxy-nebula-zone { position:absolute; border-radius:999px; filter:blur(26px); mix-blend-mode:screen; transition:opacity .35s ease; }
-.urai-orbit-rings, .urai-thread-layer { left:50%; top:50%; width:1200px; height:720px; transform:translate(-50%,-50%); }
-.urai-orbit-rings ellipse { filter:drop-shadow(0 0 10px rgba(155,231,255,.08)); }
-.urai-memory-star { position:absolute; width:42px; height:42px; margin:-21px 0 0 -21px; border:0; background:transparent; border-radius:999px; cursor:pointer; transition:filter .25s ease, opacity .25s ease; }
-.urai-memory-star.is-dimmed:not(.is-selected) { opacity:.42; filter:blur(1.2px); }
+.urai-galaxy-nebula-zone { position:absolute; border-radius:999px; filter:blur(40px); mix-blend-mode:screen; transition:opacity .35s ease; }
+.urai-orbit-rings, .urai-thread-layer { left:50%; top:50%; width:1320px; height:820px; transform:translate(-50%,-50%); overflow:visible; }
+.urai-orbit-rings ellipse { filter:drop-shadow(0 0 14px rgba(155,231,255,.14)); stroke:rgba(155,231,255,.22); }
+.urai-thread-layer line { filter: drop-shadow(0 0 8px rgba(155,231,255,.32)); }
+.urai-memory-star {
+  position:absolute;
+  width:58px; height:58px;
+  margin:-29px 0 0 -29px;
+  border:0; background:transparent; border-radius:999px; cursor:pointer;
+  transition:filter .25s ease, opacity .25s ease;
+}
+.urai-memory-star.is-dimmed:not(.is-selected) { opacity:.32; filter:blur(1.4px) saturate(.75); }
 .urai-memory-star.is-filtered-out { pointer-events:none; }
 .urai-star-halo, .urai-star-core { position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); border-radius:999px; }
-.urai-star-halo { width:82px; height:82px; opacity:.72; filter:blur(4px); }
-.urai-star-core { width:9px; height:9px; }
-.urai-memory-star.is-selected .urai-star-core { width:14px; height:14px; }
-.urai-star-label { position:absolute; left:50%; bottom:100%; min-width:150px; transform:translate(-50%,-8px); opacity:0; pointer-events:none; padding:.34rem .55rem; border-radius:999px; background:rgba(5,9,22,.72); border:1px solid rgba(255,255,255,.14); color:white; text-align:center; backdrop-filter:blur(12px); }
+.urai-star-halo { width:112px; height:112px; opacity:.8; filter:blur(8px); }
+.urai-star-core {
+  width:12px; height:12px;
+  border:1px solid rgba(255,255,255,.7);
+  box-shadow:0 0 22px rgba(155,231,255,.8), 0 0 58px rgba(155,231,255,.32);
+}
+.urai-memory-star.is-selected .urai-star-halo { width:156px; height:156px; opacity:1; }
+.urai-memory-star.is-selected .urai-star-core { width:20px; height:20px; }
+.urai-star-label {
+  position:absolute; left:50%; bottom:100%; min-width:178px; transform:translate(-50%,-10px); opacity:0; pointer-events:none;
+  padding:.5rem .8rem; border-radius:999px;
+  background:linear-gradient(180deg, rgba(9,19,38,.78), rgba(2,5,13,.72));
+  border:1px solid rgba(220,246,255,.18);
+  color:white; text-align:center; backdrop-filter:blur(16px);
+  box-shadow:0 16px 60px rgba(0,0,0,.34), 0 0 38px rgba(155,231,255,.12);
+}
 .urai-memory-star:hover .urai-star-label, .urai-memory-star.is-selected .urai-star-label { opacity:1; }
-.urai-star-label strong { display:block; font-size:.72rem; }
-.urai-star-label em { display:block; font-size:.58rem; opacity:.62; font-style:normal; }
+.urai-star-label strong { display:block; font-size:.78rem; font-weight:700; }
+.urai-star-label em { display:block; margin-top:.12rem; font-size:.62rem; opacity:.66; font-style:normal; }
 
-.urai-selected-star-focus { position:absolute; inset:0; z-index:50; pointer-events:none; }
-.urai-focus-scrim { position:absolute; inset:-40vh -40vw; border:0; background:rgba(0,4,12,.2); backdrop-filter:blur(1.5px); pointer-events:auto; }
-.urai-memory-portal-anchor { position:absolute; width:260px; height:260px; pointer-events:none; }
-.urai-portal-thread-tether { position:absolute; left:-130px; right:130px; top:50%; height:1px; background:linear-gradient(90deg, transparent, rgba(155,231,255,.55)); transform:rotate(-12deg); transform-origin:right center; }
-.urai-memory-portal { position:absolute; inset:0; border-radius:999px; border:1px solid rgba(155,231,255,.38); box-shadow:0 0 70px rgba(155,231,255,.24), inset 0 0 44px rgba(255,255,255,.08); overflow:hidden; }
-.urai-portal-image { position:absolute; inset:8px; border-radius:999px; background-size:cover; background-position:center; animation:uraiPortalDrift 12s ease-in-out infinite; }
-.urai-portal-ring { position:absolute; inset:-12px; border-radius:999px; border:1px solid rgba(255,255,255,.18); transform:rotate(-18deg) scaleX(.82); }
-.urai-confidence-ring { position:absolute; inset:-3px; border-radius:999px; mask:radial-gradient(circle, transparent 64%, black 65%); opacity:.8; }
-.urai-memory-detail { position:absolute; left:calc(50% + 170px); top:50%; width:min(380px, calc(100vw - 2rem)); transform:translateY(-50%); padding:1.1rem; border-radius:24px; pointer-events:auto; }
-.urai-detail-kicker { font-size:.62rem; letter-spacing:.18em; text-transform:uppercase; color:rgba(239,250,255,.48); }
-.urai-memory-detail h2 { margin:.4rem 0 .5rem; font-size:1.55rem; }
-.urai-memory-detail p { margin:0; color:rgba(239,250,255,.76); line-height:1.55; }
-.urai-detail-meta { display:flex; flex-wrap:wrap; gap:.38rem; margin-top:.9rem; }
-.urai-detail-meta span, .urai-mirror-note { border:1px solid rgba(255,255,255,.12); border-radius:999px; padding:.36rem .55rem; background:rgba(255,255,255,.05); font-size:.68rem; color:rgba(239,250,255,.68); }
+.urai-selected-star-focus { position:absolute; inset:0; z-index:60; pointer-events:none; }
+.urai-focus-scrim { position:absolute; inset:-40vh -40vw; border:0; background:rgba(0,4,12,.24); backdrop-filter:blur(2px); pointer-events:auto; }
+.urai-memory-portal-anchor { position:absolute; width:320px; height:320px; pointer-events:none; }
+.urai-portal-thread-tether { position:absolute; left:-180px; right:150px; top:50%; height:1px; background:linear-gradient(90deg, transparent, rgba(155,231,255,.72), transparent); transform:rotate(-12deg); transform-origin:right center; filter:drop-shadow(0 0 12px rgba(155,231,255,.44)); }
+.urai-memory-portal {
+  position:absolute; inset:0; border-radius:999px;
+  border:1px solid rgba(207,247,255,.4);
+  box-shadow:
+    0 0 90px rgba(155,231,255,.32),
+    0 0 160px rgba(199,160,255,.12),
+    inset 0 0 60px rgba(255,255,255,.1);
+  overflow:hidden;
+  background:#040b17;
+}
+.urai-portal-image { position:absolute; inset:10px; border-radius:999px; background-size:cover; background-position:center; animation:uraiPortalDrift 12s ease-in-out infinite; }
+.urai-portal-ring { position:absolute; inset:-16px; border-radius:999px; border:1px solid rgba(255,255,255,.22); transform:rotate(-18deg) scaleX(.82); box-shadow:0 0 28px rgba(255,255,255,.06); }
+.urai-confidence-ring { position:absolute; inset:-4px; border-radius:999px; mask:radial-gradient(circle, transparent 64%, black 65%); opacity:.82; }
+.urai-memory-detail {
+  position:absolute; left:calc(50% + 205px); top:50%; width:min(420px, calc(100vw - 2rem)); transform:translateY(-50%);
+  padding:1.25rem; border-radius:28px; pointer-events:auto;
+}
+.urai-detail-kicker { font-size:.62rem; letter-spacing:.2em; text-transform:uppercase; color:rgba(239,250,255,.52); }
+.urai-memory-detail h2 { margin:.42rem 0 .58rem; font-size:1.75rem; line-height:1.05; }
+.urai-memory-detail p { margin:0; color:rgba(239,250,255,.78); line-height:1.58; }
+.urai-detail-meta { display:flex; flex-wrap:wrap; gap:.45rem; margin-top:.95rem; }
+.urai-detail-meta span, .urai-mirror-note { border:1px solid rgba(255,255,255,.14); border-radius:999px; padding:.4rem .62rem; background:rgba(255,255,255,.055); font-size:.7rem; color:rgba(239,250,255,.72); }
 .urai-mirror-note { border-radius:16px; margin-top:.75rem; line-height:1.35; }
-.urai-detail-actions { margin-top:.9rem; display:flex; flex-wrap:wrap; gap:.44rem; }
-.urai-detail-actions button, .urai-galaxy-actions button, .urai-category-dock button { border:1px solid rgba(255,255,255,.14); border-radius:999px; background:rgba(255,255,255,.06); color:rgba(239,250,255,.82); padding:.45rem .7rem; font-size:.72rem; cursor:pointer; }
-.urai-detail-actions button:hover, .urai-galaxy-actions button:hover, .urai-category-dock button:hover, .urai-category-dock button.is-active { background:rgba(155,231,255,.14); border-color:rgba(155,231,255,.34); color:white; }
+.urai-detail-actions { margin-top:1rem; display:flex; flex-wrap:wrap; gap:.5rem; }
+.urai-detail-actions button, .urai-galaxy-actions button, .urai-category-dock button {
+  border:1px solid rgba(220,246,255,.17); border-radius:999px; background:rgba(255,255,255,.065); color:rgba(239,250,255,.84);
+  padding:.48rem .75rem; font-size:.72rem; cursor:pointer; transition: background .2s ease, border-color .2s ease, transform .2s ease;
+}
+.urai-detail-actions button:hover, .urai-galaxy-actions button:hover, .urai-category-dock button:hover, .urai-category-dock button.is-active { background:rgba(155,231,255,.16); border-color:rgba(155,231,255,.42); color:white; transform:translateY(-1px); }
 
-.urai-companion-card { position:absolute; z-index:72; right:1rem; top:1rem; width:min(310px, calc(100vw - 2rem)); border-radius:18px; padding:.78rem; }
-.urai-companion-card span { font-size:.56rem; letter-spacing:.18em; opacity:.48; }
-.urai-companion-card p { margin:.34rem 0; font-size:.72rem; line-height:1.4; color:rgba(239,250,255,.72); }
-.urai-companion-card em { font-style:normal; font-size:.62rem; opacity:.44; }
-.urai-galaxy-actions { position:absolute; z-index:72; left:50%; bottom:3.95rem; transform:translateX(-50%); display:flex; gap:.42rem; padding:.45rem; border-radius:999px; }
-.urai-category-dock { position:absolute; z-index:72; left:50%; bottom:1rem; transform:translateX(-50%); display:flex; gap:.45rem; padding:.48rem; border-radius:18px; max-width:min(760px, calc(100vw - 2rem)); overflow:auto; }
-.urai-zoom-minimap { position:absolute; z-index:72; left:1rem; top:1rem; border-radius:18px; padding:.65rem .75rem; min-width:110px; }
-.urai-zoom-minimap span, .urai-zoom-minimap em { display:block; font-size:.6rem; opacity:.52; font-style:normal; }
-.urai-zoom-minimap strong { display:block; font-size:1rem; }
-.is-mirror-mode .urai-galaxy-world::after { content:""; position:absolute; top:0; bottom:0; left:50%; width:1px; background:linear-gradient(180deg, transparent, rgba(232,242,255,.34), transparent); box-shadow:0 0 24px rgba(232,242,255,.28); }
+.urai-companion-card { position:absolute; z-index:95; right:1rem; top:1rem; width:min(330px, calc(100vw - 2rem)); border-radius:22px; padding:.9rem; }
+.urai-companion-card span { font-size:.56rem; letter-spacing:.2em; opacity:.5; }
+.urai-companion-card p { margin:.38rem 0; font-size:.74rem; line-height:1.45; color:rgba(239,250,255,.75); }
+.urai-companion-card em { font-style:normal; font-size:.62rem; opacity:.45; }
+.urai-galaxy-actions { position:absolute; z-index:95; left:50%; bottom:4.15rem; transform:translateX(-50%); display:flex; gap:.46rem; padding:.48rem; border-radius:999px; }
+.urai-category-dock { position:absolute; z-index:95; left:50%; bottom:1rem; transform:translateX(-50%); display:flex; gap:.48rem; padding:.5rem; border-radius:20px; max-width:min(820px, calc(100vw - 2rem)); overflow:auto; }
+.urai-zoom-minimap { position:absolute; z-index:95; left:1rem; top:1rem; border-radius:20px; padding:.7rem .82rem; min-width:120px; }
+.urai-zoom-minimap span, .urai-zoom-minimap em { display:block; font-size:.6rem; opacity:.54; font-style:normal; }
+.urai-zoom-minimap strong { display:block; font-size:1.05rem; }
+.is-mirror-mode .urai-galaxy-world::after { content:""; position:absolute; top:0; bottom:0; left:50%; width:1px; background:linear-gradient(180deg, transparent, rgba(232,242,255,.4), transparent); box-shadow:0 0 34px rgba(232,242,255,.34); }
 
-@keyframes uraiStarTwinkle { 0%,100% { transform:scale(.82); opacity:.34; } 50% { transform:scale(1.15); opacity:1; } }
-@keyframes uraiOrbBreath { 0%,100% { transform:translate(-50%,-50%) scale(.985); opacity:.56; } 50% { transform:translate(-50%,-50%) scale(1.025); opacity:.84; } }
-@keyframes uraiPortalDrift { 0%,100% { transform:scale(1); filter:saturate(1); } 50% { transform:scale(1.055); filter:saturate(1.25); } }
+@keyframes uraiStarTwinkle { 0%,100% { transform:scale(.82); opacity:.34; } 50% { transform:scale(1.2); opacity:1; } }
+@keyframes uraiOrbBreath { 0%,100% { transform:translate(-50%,-50%) scale(.985); opacity:.58; } 50% { transform:translate(-50%,-50%) scale(1.04); opacity:.92; } }
+@keyframes uraiPortalDrift { 0%,100% { transform:scale(1); filter:saturate(1); } 50% { transform:scale(1.06); filter:saturate(1.24); } }
+@keyframes uraiGalaxyDrift { 0%,100% { transform:translate(-50%,-50%) rotate(-10deg) scale(1); } 50% { transform:translate(-50%,-50%) rotate(-7deg) scale(1.035); } }
 
 @media (max-width: 760px) {
-  .urai-avatar-silhouette { width:160px; }
-  .urai-orb-core { width:96px; height:96px; }
-  .urai-orb-halo { width:280px; height:280px; }
+  .urai-ground-system { top:46%; }
+  .urai-avatar-silhouette { width:170px; }
+  .urai-orb-core { width:108px; height:108px; }
+  .urai-orb-halo { width:340px; height:340px; }
+  .urai-orb-ring { width:220px; height:100px; }
   .urai-galaxy-world { transform:translate(-50%,-50%) scale(.78); }
   .urai-memory-detail { left:1rem; right:1rem; top:auto; bottom:8.2rem; transform:none; width:auto; }
-  .urai-memory-portal-anchor { width:198px; height:198px; }
-  .urai-companion-card { top:auto; right:1rem; bottom:7rem; width:230px; opacity:.9; }
-  .urai-galaxy-actions { bottom:4.8rem; max-width:calc(100vw - 2rem); overflow:auto; }
+  .urai-memory-portal-anchor { width:210px; height:210px; }
+  .urai-companion-card { top:auto; right:1rem; bottom:7rem; width:240px; opacity:.92; }
+  .urai-galaxy-actions { bottom:4.9rem; max-width:calc(100vw - 2rem); overflow:auto; }
   .urai-category-dock { bottom:1rem; }
   .urai-zoom-minimap { display:none; }
+  .urai-life-title strong { font-size:1.25rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .urai-star-field span, .urai-galaxy-particles span, .urai-orb-halo, .urai-portal-image { animation:none !important; }
+  .urai-star-field span, .urai-galaxy-particles span, .urai-orb-halo, .urai-portal-image, .urai-galaxy-band { animation:none !important; }
   * { scroll-behavior:auto !important; }
 }


### PR DESCRIPTION
## Summary

Applies a stronger final visual art pass to the already-integrated cinematic `/home` and `/life-map` routes after reviewing the latest screenshots. The previous implementation was structurally correct but still read too flat/prototype-like. This pass pushes the scenes toward a finished flagship app look.

## What changed

### `/home` Inner Sky Shrine
- Rebalanced the full composition so the orb, avatar, ground, and sky feel like one integrated scene.
- Removed the hard/prototype horizon feel by replacing it with layered cinematic mist, glow, and dimensional ground lighting.
- Increased orb quality with stronger premium lens lighting, better halo scale, improved sphere depth, and a more believable beam into the avatar/body.
- Improved avatar integration with stronger aura, vertical light column, and softer symbolic silhouette treatment.
- Added richer sky gradients, vignette, glow falloff, and emotional color atmosphere.
- Strengthened ground/horizon dimensionality using multiple layered ridges, light spill, fog, and rim lighting.

### `/life-map` Memory Galaxy
- Reworked the galaxy as a deeper cinematic field instead of a flat constellation board.
- Added stronger galaxy core, larger field, animated galaxy drift, richer starfield texture, dimensional banding, stronger rings, and more premium nebula feel.
- Improved star hierarchy with larger halos, stronger selected state, premium labels, and better glow.
- Improved selected-star portal scale, depth, ring treatment, tether glow, and memory detail panel styling.
- Upgraded HUD/button/glass styling to feel more like a finished celestial observatory instead of prototype controls.

## Scope

This is a CSS-driven final art pass over the existing modular implementation. No heavy 3D engine is introduced. It preserves the lightweight CSS/SVG/Framer Motion direction from the prior merged PRs.

## Files changed
- `src/styles/urai-cinematic.css`

## Validation

Patched through the GitHub connector. Please run in the workspace:

```bash
npm run check:types
npm run lint
npm run build
npm run dev
```

Then review:

```text
/home
/life-map
```
