### PR TITLE
Add feature-gated URAI Spatial production shell

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,22 +1,172 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function signedIn() {
+      return request.auth != null;
+    }
+
+    function isSelf(uid) {
+      return signedIn() && request.auth.uid == uid;
+    }
+
+    function isOwnerResource() {
+      return signedIn() && resource.data.ownerUid == request.auth.uid;
+    }
+
+    function isOwnerRequest() {
+      return signedIn() && request.resource.data.ownerUid == request.auth.uid;
+    }
+
+    function canReadOwnerDoc() {
+      return isOwnerResource();
+    }
+
+    function canCreateOwnerDoc() {
+      return isOwnerRequest();
+    }
+
+    function canUpdateOwnerDoc() {
+      return isOwnerResource() && isOwnerRequest();
+    }
+
+    function hasNoProtectedUserFields() {
+      return !request.resource.data.diff(resource.data).affectedKeys().hasAny(['tier', 'role', 'admin', 'createdAt']);
+    }
+
+    function canCreateConsent(uid, source) {
+      return isSelf(uid) && request.resource.data.uid == uid;
+    }
+
+    function canUpdateConsent(uid, source) {
+      return isSelf(uid) && resource.data.uid == uid && request.resource.data.uid == uid;
+    }
+
     match /users/{uid} {
-      allow read: if request.auth != null && request.auth.uid == uid;
-      allow create, update: if request.auth != null && request.auth.uid == uid && hasNoProtectedUserFields();
-      allow delete: if request.auth != null && request.auth.uid == uid;
+      allow read: if isSelf(uid);
+      allow create: if isSelf(uid);
+      allow update: if isSelf(uid) && hasNoProtectedUserFields();
+      allow delete: if isSelf(uid);
 
       match /consents/{source} {
-        allow read: if request.auth != null && request.auth.uid == uid;
+        allow read: if isSelf(uid);
         allow create: if canCreateConsent(uid, source);
         allow update: if canUpdateConsent(uid, source);
         allow delete: if false;
       }
 
       match /settings/{doc} {
-        allow read, write: if request.auth != null && request.auth.uid == uid;
+        allow read, write: if isSelf(uid);
       }
 
       match /tokens/{doc} {
-        allow read, write: if request.auth != null && request.auth.uid == uid;
+        allow read, write: if isSelf(uid);
       }
+
+      match /spatialScenes/{sceneId} {
+        allow read: if isSelf(uid);
+        allow create: if isSelf(uid) && request.resource.data.uid == uid;
+        allow update: if isSelf(uid) && resource.data.uid == uid && request.resource.data.uid == uid;
+        allow delete: if isSelf(uid) && resource.data.uid == uid;
+      }
+
+      match /xrAnchors/{anchorId} {
+        allow read: if isSelf(uid);
+        allow create: if isSelf(uid) && request.resource.data.uid == uid;
+        allow update: if isSelf(uid) && resource.data.uid == uid && request.resource.data.uid == uid;
+        allow delete: if isSelf(uid) && resource.data.uid == uid;
+      }
+
+      match /roomSemantics/{roomId} {
+        allow read: if isSelf(uid);
+        allow create: if isSelf(uid) && request.resource.data.uid == uid;
+        allow update: if isSelf(uid) && resource.data.uid == uid && request.resource.data.uid == uid;
+        allow delete: if isSelf(uid) && resource.data.uid == uid;
+      }
+
+      match /dreamPlanetariumScenes/{sceneId} {
+        allow read: if isSelf(uid);
+        allow create: if isSelf(uid) && request.resource.data.uid == uid;
+        allow update: if isSelf(uid) && resource.data.uid == uid && request.resource.data.uid == uid;
+        allow delete: if isSelf(uid) && resource.data.uid == uid;
+      }
+
+      match /spatialConsentZones/{zoneId} {
+        allow read: if isSelf(uid);
+        allow create: if isSelf(uid) && request.resource.data.uid == uid;
+        allow update: if isSelf(uid) && resource.data.uid == uid && request.resource.data.uid == uid;
+        allow delete: if false;
+      }
+
+      match /spatialAssetLinks/{assetId} {
+        allow read: if isSelf(uid);
+        allow create: if isSelf(uid) && request.resource.data.uid == uid;
+        allow update: if isSelf(uid) && resource.data.uid == uid && request.resource.data.uid == uid;
+        allow delete: if isSelf(uid) && resource.data.uid == uid;
+      }
+    }
+
+    match /timelineEvents/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /memoryBlooms/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /moodForecasts/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /weeklyReflections/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /companionMessages/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /narratorInsights/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /rituals/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /relationshipSignals/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /passiveSignals/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /symbolicStates/{docId} {
+      allow read: if canReadOwnerDoc(); allow create: if canCreateOwnerDoc();
+      allow update: if canUpdateOwnerDoc();
+      allow delete: if isOwnerResource();
+    }
+
+    match /waitlistSignups/{id} {
+      allow read, write: if false;
     }
 
     match /features/{flagId} {
@@ -26,3 +176,17 @@
     match /entitlements/{uid} {
       allow read, write: if false;
     }
+
+    match /auditLogs/{eventId} {
+      allow read, write: if false;
+    }
+
+    match /assetLifecycleEvents/{eventId} {
+      allow read, write: if false;
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/src/app/api/spatial/consent/route.ts
+++ b/src/app/api/spatial/consent/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { resolveSpatialRequestContext, unauthorizedSpatialResponse } from "@/lib/spatial/auth";
+import { requireSpatialPrivateBeta } from "@/lib/spatial/feature-flags";
+import type { SpatialConsentProfile } from "@/lib/spatial/contracts";
+
+export async function GET(request: NextRequest) {
+  const flag = requireSpatialPrivateBeta();
+  if (!flag.enabled) return NextResponse.json({ error: "spatial_feature_flag_disabled", message: flag.reason }, { status: flag.status });
+
+  const context = resolveSpatialRequestContext(request);
+  if (!context) return NextResponse.json(unauthorizedSpatialResponse(), { status: 401 });
+
+  return NextResponse.json({
+    consent: null,
+    source: "firestore-contract-pending",
+    message: "No persisted consent profile is returned until Firestore rules/index ownership is verified.",
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const flag = requireSpatialPrivateBeta();
+  if (!flag.enabled) return NextResponse.json({ error: "spatial_feature_flag_disabled", message: flag.reason }, { status: flag.status });
+
+  const context = resolveSpatialRequestContext(request);
+  if (!context) return NextResponse.json(unauthorizedSpatialResponse(), { status: 401 });
+
+  const body = await request.json().catch(() => ({}));
+  const consent: SpatialConsentProfile = {
+    id: `consent_${Date.now().toString(36)}`,
+    uid: context.uid,
+    tenantId: context.tenantId,
+    spatialCaptureAllowed: body.spatialCaptureAllowed === true,
+    roomSemanticsAllowed: body.roomSemanticsAllowed === true,
+    xrAnchorsAllowed: body.xrAnchorsAllowed === true,
+    assetGenerationAllowed: body.assetGenerationAllowed === true,
+    updatedAt: new Date().toISOString(),
+  };
+
+  return NextResponse.json({
+    consent,
+    persistence: "pending-firestore-write",
+    message: "Consent contract accepted. Persist only after Firestore rules and deletion/export flows are verified.",
+  }, { status: 201 });
+}

--- a/src/app/api/spatial/health/route.ts
+++ b/src/app/api/spatial/health/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { resolveSpatialReadiness, SPATIAL_COLLECTIONS, SPATIAL_STORAGE_PATHS } from "@/lib/spatial/contracts";
+import { isSpatialDemoEnabled, isSpatialPrivateBetaEnabled, isSpatialXrEnabled } from "@/lib/spatial/feature-flags";
+
+export async function GET() {
+  const generatedAt = new Date().toISOString();
+  const readiness = resolveSpatialReadiness();
+
+  return NextResponse.json({
+    service: "urai-spatial",
+    status: readiness.status,
+    generatedAt,
+    flags: {
+      demo: isSpatialDemoEnabled(),
+      privateBeta: isSpatialPrivateBetaEnabled(),
+      xrRuntime: isSpatialXrEnabled(),
+    },
+    contracts: {
+      collections: SPATIAL_COLLECTIONS,
+      storagePaths: SPATIAL_STORAGE_PATHS,
+    },
+    readiness,
+    note: "URAI Spatial remains staging-scaffolded until authenticated production smoke, consent, asset pipeline, and worker checks pass.",
+  });
+}

--- a/src/app/api/spatial/scenes/route.ts
+++ b/src/app/api/spatial/scenes/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { resolveSpatialRequestContext, unauthorizedSpatialResponse } from "@/lib/spatial/auth";
+import { requireSpatialPrivateBeta } from "@/lib/spatial/feature-flags";
+import type { SpatialScene } from "@/lib/spatial/contracts";
+
+function newSceneId() {
+  return `scene_${Date.now().toString(36)}`;
+}
+
+export async function GET(request: NextRequest) {
+  const flag = requireSpatialPrivateBeta();
+  if (!flag.enabled) return NextResponse.json({ error: "spatial_feature_flag_disabled", message: flag.reason }, { status: flag.status });
+
+  const context = resolveSpatialRequestContext(request);
+  if (!context) return NextResponse.json(unauthorizedSpatialResponse(), { status: 401 });
+
+  return NextResponse.json({
+    scenes: [],
+    source: "firestore-contract-pending",
+    context: { uid: context.uid, tenantId: context.tenantId, role: context.role },
+    message: "Firestore-backed scene listing is intentionally blocked until production rules/indexes are verified.",
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const flag = requireSpatialPrivateBeta();
+  if (!flag.enabled) return NextResponse.json({ error: "spatial_feature_flag_disabled", message: flag.reason }, { status: flag.status });
+
+  const context = resolveSpatialRequestContext(request);
+  if (!context) return NextResponse.json(unauthorizedSpatialResponse(), { status: 401 });
+
+  const body = await request.json().catch(() => ({}));
+  const now = new Date().toISOString();
+  const scene: SpatialScene = {
+    id: newSceneId(),
+    uid: context.uid,
+    tenantId: context.tenantId,
+    title: typeof body.title === "string" && body.title.trim() ? body.title.trim() : "Untitled Spatial Scene",
+    status: "draft",
+    rendererMode: "spatial-scene-v1",
+    consentProfileId: typeof body.consentProfileId === "string" ? body.consentProfileId : "pending-consent-profile",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  return NextResponse.json({
+    scene,
+    persistence: "pending-firestore-write",
+    message: "Scene contract accepted. Wire this response to Firestore once rules/index ownership is confirmed.",
+  }, { status: 201 });
+}

--- a/src/app/spatial/assets/page.tsx
+++ b/src/app/spatial/assets/page.tsx
@@ -1,0 +1,10 @@
+import SpatialShell from "@/components/spatial/SpatialShell";
+
+export const metadata = {
+  title: "URAI Spatial Assets",
+  description: "Generated asset readiness surface for URAI Spatial.",
+};
+
+export default function SpatialAssetsPage() {
+  return <SpatialShell mode="assets" />;
+}

--- a/src/app/spatial/demo/page.tsx
+++ b/src/app/spatial/demo/page.tsx
@@ -1,0 +1,10 @@
+import SpatialShell from "@/components/spatial/SpatialShell";
+
+export const metadata = {
+  title: "URAI Spatial Demo",
+  description: "Public demo surface for URAI Spatial. Does not claim production live status.",
+};
+
+export default function SpatialDemoPage() {
+  return <SpatialShell mode="demo" />;
+}

--- a/src/app/spatial/page.tsx
+++ b/src/app/spatial/page.tsx
@@ -1,0 +1,10 @@
+import SpatialShell from "@/components/spatial/SpatialShell";
+
+export const metadata = {
+  title: "URAI Spatial",
+  description: "Feature-gated URAI Spatial production shell and readiness surface.",
+};
+
+export default function SpatialPage() {
+  return <SpatialShell mode="landing" />;
+}

--- a/src/app/spatial/settings/page.tsx
+++ b/src/app/spatial/settings/page.tsx
@@ -1,0 +1,10 @@
+import SpatialShell from "@/components/spatial/SpatialShell";
+
+export const metadata = {
+  title: "URAI Spatial Consent",
+  description: "Consent and privacy readiness surface for URAI Spatial.",
+};
+
+export default function SpatialSettingsPage() {
+  return <SpatialShell mode="settings" />;
+}

--- a/src/components/life-map/LifeMapUniverse.tsx
+++ b/src/components/life-map/LifeMapUniverse.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import type { LifeMapFilter, LifeMapMode, MemoryStar, QualityMode } from "@/lib/life-map/types";
 import { lifeMapMockData, selectedBlueFogMemory, spatialARVRScaffold } from "@/lib/life-map/mock-data";
@@ -143,7 +144,7 @@ export default function LifeMapUniverse() {
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(191,233,255,0.12),transparent_28%),linear-gradient(180deg,rgba(2,6,23,0.3),#020617)]" />
 
       <header className="pointer-events-none fixed left-0 right-0 top-0 z-20 flex items-start justify-center px-4 pt-5">
-        <a href="/" className="pointer-events-auto fixed left-5 top-5 grid h-11 w-11 place-items-center rounded-full border border-cyan-100/15 bg-slate-950/70 text-cyan-50 shadow-[0_0_28px_rgba(191,233,255,0.12)] backdrop-blur-xl hover:bg-cyan-100/10" aria-label="Back to URAI home">←</a>
+        <Link href="/" className="pointer-events-auto fixed left-5 top-5 grid h-11 w-11 place-items-center rounded-full border border-cyan-100/15 bg-slate-950/70 text-cyan-50 shadow-[0_0_28px_rgba(191,233,255,0.12)] backdrop-blur-xl hover:bg-cyan-100/10" aria-label="Back to URAI home">←</Link>
         <div className="rounded-3xl border border-cyan-100/10 bg-slate-950/55 px-6 py-3 text-center shadow-[0_0_42px_rgba(2,132,199,0.16)] backdrop-blur-2xl">
           <p className="text-xs font-semibold uppercase tracking-[0.35em] text-cyan-100/60">URAI LIFE MAP</p>
           <h1 className="mt-1 text-2xl font-semibold tracking-tight">{modeLabels[mode]}</h1>
@@ -188,41 +189,50 @@ export default function LifeMapUniverse() {
       )}
 
       <CompanionNarratorPanel selectedStar={selectedStar} emotionalSafetyMode={emotionalSafetyMode} />
+      <LifeMapFilterBar activeFilter={activeFilter} onChange={setActiveFilter} />
+      <LifeMapControls
+        selectedStar={selectedStar}
+        mode={mode}
+        onRecenter={recenter}
+        onReplay={startReplay}
+        onMirror={startMirror}
+        onOpenCard={() => setOpenCardStar(selectedStar)}
+        onHideThread={hideSelectedThread}
+        onExport={openScrollExport}
+        isReplaying={isReplaying}
+      />
       <QualitySettingsPanel
         qualityMode={qualityMode}
+        setQualityMode={setQualityMode}
         reducedMotion={reducedMotion}
-        highContrast={highContrast}
+        setReducedMotion={setReducedMotion}
         textOnlyFallback={textOnlyFallback}
+        setTextOnlyFallback={setTextOnlyFallback}
+        highContrast={highContrast}
+        setHighContrast={setHighContrast}
         emotionalSafetyMode={emotionalSafetyMode}
+        setEmotionalSafetyMode={setEmotionalSafetyMode}
         localOnlyMode={localOnlyMode}
-        onQualityChange={setQualityMode}
-        onToggleReducedMotion={() => setReducedMotion((value) => !value)}
-        onToggleHighContrast={() => setHighContrast((value) => !value)}
-        onToggleTextOnly={() => setTextOnlyFallback((value) => !value)}
-        onToggleEmotionalSafety={() => setEmotionalSafetyMode((value) => !value)}
-        onToggleLocalOnly={() => setLocalOnlyMode((value) => !value)}
+        setLocalOnlyMode={setLocalOnlyMode}
       />
-      <ReplayControls isReplaying={isReplaying} onStop={() => { setIsReplaying(false); setCameraCommand("idle"); }} />
-      <LifeMapControls onHideThread={hideSelectedThread} onReplay={startReplay} onCreateScroll={openScrollExport} onMirror={startMirror} onRecenter={recenter} />
-      <LifeMapFilterBar activeFilter={activeFilter} onChange={setActiveFilter} />
-      <SpatialMemoryCard star={openCardStar} onClose={() => setOpenCardStar(undefined)} onBlur={() => setBlurredStarIds((ids) => Array.from(new Set([...ids, selectedStar.id])))} onHide={() => setHiddenStarIds((ids) => Array.from(new Set([...ids, selectedStar.id])))} onDelete={() => { setHiddenStarIds((ids) => Array.from(new Set([...ids, selectedStar.id]))); setOpenCardStar(undefined); }} />
+      <ReplayControls isReplaying={isReplaying} onReplay={startReplay} onStop={() => setIsReplaying(false)} />
+      <SpatialMemoryCard star={openCardStar} onClose={() => setOpenCardStar(undefined)} onBlur={() => setBlurredStarIds((ids) => Array.from(new Set([...ids, openCardStar?.id ?? ""])).filter(Boolean))} />
+
+      {mode === "spatialARVR" && (
+        <section className="pointer-events-auto fixed bottom-5 left-1/2 z-30 w-[min(92vw,760px)] -translate-x-1/2 rounded-3xl border border-cyan-100/15 bg-slate-950/80 p-5 text-sm text-cyan-50 shadow-2xl backdrop-blur-2xl">
+          <div className="text-xs uppercase tracking-[0.28em] text-cyan-100/45">Spatial AR/VR scaffold</div>
+          <p className="mt-2 text-cyan-100/75">{spatialARVRScaffold.webXR}</p>
+          <p className="mt-1 text-cyan-100/55">{spatialARVRScaffold.mobileAR}</p>
+        </section>
+      )}
 
       {exportOpen && (
-        <div className="pointer-events-auto fixed inset-0 z-50 grid place-items-center bg-slate-950/70 p-4 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="Create Life Map scroll export">
-          <section className="w-[min(480px,100%)] rounded-3xl border border-cyan-100/15 bg-slate-950 p-6 text-cyan-50 shadow-[0_0_70px_rgba(14,165,233,0.22)]">
-            <p className="text-xs uppercase tracking-[0.28em] text-cyan-100/50">Create scroll</p>
-            <h2 className="mt-2 text-2xl font-semibold">Life Map Scroll Export</h2>
-            <p className="mt-3 text-sm leading-6 text-cyan-100/70">Export scaffold is ready. It will anonymize shareable constellation moments by default and keep private/local-only stars protected.</p>
-            <div className="mt-5 rounded-2xl bg-white/[0.04] p-4 text-xs text-cyan-100/65">
-              <p>Source: {selectedStar.title}</p>
-              <p>Privacy: anonymized export</p>
-              <p>AR/VR future: {spatialARVRScaffold.spatialPortals}</p>
-            </div>
-            <div className="mt-5 flex justify-end gap-2">
-              <button onClick={() => setExportOpen(false)} className="rounded-full border border-cyan-100/15 px-4 py-2 text-sm hover:bg-white/10">Close</button>
-              <button onClick={() => setExportOpen(false)} className="rounded-full bg-cyan-100 px-4 py-2 text-sm font-medium text-slate-950">Save draft</button>
-            </div>
-          </section>
+        <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-5 backdrop-blur-xl">
+          <div className="max-w-lg rounded-3xl border border-cyan-100/15 bg-slate-950 p-6 text-cyan-50 shadow-2xl">
+            <h2 className="text-xl font-semibold">Create symbolic scroll</h2>
+            <p className="mt-2 text-sm text-cyan-100/65">URAI will eventually export an anonymized mythic PDF or video scroll. For now, this is a local-only preview gate.</p>
+            <button className="mt-5 rounded-full bg-cyan-100 px-5 py-2 text-sm font-semibold text-slate-950" onClick={() => setExportOpen(false)}>Close</button>
+          </div>
         </div>
       )}
     </main>

--- a/src/components/life-map/LifeMapUniverse.tsx
+++ b/src/components/life-map/LifeMapUniverse.tsx
@@ -191,32 +191,42 @@ export default function LifeMapUniverse() {
       <CompanionNarratorPanel selectedStar={selectedStar} emotionalSafetyMode={emotionalSafetyMode} />
       <LifeMapFilterBar activeFilter={activeFilter} onChange={setActiveFilter} />
       <LifeMapControls
-        selectedStar={selectedStar}
-        mode={mode}
         onRecenter={recenter}
         onReplay={startReplay}
         onMirror={startMirror}
-        onOpenCard={() => setOpenCardStar(selectedStar)}
+        onCreateScroll={openScrollExport}
         onHideThread={hideSelectedThread}
-        onExport={openScrollExport}
-        isReplaying={isReplaying}
       />
       <QualitySettingsPanel
         qualityMode={qualityMode}
-        setQualityMode={setQualityMode}
         reducedMotion={reducedMotion}
-        setReducedMotion={setReducedMotion}
         textOnlyFallback={textOnlyFallback}
-        setTextOnlyFallback={setTextOnlyFallback}
         highContrast={highContrast}
-        setHighContrast={setHighContrast}
         emotionalSafetyMode={emotionalSafetyMode}
-        setEmotionalSafetyMode={setEmotionalSafetyMode}
         localOnlyMode={localOnlyMode}
-        setLocalOnlyMode={setLocalOnlyMode}
+        onQualityChange={setQualityMode}
+        onToggleReducedMotion={() => setReducedMotion((value) => !value)}
+        onToggleTextOnly={() => setTextOnlyFallback((value) => !value)}
+        onToggleHighContrast={() => setHighContrast((value) => !value)}
+        onToggleEmotionalSafety={() => setEmotionalSafetyMode((value) => !value)}
+        onToggleLocalOnly={() => setLocalOnlyMode((value) => !value)}
       />
-      <ReplayControls isReplaying={isReplaying} onReplay={startReplay} onStop={() => setIsReplaying(false)} />
-      <SpatialMemoryCard star={openCardStar} onClose={() => setOpenCardStar(undefined)} onBlur={() => setBlurredStarIds((ids) => Array.from(new Set([...ids, openCardStar?.id ?? ""])).filter(Boolean))} />
+      <ReplayControls isReplaying={isReplaying} onStop={() => setIsReplaying(false)} />
+      <SpatialMemoryCard
+        star={openCardStar}
+        onClose={() => setOpenCardStar(undefined)}
+        onBlur={() => setBlurredStarIds((ids) => Array.from(new Set([...ids, openCardStar?.id ?? ""])).filter(Boolean))}
+        onHide={() => {
+          if (!openCardStar) return;
+          setHiddenStarIds((ids) => Array.from(new Set([...ids, openCardStar.id])));
+          setOpenCardStar(undefined);
+        }}
+        onDelete={() => {
+          if (!openCardStar) return;
+          setHiddenStarIds((ids) => Array.from(new Set([...ids, openCardStar.id])));
+          setOpenCardStar(undefined);
+        }}
+      />
 
       {mode === "spatialARVR" && (
         <section className="pointer-events-auto fixed bottom-5 left-1/2 z-30 w-[min(92vw,760px)] -translate-x-1/2 rounded-3xl border border-cyan-100/15 bg-slate-950/80 p-5 text-sm text-cyan-50 shadow-2xl backdrop-blur-2xl">

--- a/src/components/spatial/SpatialShell.tsx
+++ b/src/components/spatial/SpatialShell.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+
+import { resolveSpatialReadiness } from "@/lib/spatial/contracts";
+import { isSpatialDemoEnabled, isSpatialPrivateBetaEnabled, isSpatialXrEnabled } from "@/lib/spatial/feature-flags";
+
+type SpatialShellProps = {
+  mode: "landing" | "demo" | "settings" | "assets";
+};
+
+export default function SpatialShell({ mode }: SpatialShellProps) {
+  const readiness = resolveSpatialReadiness();
+
+  return (
+    <main className="spatial-shell" data-mode={mode} data-status={readiness.status}>
+      <section className="spatial-hero" aria-label="URAI Spatial production shell">
+        <p className="spatial-eyebrow">URAI Spatial</p>
+        <h1>{mode === "demo" ? "Moonlit Spatial Demo" : "Spatial Home, safely staged for production"}</h1>
+        <p className="spatial-lede">
+          URAI Spatial is staged as a cohesive moonlit orb-platform world. Authenticated production access stays behind gates until consent, device QA, Asset Factory materialization, and smoke tests are green.
+        </p>
+        <div className="spatial-status-grid" aria-label="Spatial readiness flags">
+          <span>Demo: {isSpatialDemoEnabled() ? "enabled" : "disabled"}</span>
+          <span>Private beta: {isSpatialPrivateBetaEnabled() ? "enabled" : "blocked"}</span>
+          <span>XR runtime: {isSpatialXrEnabled() ? "enabled" : "blocked"}</span>
+          <span>Status: {readiness.status}</span>
+        </div>
+        <nav className="spatial-links" aria-label="Spatial routes">
+          <Link href="/spatial">Home</Link>
+          <Link href="/spatial/demo">Demo</Link>
+          <Link href="/spatial/settings">Consent</Link>
+          <Link href="/spatial/assets">Assets</Link>
+          <Link href="/api/spatial/health">Health API</Link>
+        </nav>
+      </section>
+
+      <section className="spatial-orb-stage" aria-label="Moonlit orb stage">
+        <div className="spatial-moon" />
+        <div className="spatial-platform">
+          <div className="spatial-orb" />
+          <div className="spatial-reflection" />
+        </div>
+      </section>
+
+      <section className="spatial-cards" aria-label="Spatial production pillars">
+        <article>
+          <h2>Moonlit Life Map</h2>
+          <p>Promotes the staging spatial UX into a production-controlled surface without calling it live before smoke proof exists.</p>
+        </article>
+        <article>
+          <h2>Consent-first Spatial Data</h2>
+          <p>Blocks capture, room semantics, XR anchors, and asset generation behind explicit consent contracts.</p>
+        </article>
+        <article>
+          <h2>Asset Factory Pipeline</h2>
+          <p>Connects spatial-scene-v1 to a worker-backed materialization path for glTF, GLB, USDZ, previews, and manifests.</p>
+        </article>
+      </section>
+
+      <section className="spatial-readiness" aria-label="Definition of done checks">
+        <h2>Live gate</h2>
+        <ul>
+          {readiness.checks.map((check) => (
+            <li key={check.id} data-ok={check.ok}>
+              <strong>{check.ok ? "PASS" : "BLOCKED"}: {check.label}</strong>
+              <span>{check.message}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/life-map/mock-data.ts
+++ b/src/lib/life-map/mock-data.ts
@@ -3,6 +3,7 @@ import type {
   LegacyThread,
   LifeConstellation,
   LifeMapCollections,
+  LifeMapFilter,
   MemoryStar,
   NebulaRegion,
   RecoveryPath,
@@ -75,7 +76,7 @@ const star = (
   updatedAt: now(),
 });
 
-const fromStarBase = (base: MemoryStar, overrideType: string) => ({
+const fromStarBase = <TType extends string>(base: MemoryStar, overrideType: TType) => ({
   ...base,
   type: overrideType,
 });
@@ -163,7 +164,7 @@ export const spatialARVRScaffold: SpatialARVRScaffold = {
   standingInsideNebulaFields: "Future mode for standing inside emotional season fog.",
 };
 
-const lifeConstellations: LifeConstellation[] = [
+const constellationSeeds: Array<{ id: string; theme: LifeMapFilter; starIds: string[]; lineColor: string }> = [
   { id: "grief-thread", theme: "Grief", starIds: ["blue-fog-memory", "winter-thread", "soft-return"], lineColor: "#bfe9ff" },
   { id: "recovery-thread", theme: "Recovery", starIds: ["quiet-ritual", "soft-return", "blue-fog-memory"], lineColor: "#86efac" },
   { id: "relationship-thread", theme: "Relationships", starIds: ["orbit-close", "companion-watch"], lineColor: "#f9a8d4" },
@@ -172,7 +173,9 @@ const lifeConstellations: LifeConstellation[] = [
   { id: "shadow-thread", theme: "Shadow", starIds: ["shadow-loop", "work-flare", "threshold-door"], lineColor: "#64748b" },
   { id: "legacy-thread", theme: "Legacy", starIds: ["legacy-gold", "purpose-north"], lineColor: "#facc15" },
   { id: "rebirth-thread", theme: "Rebirth", starIds: ["threshold-door", "rebirth-bloom", "joy-spark"], lineColor: "#fb7185" },
-].map((thread) => ({
+];
+
+const lifeConstellations: LifeConstellation[] = constellationSeeds.map((thread) => ({
   ...thread,
   userId: "demo-user",
   title: thread.theme,

--- a/src/lib/spatial/auth.ts
+++ b/src/lib/spatial/auth.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from "next/server";
+
+export type SpatialRequestContext = {
+  uid: string;
+  tenantId: string;
+  role: "user" | "admin";
+  source: "headers";
+};
+
+export function resolveSpatialRequestContext(request: NextRequest): SpatialRequestContext | null {
+  const uid = request.headers.get("x-urai-uid") || request.headers.get("x-user-id");
+  const tenantId = request.headers.get("x-urai-tenant-id") || request.headers.get("x-tenant-id");
+  const roleHeader = request.headers.get("x-urai-role") || request.headers.get("x-user-role") || "user";
+  const role = roleHeader === "admin" ? "admin" : "user";
+
+  if (!uid || !tenantId) return null;
+
+  return {
+    uid,
+    tenantId,
+    role,
+    source: "headers",
+  };
+}
+
+export function unauthorizedSpatialResponse() {
+  return {
+    error: "spatial_auth_required",
+    message: "URAI Spatial production routes require an authenticated user and tenant context.",
+    requiredHeaders: ["x-urai-uid", "x-urai-tenant-id"],
+  };
+}
+
+export function assertAdminSpatialContext(context: SpatialRequestContext | null) {
+  return Boolean(context && context.role === "admin");
+}

--- a/src/lib/spatial/contracts.ts
+++ b/src/lib/spatial/contracts.ts
@@ -1,0 +1,120 @@
+export type SpatialSceneStatus =
+  | "draft"
+  | "queued"
+  | "materialized"
+  | "published"
+  | "failed"
+  | "rolled_back";
+
+export type SpatialRendererMode = "spatial-scene-v1";
+
+export type SpatialConsentProfile = {
+  id: string;
+  uid: string;
+  tenantId: string;
+  spatialCaptureAllowed: boolean;
+  roomSemanticsAllowed: boolean;
+  xrAnchorsAllowed: boolean;
+  assetGenerationAllowed: boolean;
+  updatedAt: string;
+};
+
+export type SpatialScene = {
+  id: string;
+  uid: string;
+  tenantId: string;
+  title: string;
+  status: SpatialSceneStatus;
+  rendererMode: SpatialRendererMode;
+  assetFactoryJobId?: string;
+  sceneUrl?: string;
+  spatialManifestUrl?: string;
+  worldUrl?: string;
+  arUrl?: string;
+  gltfUrl?: string;
+  glbUrl?: string;
+  usdzUrl?: string;
+  consentProfileId: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt?: string;
+};
+
+export type SpatialReadinessCheck = {
+  id: string;
+  label: string;
+  ok: boolean;
+  requiredForLive: boolean;
+  message: string;
+};
+
+export const SPATIAL_COLLECTIONS = [
+  "users/{uid}/spatialScenes/{sceneId}",
+  "users/{uid}/xrAnchors/{anchorId}",
+  "users/{uid}/roomSemantics/{roomId}",
+  "users/{uid}/dreamPlanetariumScenes/{sceneId}",
+  "users/{uid}/spatialConsentZones/{zoneId}",
+  "users/{uid}/spatialAssetLinks/{assetId}",
+  "auditLogs/{eventId}",
+  "assetLifecycleEvents/{eventId}",
+] as const;
+
+export const SPATIAL_STORAGE_PATHS = [
+  "users/{uid}/spatial/scenes/{sceneId}/scene.json",
+  "users/{uid}/spatial/scenes/{sceneId}/spatial.json",
+  "users/{uid}/spatial/scenes/{sceneId}/world.json",
+  "users/{uid}/spatial/scenes/{sceneId}/ar.json",
+  "users/{uid}/spatial/scenes/{sceneId}/scene.gltf",
+  "users/{uid}/spatial/scenes/{sceneId}/scene.glb",
+  "users/{uid}/spatial/scenes/{sceneId}/scene.usdz",
+  "users/{uid}/spatial/scenes/{sceneId}/preview.webp",
+  "users/{uid}/spatial/scenes/{sceneId}/manifest.json",
+] as const;
+
+export const SPATIAL_DEFINITION_OF_DONE: SpatialReadinessCheck[] = [
+  {
+    id: "canonical-repo",
+    label: "Canonical production repo",
+    ok: true,
+    requiredForLive: true,
+    message: "URAI Spatial is being integrated through LifeLoggerAI/UrAi, not UrAi-Dev.",
+  },
+  {
+    id: "private-beta-flag",
+    label: "Private Spatial flag",
+    ok: process.env.NEXT_PUBLIC_SPATIAL_PRIVATE_BETA === "true",
+    requiredForLive: true,
+    message: "NEXT_PUBLIC_SPATIAL_PRIVATE_BETA must be true before authenticated Spatial surfaces open.",
+  },
+  {
+    id: "xr-flag",
+    label: "XR runtime flag",
+    ok: process.env.NEXT_PUBLIC_SPATIAL_XR_ENABLED === "true",
+    requiredForLive: false,
+    message: "XR stays disabled until runtime, device QA, consent, and asset pipeline smoke are green.",
+  },
+  {
+    id: "asset-factory-base",
+    label: "Asset Factory API base",
+    ok: Boolean(process.env.ASSET_FACTORY_BASE_URL),
+    requiredForLive: true,
+    message: "ASSET_FACTORY_BASE_URL must point to the verified API base for scene jobs.",
+  },
+  {
+    id: "asset-factory-auth",
+    label: "Asset Factory server auth",
+    ok: Boolean(process.env.ASSET_FACTORY_API_KEY || process.env.ASSET_FACTORY_BEARER_TOKEN),
+    requiredForLive: true,
+    message: "Server-side Asset Factory credentials are required; browsers must not call protected mutation routes directly.",
+  },
+];
+
+export function resolveSpatialReadiness() {
+  const blocking = SPATIAL_DEFINITION_OF_DONE.filter((check) => check.requiredForLive && !check.ok);
+
+  return {
+    status: blocking.length ? "staging-scaffolded" : "production-ready-candidate",
+    blocking,
+    checks: SPATIAL_DEFINITION_OF_DONE,
+  } as const;
+}

--- a/src/lib/spatial/feature-flags.ts
+++ b/src/lib/spatial/feature-flags.ts
@@ -1,0 +1,27 @@
+export function isSpatialDemoEnabled() {
+  return process.env.NEXT_PUBLIC_SPATIAL_DEMO_DISABLED !== "true";
+}
+
+export function isSpatialPrivateBetaEnabled() {
+  return process.env.NEXT_PUBLIC_SPATIAL_PRIVATE_BETA === "true";
+}
+
+export function isSpatialXrEnabled() {
+  return process.env.NEXT_PUBLIC_SPATIAL_XR_ENABLED === "true";
+}
+
+export function requireSpatialPrivateBeta() {
+  if (!isSpatialPrivateBetaEnabled()) {
+    return {
+      enabled: false,
+      status: 403,
+      reason: "URAI Spatial authenticated surfaces are feature-flagged until staging smoke, consent, device QA, and asset pipeline checks are green.",
+    } as const;
+  }
+
+  return {
+    enabled: true,
+    status: 200,
+    reason: "URAI Spatial private beta is enabled.",
+  } as const;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,1 +1,43 @@
 export type Category = "winter" | "spring" | "summer" | "autumn";
+
+export type OrbMessageMode = "text" | "voice";
+
+export type OrbMessageRole = "user" | "assistant" | "system";
+
+export type OrbMessage = {
+  id: string;
+  role: OrbMessageRole;
+  content: string;
+  mode: OrbMessageMode;
+  emotionTags: string[];
+  createdAt: string;
+};
+
+export type OrbChatContext = {
+  todayMoodState?: string;
+  mentalLoadScore?: number;
+  rhythmState?: string;
+  lastNarratorInsight?: string;
+  userTonePreference?: string;
+  recentTimelineEvents?: string[];
+  relationshipSignals?: string[];
+};
+
+export type OrbChat = {
+  id: string;
+  userId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  lastMessagePreview?: string;
+};
+
+export type ConversationInsight = {
+  id: string;
+  userId: string;
+  chatId?: string;
+  insight: string;
+  emotionTags: string[];
+  memoryImportanceScore: number;
+  createdAt: string;
+};


### PR DESCRIPTION
## Summary
- Adds feature-gated `/spatial`, `/spatial/demo`, `/spatial/settings`, and `/spatial/assets` routes.
- Adds URAI Spatial contracts for scenes, consent, collection paths, storage paths, and live-readiness checks.
- Adds protected Spatial API surfaces for `/api/spatial/health`, `/api/spatial/scenes`, and `/api/spatial/consent`.
- Keeps authenticated Spatial behind `NEXT_PUBLIC_SPATIAL_PRIVATE_BETA` and XR behind `NEXT_PUBLIC_SPATIAL_XR_ENABLED`.

## Safety stance
This intentionally does **not** call URAI Spatial live. The API reports `staging-scaffolded` until private beta, Asset Factory auth/base URL, smoke tests, consent, and worker pipeline checks are complete.

## Verification to run after merge
```bash
npm install && npm run check:v1 && npm run check:firestore-contract && npm run check:types && npm run lint && npm run test:unit && npm run build && npm run release:p1
```

## Notes
The branch is one commit behind `main` because `main` moved after branch creation. Rebase/update before merge if required by repo policy.