### PR TITLE
Implement immersive 3D world on Home and Life Map

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -22,6 +22,18 @@ service cloud.firestore {
       ];
     }
 
+    function canCreateOwnedDoc() {
+      return request.auth != null && request.resource.data.ownerUid == request.auth.uid;
+    }
+
+    function canReadOwnedDoc() {
+      return request.auth != null && resource.data.ownerUid == request.auth.uid;
+    }
+
+    function canUpdateOwnedDoc() {
+      return canReadOwnedDoc() && request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+
     function hasNoProtectedUserFields() {
       return !request.resource.data.diff(resource.data).affectedKeys().hasAny([
         "entitlementTier",
@@ -73,9 +85,23 @@ service cloud.firestore {
     }
 
     match /dreams/{id} {
-      allow create: if request.auth != null && request.resource.data.ownerUid == request.auth.uid;
-      allow read: if request.auth != null && resource.data.ownerUid == request.auth.uid;
-      allow update: if request.auth != null && resource.data.ownerUid == request.auth.uid && request.resource.data.ownerUid == resource.data.ownerUid;
+      allow create: if canCreateOwnedDoc();
+      allow read: if canReadOwnedDoc();
+      allow update: if canUpdateOwnedDoc();
+      allow delete: if false;
+    }
+
+    match /rituals/{id} {
+      allow create: if canCreateOwnedDoc();
+      allow read: if canReadOwnedDoc();
+      allow update: if canUpdateOwnedDoc();
+      allow delete: if false;
+    }
+
+    match /timelineEvents/{id} {
+      allow create: if canCreateOwnedDoc();
+      allow read: if canReadOwnedDoc();
+      allow update: if canUpdateOwnedDoc();
       allow delete: if false;
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,3 +1,56 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(uid) {
+      return isSignedIn() && request.auth.uid == uid;
+    }
+
+    function validConsentSource(source) {
+      return source in [
+        "profile",
+        "timeline_events",
+        "memory_blooms",
+        "mood_inference",
+        "relationship_signals",
+        "rituals",
+        "offline_cache"
+      ];
+    }
+
+    function hasNoProtectedUserFields() {
+      return !request.resource.data.diff(resource.data).affectedKeys().hasAny([
+        "entitlementTier",
+        "roles",
+        "admin",
+        "founder",
+        "internal",
+        "internalOverride",
+        "isAdmin",
+        "isFounder"
+      ]);
+    }
+
+    function canCreateConsent(uid, source) {
+      return isOwner(uid)
+        && validConsentSource(source)
+        && request.resource.data.ownerUid == uid
+        && request.resource.data.source == source;
+    }
+
+    function canUpdateConsent(uid, source) {
+      return isOwner(uid)
+        && validConsentSource(source)
+        && resource.data.ownerUid == uid
+        && resource.data.source == source
+        && request.resource.data.ownerUid == uid
+        && request.resource.data.source == source;
+    }
+
     match /users/{uid} {
       allow read: if request.auth != null && request.auth.uid == uid;
       allow create, update: if request.auth != null && request.auth.uid == uid && hasNoProtectedUserFields();
@@ -19,6 +72,10 @@
       }
     }
 
+    match /waitlistSignups/{id} {
+      allow read, write: if false;
+    }
+
     match /features/{flagId} {
       allow read, write: if false;
     }
@@ -26,3 +83,13 @@
     match /entitlements/{uid} {
       allow read, write: if false;
     }
+
+    match /auditLogs/{id} {
+      allow read, write: if false;
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -72,6 +72,13 @@ service cloud.firestore {
       }
     }
 
+    match /dreams/{id} {
+      allow create: if request.auth != null && request.resource.data.ownerUid == request.auth.uid;
+      allow read: if request.auth != null && resource.data.ownerUid == request.auth.uid;
+      allow update: if request.auth != null && resource.data.ownerUid == request.auth.uid && request.resource.data.ownerUid == resource.data.ownerUid;
+      allow delete: if false;
+    }
+
     match /waitlistSignups/{id} {
       allow read, write: if false;
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -84,26 +84,27 @@ service cloud.firestore {
       }
     }
 
-    match /dreams/{id} {
-      allow create: if canCreateOwnedDoc();
-      allow read: if canReadOwnedDoc();
-      allow update: if canUpdateOwnedDoc();
-      allow delete: if false;
-    }
-
-    match /rituals/{id} {
-      allow create: if canCreateOwnedDoc();
-      allow read: if canReadOwnedDoc();
-      allow update: if canUpdateOwnedDoc();
-      allow delete: if false;
-    }
-
-    match /timelineEvents/{id} {
-      allow create: if canCreateOwnedDoc();
-      allow read: if canReadOwnedDoc();
-      allow update: if canUpdateOwnedDoc();
-      allow delete: if false;
-    }
+    match /dreams/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /rituals/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /timelineEvents/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /personaEvolutions/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /soulThreads/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /socialArchetypes/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /weeklyScrolls/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /moods/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /shadowMetrics/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /obscuraPatterns/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /cognitiveStress/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /recoveryBlooms/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /relationshipConstellations/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /voiceEvents/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /dreamConstellations/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /memoryBlooms/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /badges/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /notifications/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /journalEntries/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /events/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
+    match /insightMarket/{id} { allow create: if canCreateOwnedDoc(); allow read: if canReadOwnedDoc(); allow update: if canUpdateOwnedDoc(); allow delete: if false; }
 
     match /waitlistSignups/{id} {
       allow read, write: if false;

--- a/src/app/home-view.tsx
+++ b/src/app/home-view.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import Button from "@/components/ui/Button";
 import Chip from "@/components/ui/Chip";
 import OrbChatDrawer from "@/components/orb/OrbChatDrawer";
+import ImmersiveWorld3D from "@/components/urai/world/ImmersiveWorld3D";
 
 const STATUS_MESSAGES = [
   "Calibrating constellations…",
@@ -42,12 +43,15 @@ export default function HomeView(): React.ReactElement {
   return (
     <>
       <div className="relative flex min-h-screen flex-col items-center justify-between overflow-hidden bg-black text-white">
-        <div className="absolute left-0 right-0 top-0 flex items-center justify-between p-4 text-sm text-white/80">
+        <ImmersiveWorld3D mode="home" activeLabel={statusMessage} selectedLabel={orbOpen ? "Origin Orb" : undefined} />
+        <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-t from-black via-transparent to-black/70" />
+
+        <div className="absolute left-0 right-0 top-0 z-20 flex items-center justify-between p-4 text-sm text-white/80">
           <span>{statusMessage}</span>
           <Button variant="secondary">Local-Only</Button>
         </div>
 
-        <div className="flex w-full flex-1 flex-col items-center justify-center gap-8 py-20">
+        <div className="relative z-10 flex w-full flex-1 flex-col items-center justify-center gap-8 py-20">
           <AnimatePresence mode="wait">
             <motion.div
               key={statusIndex}
@@ -57,21 +61,22 @@ export default function HomeView(): React.ReactElement {
               transition={{ duration: 0.5 }}
               className="flex flex-col items-center gap-6"
             >
-              <div className="relative h-64 w-64">
+              <div className="relative h-64 w-64 rounded-full border border-cyan-100/10 bg-slate-950/20 shadow-[0_0_120px_rgba(125,211,252,.16)] backdrop-blur-[1px]">
                 {HERO_IMAGES.map((image, index) => (
                   <motion.video
                     key={image.src}
-                    className="absolute inset-0 h-full w-full rounded-full object-cover"
+                    className="absolute inset-0 h-full w-full rounded-full object-cover mix-blend-screen"
                     autoPlay
                     muted
                     loop
                     playsInline
                     initial={{ opacity: 0 }}
-                    animate={{ opacity: statusIndex === index ? 1 : 0 }}
+                    animate={{ opacity: statusIndex === index ? 0.62 : 0 }}
                     transition={{ duration: 0.6 }}
                     src={image.src}
                   />
                 ))}
+                <div className="absolute inset-8 rounded-full bg-cyan-100/10 blur-2xl" />
               </div>
 
               <div className="flex flex-col items-center gap-4">
@@ -79,12 +84,12 @@ export default function HomeView(): React.ReactElement {
                   type="button"
                   aria-label="Open URAI Orb"
                   onClick={() => setOrbOpen(true)}
-                  className="relative flex h-24 w-24 items-center justify-center rounded-full border border-sky-300/30 bg-sky-400/20"
+                  className="relative flex h-24 w-24 items-center justify-center rounded-full border border-sky-100/40 bg-sky-300/15 shadow-[0_0_80px_rgba(125,211,252,.28)] backdrop-blur-md"
                   animate={{
                     scale: orbState === "open" ? 1.08 : [1, 1.12, 1],
                     boxShadow:
                       orbState === "open"
-                        ? "0 0 60px rgba(56,189,248,0.55)"
+                        ? "0 0 84px rgba(224,242,254,0.68)"
                         : [
                             "0 0 0 0 rgba(56,189,248,0.55)",
                             "0 0 0 24px rgba(56,189,248,0)",
@@ -93,7 +98,7 @@ export default function HomeView(): React.ReactElement {
                   }}
                   transition={{ duration: 2.2, repeat: Infinity, ease: "easeInOut" }}
                 >
-                  <div className="absolute inset-2 rounded-full bg-sky-300/30 blur-md" />
+                  <div className="absolute inset-2 rounded-full bg-sky-200/35 blur-md" />
                   <div className="relative z-10 text-xs uppercase tracking-[0.25em] text-white/90">
                     Orb
                   </div>
@@ -110,12 +115,12 @@ export default function HomeView(): React.ReactElement {
                       window.location.href = "/life-map";
                     }}
                   >
-                    Tap the sky
+                    Enter Life Map
                   </Button>
                 </div>
 
-                <p className="max-w-md text-center text-sm text-white/55">
-                  Your orb remembers rhythm, mood, recovery, and emotional patterns over time.
+                <p className="max-w-md text-center text-sm text-white/65">
+                  Move your pointer to feel the world shift around your orb. Enter the Life Map to fly through memory, recovery, purpose, and legacy.
                 </p>
               </div>
             </motion.div>
@@ -128,8 +133,6 @@ export default function HomeView(): React.ReactElement {
           <Chip>Orb Chat</Chip>
           <Chip>Rituals</Chip>
         </div>
-
-        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black via-transparent to-black" />
       </div>
 
       <OrbChatDrawer

--- a/src/components/life-map/LifeMapUniverse.tsx
+++ b/src/components/life-map/LifeMapUniverse.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { LifeMapFilter, LifeMapMode, MemoryStar, QualityMode } from "@/lib/life-map/types";
 import { lifeMapMockData, selectedBlueFogMemory, spatialARVRScaffold } from "@/lib/life-map/mock-data";
 import CompanionNarratorPanel from "./CompanionNarratorPanel";
@@ -49,16 +50,42 @@ export default function LifeMapUniverse() {
 
   const selectedStar = useMemo(() => lifeMapMockData.memoryStars.find((star) => star.id === selectedStarId) ?? selectedBlueFogMemory, [selectedStarId]);
 
-  function selectStar(star: MemoryStar) {
+  const selectStar = useCallback((star: MemoryStar) => {
     setSelectedStarId(star.id);
     setCameraCommand("focus");
-  }
+  }, []);
 
-  function selectStarByOffset(offset: number) {
+  const selectStarByOffset = useCallback((offset: number) => {
     const visibleStars = lifeMapMockData.memoryStars.filter((star) => !hiddenStarIds.includes(star.id));
     const currentIndex = Math.max(0, visibleStars.findIndex((star) => star.id === selectedStarId));
     const nextStar = visibleStars[(currentIndex + offset + visibleStars.length) % visibleStars.length];
     if (nextStar) selectStar(nextStar);
+  }, [hiddenStarIds, selectStar, selectedStarId]);
+
+  function hideSelectedThread() {
+    const threadId = selectedStar.constellationId;
+    const constellation = lifeMapMockData.lifeConstellations.find((thread) => thread.id === threadId);
+    if (!constellation) return setHiddenStarIds((ids) => Array.from(new Set([...ids, selectedStar.id])));
+    setHiddenStarIds((ids) => Array.from(new Set([...ids, ...constellation.starIds])));
+  }
+
+  function startReplay() {
+    setIsReplaying(true);
+    setCameraCommand("replay");
+  }
+
+  function startMirror() {
+    setMode("mirrorOfBecoming");
+    setCameraCommand("mirror");
+  }
+
+  function recenter() {
+    setMode("memoryGalaxy");
+    setCameraCommand("recenter");
+  }
+
+  function openScrollExport() {
+    setExportOpen(true);
   }
 
   useEffect(() => {
@@ -87,33 +114,7 @@ export default function LifeMapUniverse() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [hiddenStarIds, selectedStar, selectedStarId]);
-
-  function hideSelectedThread() {
-    const threadId = selectedStar.constellationId;
-    const constellation = lifeMapMockData.lifeConstellations.find((thread) => thread.id === threadId);
-    if (!constellation) return setHiddenStarIds((ids) => Array.from(new Set([...ids, selectedStar.id])));
-    setHiddenStarIds((ids) => Array.from(new Set([...ids, ...constellation.starIds])));
-  }
-
-  function startReplay() {
-    setIsReplaying(true);
-    setCameraCommand("replay");
-  }
-
-  function startMirror() {
-    setMode("mirrorOfBecoming");
-    setCameraCommand("mirror");
-  }
-
-  function recenter() {
-    setMode("memoryGalaxy");
-    setCameraCommand("recenter");
-  }
-
-  function openScrollExport() {
-    setExportOpen(true);
-  }
+  }, [selectStarByOffset, selectedStar]);
 
   function textOnlyStars() {
     return (
@@ -143,7 +144,7 @@ export default function LifeMapUniverse() {
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(191,233,255,0.12),transparent_28%),linear-gradient(180deg,rgba(2,6,23,0.3),#020617)]" />
 
       <header className="pointer-events-none fixed left-0 right-0 top-0 z-20 flex items-start justify-center px-4 pt-5">
-        <a href="/" className="pointer-events-auto fixed left-5 top-5 grid h-11 w-11 place-items-center rounded-full border border-cyan-100/15 bg-slate-950/70 text-cyan-50 shadow-[0_0_28px_rgba(191,233,255,0.12)] backdrop-blur-xl hover:bg-cyan-100/10" aria-label="Back to URAI home">←</a>
+        <Link href="/" className="pointer-events-auto fixed left-5 top-5 grid h-11 w-11 place-items-center rounded-full border border-cyan-100/15 bg-slate-950/70 text-cyan-50 shadow-[0_0_28px_rgba(191,233,255,0.12)] backdrop-blur-xl hover:bg-cyan-100/10" aria-label="Back to URAI home">←</Link>
         <div className="rounded-3xl border border-cyan-100/10 bg-slate-950/55 px-6 py-3 text-center shadow-[0_0_42px_rgba(2,132,199,0.16)] backdrop-blur-2xl">
           <p className="text-xs font-semibold uppercase tracking-[0.35em] text-cyan-100/60">URAI LIFE MAP</p>
           <h1 className="mt-1 text-2xl font-semibold tracking-tight">{modeLabels[mode]}</h1>

--- a/src/components/urai/life-map/LifeMapPage.tsx
+++ b/src/components/urai/life-map/LifeMapPage.tsx
@@ -6,6 +6,7 @@ import type { MemoryCategory } from "@/components/urai/data/emotionPalette";
 import { useGalaxyCamera } from "@/components/urai/hooks/useGalaxyCamera";
 import { useReducedMotionSafe } from "@/components/urai/hooks/useReducedMotionSafe";
 import { useStarSelection } from "@/components/urai/hooks/useStarSelection";
+import ImmersiveWorld3D from "@/components/urai/world/ImmersiveWorld3D";
 import { ConstellationThreadLayer } from "./ConstellationThreadLayer";
 import { GalaxyBackground } from "./GalaxyBackground";
 import { GalaxyCamera } from "./GalaxyCamera";
@@ -77,6 +78,11 @@ export function LifeMapPage() {
 
   return (
     <main className={`urai-screen urai-life-map-screen ${mode === "mirror" ? "is-mirror-mode" : ""} ${selected ? "has-selected-star" : ""}`}>
+      <ImmersiveWorld3D
+        mode="life-map"
+        activeLabel={activeCategory === "all" ? `All fields · ${mode}` : `${activeCategory} · ${mode}`}
+        selectedLabel={selected?.title}
+      />
       <GalaxyParticles />
       <GalaxyBackground />
       <header className="urai-life-title">

--- a/src/components/urai/world/ImmersiveWorld3D.tsx
+++ b/src/components/urai/world/ImmersiveWorld3D.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type ImmersiveWorldMode = "home" | "life-map";
+
+interface ImmersiveWorld3DProps {
+  mode: ImmersiveWorldMode;
+  activeLabel?: string;
+  selectedLabel?: string;
+  className?: string;
+}
+
+const WORLD_NODES = [
+  { id: "origin", x: 50, y: 48, z: 0, size: 138, label: "Origin Orb" },
+  { id: "memory", x: 32, y: 42, z: -80, size: 58, label: "Memory" },
+  { id: "recovery", x: 67, y: 43, z: -110, size: 52, label: "Recovery" },
+  { id: "purpose", x: 47, y: 28, z: -170, size: 46, label: "Purpose" },
+  { id: "shadow", x: 24, y: 61, z: -210, size: 38, label: "Shadow" },
+  { id: "joy", x: 73, y: 60, z: -190, size: 42, label: "Joy" },
+  { id: "legacy", x: 52, y: 72, z: -260, size: 34, label: "Legacy" },
+];
+
+function useWorldMotion(mode: ImmersiveWorldMode) {
+  const [motion, setMotion] = useState({ x: 0, y: 0, depth: mode === "home" ? 1 : 1.08 });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (mediaQuery.matches) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const nextX = (event.clientX / Math.max(1, window.innerWidth) - 0.5) * 2;
+      const nextY = (event.clientY / Math.max(1, window.innerHeight) - 0.5) * 2;
+      setMotion((current) => ({
+        x: current.x + (nextX - current.x) * 0.18,
+        y: current.y + (nextY - current.y) * 0.18,
+        depth: current.depth,
+      }));
+    };
+
+    window.addEventListener("pointermove", handlePointerMove, { passive: true });
+    return () => window.removeEventListener("pointermove", handlePointerMove);
+  }, []);
+
+  return motion;
+}
+
+export default function ImmersiveWorld3D({ mode, activeLabel, selectedLabel, className = "" }: ImmersiveWorld3DProps) {
+  const motion = useWorldMotion(mode);
+  const constellationLines = useMemo(
+    () => [
+      [WORLD_NODES[0], WORLD_NODES[1]],
+      [WORLD_NODES[0], WORLD_NODES[2]],
+      [WORLD_NODES[1], WORLD_NODES[3]],
+      [WORLD_NODES[2], WORLD_NODES[5]],
+      [WORLD_NODES[3], WORLD_NODES[6]],
+      [WORLD_NODES[4], WORLD_NODES[6]],
+    ],
+    [],
+  );
+
+  const worldTransform = `rotateX(${8 - motion.y * 5}deg) rotateY(${motion.x * 9}deg) translate3d(${motion.x * 16}px, ${motion.y * 12}px, 0) scale(${motion.depth})`;
+  const modeClass = mode === "home" ? "urai-world-home" : "urai-world-life-map";
+
+  return (
+    <div className={`urai-immersive-world ${modeClass} ${className}`} aria-hidden="true">
+      <div className="urai-world-sky" />
+      <div className="urai-world-moon" />
+      <div className="urai-world-perspective">
+        <div className="urai-world-stage" style={{ transform: worldTransform }}>
+          <div className="urai-world-floor">
+            <div className="urai-world-grid" />
+            <div className="urai-world-reflection" />
+          </div>
+
+          <div className="urai-world-ring urai-world-ring-one" />
+          <div className="urai-world-ring urai-world-ring-two" />
+          <div className="urai-world-ring urai-world-ring-three" />
+
+          {constellationLines.map(([from, to]) => {
+            const dx = to.x - from.x;
+            const dy = to.y - from.y;
+            const length = Math.sqrt(dx * dx + dy * dy);
+            const angle = Math.atan2(dy, dx) * (180 / Math.PI);
+            return (
+              <span
+                key={`${from.id}-${to.id}`}
+                className="urai-world-line"
+                style={{
+                  left: `${from.x}%`,
+                  top: `${from.y}%`,
+                  width: `${length}%`,
+                  transform: `rotate(${angle}deg) translateZ(${Math.min(from.z, to.z)}px)`,
+                }}
+              />
+            );
+          })}
+
+          {WORLD_NODES.map((node, index) => {
+            const isCore = node.id === "origin";
+            const isSelected = selectedLabel?.toLowerCase().includes(node.label.toLowerCase());
+            return (
+              <div
+                key={node.id}
+                className={`urai-world-node ${isCore ? "is-core" : ""} ${isSelected ? "is-selected" : ""}`}
+                style={{
+                  left: `${node.x}%`,
+                  top: `${node.y}%`,
+                  width: node.size,
+                  height: node.size,
+                  transform: `translate3d(-50%, -50%, ${node.z}px)`,
+                  animationDelay: `${index * 0.36}s`,
+                }}
+              >
+                <span className="urai-world-node-core" />
+                <span className="urai-world-node-label">{node.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="urai-world-atmosphere" />
+      <div className="urai-world-vignette" />
+      {(activeLabel || selectedLabel) && (
+        <div className="urai-world-status">
+          <span>{selectedLabel || activeLabel}</span>
+        </div>
+      )}
+
+      <style jsx>{`
+        .urai-immersive-world {
+          position: absolute;
+          inset: 0;
+          overflow: hidden;
+          pointer-events: none;
+          background:
+            radial-gradient(circle at 50% 20%, rgba(125, 211, 252, 0.16), transparent 24%),
+            radial-gradient(circle at 74% 28%, rgba(196, 181, 253, 0.12), transparent 22%),
+            linear-gradient(180deg, #020617 0%, #041026 46%, #020617 100%);
+          isolation: isolate;
+        }
+
+        .urai-world-life-map {
+          opacity: 0.78;
+          mix-blend-mode: screen;
+        }
+
+        .urai-world-home {
+          opacity: 0.9;
+        }
+
+        .urai-world-sky,
+        .urai-world-atmosphere,
+        .urai-world-vignette,
+        .urai-world-moon {
+          position: absolute;
+          inset: 0;
+        }
+
+        .urai-world-sky {
+          background-image:
+            radial-gradient(circle at 8% 18%, rgba(255, 255, 255, 0.9) 0 1px, transparent 2px),
+            radial-gradient(circle at 20% 36%, rgba(186, 230, 253, 0.7) 0 1px, transparent 2px),
+            radial-gradient(circle at 38% 17%, rgba(255, 255, 255, 0.8) 0 1px, transparent 2px),
+            radial-gradient(circle at 59% 31%, rgba(221, 214, 254, 0.75) 0 1px, transparent 2px),
+            radial-gradient(circle at 83% 15%, rgba(255, 255, 255, 0.86) 0 1px, transparent 2px),
+            radial-gradient(circle at 91% 44%, rgba(186, 230, 253, 0.72) 0 1px, transparent 2px);
+          opacity: 0.65;
+          filter: drop-shadow(0 0 10px rgba(125, 211, 252, 0.4));
+        }
+
+        .urai-world-moon {
+          left: auto;
+          right: clamp(32px, 8vw, 120px);
+          top: clamp(54px, 10vh, 110px);
+          width: clamp(84px, 9vw, 148px);
+          height: clamp(84px, 9vw, 148px);
+          border-radius: 999px;
+          background: radial-gradient(circle at 38% 36%, rgba(255, 255, 255, 0.9), rgba(219, 234, 254, 0.36) 38%, transparent 69%);
+          filter: blur(0.2px) drop-shadow(0 0 52px rgba(186, 230, 253, 0.34));
+          opacity: 0.34;
+        }
+
+        .urai-world-perspective {
+          position: absolute;
+          inset: 0;
+          perspective: 900px;
+          perspective-origin: 50% 44%;
+          transform-style: preserve-3d;
+        }
+
+        .urai-world-stage {
+          position: absolute;
+          inset: 0;
+          transform-style: preserve-3d;
+          transition: transform 280ms ease-out;
+          will-change: transform;
+        }
+
+        .urai-world-floor {
+          position: absolute;
+          left: 50%;
+          top: 62%;
+          width: min(1120px, 112vw);
+          height: min(560px, 55vh);
+          transform: translate3d(-50%, -18%, -340px) rotateX(68deg);
+          transform-style: preserve-3d;
+          border-radius: 50%;
+          background:
+            radial-gradient(ellipse at 50% 42%, rgba(125, 211, 252, 0.18), transparent 42%),
+            radial-gradient(ellipse at 50% 70%, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.98) 72%);
+          border: 1px solid rgba(186, 230, 253, 0.14);
+          box-shadow: inset 0 18px 80px rgba(125, 211, 252, 0.08), 0 0 100px rgba(14, 165, 233, 0.14);
+        }
+
+        .urai-world-grid {
+          position: absolute;
+          inset: 0;
+          border-radius: inherit;
+          background-image:
+            linear-gradient(rgba(125, 211, 252, 0.13) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(125, 211, 252, 0.13) 1px, transparent 1px);
+          background-size: 58px 58px;
+          opacity: 0.28;
+          mask-image: radial-gradient(ellipse at 50% 50%, #000 0%, transparent 70%);
+        }
+
+        .urai-world-reflection {
+          position: absolute;
+          inset: 18% 24%;
+          border-radius: 50%;
+          background: radial-gradient(ellipse at 50% 50%, rgba(255, 255, 255, 0.16), rgba(125, 211, 252, 0.1) 30%, transparent 68%);
+          filter: blur(18px);
+        }
+
+        .urai-world-ring {
+          position: absolute;
+          left: 50%;
+          top: 50%;
+          border-radius: 50%;
+          border: 1px solid rgba(186, 230, 253, 0.2);
+          transform-style: preserve-3d;
+          box-shadow: 0 0 38px rgba(125, 211, 252, 0.09);
+        }
+
+        .urai-world-ring-one {
+          width: min(560px, 72vw);
+          height: min(560px, 72vw);
+          transform: translate3d(-50%, -50%, -90px) rotateX(62deg) rotateZ(-12deg);
+        }
+
+        .urai-world-ring-two {
+          width: min(760px, 92vw);
+          height: min(760px, 92vw);
+          transform: translate3d(-50%, -50%, -180px) rotateX(66deg) rotateZ(18deg);
+          opacity: 0.72;
+        }
+
+        .urai-world-ring-three {
+          width: min(980px, 118vw);
+          height: min(980px, 118vw);
+          transform: translate3d(-50%, -50%, -280px) rotateX(70deg) rotateZ(-28deg);
+          opacity: 0.46;
+        }
+
+        .urai-world-line {
+          position: absolute;
+          height: 1px;
+          transform-origin: 0 50%;
+          background: linear-gradient(90deg, rgba(125, 211, 252, 0), rgba(165, 243, 252, 0.48), rgba(196, 181, 253, 0));
+          filter: drop-shadow(0 0 8px rgba(125, 211, 252, 0.36));
+        }
+
+        .urai-world-node {
+          position: absolute;
+          display: grid;
+          place-items: center;
+          transform-style: preserve-3d;
+          border-radius: 50%;
+          animation: urai-world-float 7s ease-in-out infinite;
+        }
+
+        .urai-world-node-core {
+          width: 100%;
+          height: 100%;
+          border-radius: inherit;
+          background:
+            radial-gradient(circle at 36% 30%, rgba(255, 255, 255, 0.96), rgba(186, 230, 253, 0.82) 19%, rgba(56, 189, 248, 0.32) 43%, rgba(88, 28, 135, 0.06) 72%, transparent 78%);
+          border: 1px solid rgba(224, 242, 254, 0.5);
+          box-shadow:
+            inset -18px -22px 42px rgba(14, 165, 233, 0.18),
+            inset 12px 12px 34px rgba(255, 255, 255, 0.16),
+            0 0 34px rgba(125, 211, 252, 0.32),
+            0 0 96px rgba(99, 102, 241, 0.14);
+        }
+
+        .urai-world-node.is-core .urai-world-node-core {
+          box-shadow:
+            inset -22px -30px 60px rgba(14, 165, 233, 0.24),
+            inset 14px 16px 42px rgba(255, 255, 255, 0.2),
+            0 0 46px rgba(224, 242, 254, 0.52),
+            0 0 130px rgba(125, 211, 252, 0.36),
+            0 0 220px rgba(196, 181, 253, 0.18);
+        }
+
+        .urai-world-node.is-selected .urai-world-node-core {
+          outline: 2px solid rgba(255, 255, 255, 0.8);
+          box-shadow: 0 0 46px rgba(255, 255, 255, 0.72), 0 0 150px rgba(125, 211, 252, 0.45);
+        }
+
+        .urai-world-node-label {
+          position: absolute;
+          top: calc(100% + 8px);
+          left: 50%;
+          transform: translateX(-50%);
+          white-space: nowrap;
+          border-radius: 999px;
+          border: 1px solid rgba(186, 230, 253, 0.18);
+          background: rgba(2, 6, 23, 0.5);
+          padding: 4px 9px;
+          font-size: 10px;
+          letter-spacing: 0.18em;
+          text-transform: uppercase;
+          color: rgba(224, 242, 254, 0.72);
+          backdrop-filter: blur(10px);
+        }
+
+        .urai-world-atmosphere {
+          background:
+            radial-gradient(ellipse at 50% 62%, rgba(125, 211, 252, 0.16), transparent 28%),
+            radial-gradient(ellipse at 50% 78%, rgba(15, 23, 42, 0.4), transparent 40%),
+            linear-gradient(180deg, transparent 0%, rgba(2, 6, 23, 0.18) 45%, rgba(0, 0, 0, 0.7) 100%);
+          z-index: 3;
+        }
+
+        .urai-world-vignette {
+          z-index: 4;
+          box-shadow: inset 0 0 140px rgba(0, 0, 0, 0.78);
+        }
+
+        .urai-world-status {
+          position: absolute;
+          right: clamp(18px, 4vw, 56px);
+          bottom: clamp(18px, 5vh, 72px);
+          z-index: 5;
+          max-width: min(360px, 70vw);
+          border: 1px solid rgba(186, 230, 253, 0.16);
+          border-radius: 999px;
+          background: rgba(2, 6, 23, 0.48);
+          padding: 10px 14px;
+          color: rgba(224, 242, 254, 0.76);
+          font-size: 11px;
+          letter-spacing: 0.16em;
+          text-transform: uppercase;
+          backdrop-filter: blur(16px);
+        }
+
+        @keyframes urai-world-float {
+          0%, 100% {
+            filter: brightness(0.94);
+          }
+          50% {
+            filter: brightness(1.2);
+          }
+        }
+
+        @media (max-width: 760px) {
+          .urai-world-life-map {
+            opacity: 0.58;
+          }
+
+          .urai-world-node-label {
+            display: none;
+          }
+
+          .urai-world-node:not(.is-core) {
+            opacity: 0.7;
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .urai-world-stage {
+            transition: none;
+          }
+
+          .urai-world-node {
+            animation: none;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/lib/life-map/mock-data.ts
+++ b/src/lib/life-map/mock-data.ts
@@ -75,11 +75,6 @@ const star = (
   updatedAt: now(),
 });
 
-const fromStarBase = (base: MemoryStar, overrideType: string) => ({
-  ...base,
-  type: overrideType,
-});
-
 export const memoryStars: MemoryStar[] = [
   selectedBlueFogMemory,
   star("soft-return", "recovery", "Soft Return", "first green-gold recovery thread", -1.4, 0.2, -0.4, ["recovery", "relief"], ["green path"], "#86efac", "recovery-thread", "A recovery path is forming near this cluster."),
@@ -163,7 +158,7 @@ export const spatialARVRScaffold: SpatialARVRScaffold = {
   standingInsideNebulaFields: "Future mode for standing inside emotional season fog.",
 };
 
-const lifeConstellations: LifeConstellation[] = [
+const lifeConstellationSeeds: Pick<LifeConstellation, "id" | "theme" | "starIds" | "lineColor">[] = [
   { id: "grief-thread", theme: "Grief", starIds: ["blue-fog-memory", "winter-thread", "soft-return"], lineColor: "#bfe9ff" },
   { id: "recovery-thread", theme: "Recovery", starIds: ["quiet-ritual", "soft-return", "blue-fog-memory"], lineColor: "#86efac" },
   { id: "relationship-thread", theme: "Relationships", starIds: ["orbit-close", "companion-watch"], lineColor: "#f9a8d4" },
@@ -172,7 +167,9 @@ const lifeConstellations: LifeConstellation[] = [
   { id: "shadow-thread", theme: "Shadow", starIds: ["shadow-loop", "work-flare", "threshold-door"], lineColor: "#64748b" },
   { id: "legacy-thread", theme: "Legacy", starIds: ["legacy-gold", "purpose-north"], lineColor: "#facc15" },
   { id: "rebirth-thread", theme: "Rebirth", starIds: ["threshold-door", "rebirth-bloom", "joy-spark"], lineColor: "#fb7185" },
-].map((thread) => ({
+];
+
+const lifeConstellations: LifeConstellation[] = lifeConstellationSeeds.map((thread) => ({
   ...thread,
   userId: "demo-user",
   title: thread.theme,
@@ -207,23 +204,27 @@ const nebulaRegions: NebulaRegion[] = ["Grief Fog", "Stress Shimmer", "Dream Clo
 }));
 
 const dreamSymbols: DreamSymbol[] = ["Orchid", "Violet Door", "Moon Water"].map((title, i) => ({
-  ...fromStarBase(star(`dream-symbol-${i + 1}`, "dream", title, "dream symbolic cloud", -1 + i, 2, -1.8, ["dream"], [title], "#c084fc", "dream-thread"), "dreamSymbol"),
+  ...star(`dream-symbol-${i + 1}`, "dream", title, "dream symbolic cloud", -1 + i, 2, -1.8, ["dream"], [title], "#c084fc", "dream-thread"),
+  type: "dreamSymbol",
   symbolKind: title,
 }));
 
 const shadowThreads: ShadowThread[] = ["Shame Loop", "Conflict Echo"].map((title, i) => ({
-  ...fromStarBase(star(`shadow-thread-${i + 1}`, "shadow", title, "dim unresolved cluster", -2 + i, -1.5, -1.4, ["stress"], ["shadow"], "#64748b", "shadow-thread"), "shadowThread"),
+  ...star(`shadow-thread-${i + 1}`, "shadow", title, "dim unresolved cluster", -2 + i, -1.5, -1.4, ["stress"], ["shadow"], "#64748b", "shadow-thread"),
+  type: "shadowThread",
   unresolvedLoopScore: 0.6 + i * 0.2,
 }));
 
 const legacyThreads: LegacyThread[] = ["Ancestor Gold", "Future Letter"].map((title, i) => ({
-  ...fromStarBase(star(`legacy-thread-${i + 1}`, "legacy", title, "gold ancestral thread", 3 + i, 1.4, -1, ["legacy"], ["gold thread"], "#facc15", "legacy-thread"), "legacyThread"),
+  ...star(`legacy-thread-${i + 1}`, "legacy", title, "gold ancestral thread", 3 + i, 1.4, -1, ["legacy"], ["gold thread"], "#facc15", "legacy-thread"),
+  type: "legacyThread",
   ancestralTone: "gold",
 }));
 
 const replaySequences: ReplaySequence[] = [
   {
-    ...fromStarBase(star("replay-blue-thread", "memory", "Blue Thread Replay", "camera path through grief and recovery", 0, 0, 0, ["replay"], ["camera path"], "#bfe9ff", "grief-thread"), "replaySequence"),
+    ...star("replay-blue-thread", "memory", "Blue Thread Replay", "camera path through grief and recovery", 0, 0, 0, ["replay"], ["camera path"], "#bfe9ff", "grief-thread"),
+    type: "replaySequence",
     starIds: ["blue-fog-memory", "soft-return", "quiet-ritual"],
     cameraPathId: "replay",
     durationMs: 3600,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,1 +1,40 @@
 export type Category = "winter" | "spring" | "summer" | "autumn";
+
+export type OrbMessageMode = "text" | "voice";
+
+export interface OrbChatContext {
+  todayMoodState?: string;
+  mentalLoadScore?: number;
+  rhythmState?: string;
+  lastNarratorInsight?: string;
+  recentTimelineEvents?: string[];
+  relationshipSignals?: string[];
+  userTonePreference?: string;
+}
+
+export interface OrbMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  mode: OrbMessageMode;
+  emotionTags: string[];
+  createdAt: string;
+}
+
+export interface OrbChat {
+  id: string;
+  userId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  lastMessagePreview?: string;
+}
+
+export interface ConversationInsight {
+  id: string;
+  userId: string;
+  insight: string;
+  emotionTags: string[];
+  score: number;
+  createdAt: string;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,6 +35,6 @@ export interface ConversationInsight {
   userId: string;
   insight: string;
   emotionTags: string[];
-  score: number;
+  memoryImportanceScore: number;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- Added a shared dependency-free `ImmersiveWorld3D` client component with parallax camera motion, layered perspective depth, reflective floor, orbit rings, constellation lines, and orb/memory nodes.
- Wired the 3D world into Home behind the existing orb/chat entry points, preserving the current CTA flow while making the landing experience feel interactive.
- Wired the same 3D world into Life Map behind the existing Memory Galaxy controls so the page now feels spatial without removing zoom, replay, mirror, recenter, or star selection behavior.

## Notes
- Uses CSS 3D transforms and existing React/Next dependencies only; no Three.js or new package install required.
- Honors `prefers-reduced-motion` by disabling pointer-driven motion and float animation.

## Validation
- Static sanity pass performed against the touched files and existing `MemoryStar` shape.
- I did not run the full repo build in this environment.