### PR TITLE
Harden 3D world routes for home and life map

### DIFF
--- a/src/components/spatial-life-map/LifeGalaxyScene.tsx
+++ b/src/components/spatial-life-map/LifeGalaxyScene.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Canvas } from "@react-three/fiber";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { useRef } from "react";
 import * as THREE from "three";
 import type { GalaxyCameraState, LifeMapConstellation, LifeMapLayerId, LifeMapStar } from "@/lib/spatial-life-map/lifeMap.types";
 import GalaxyCameraController from "./GalaxyCameraController";
@@ -20,6 +21,19 @@ interface LifeGalaxySceneProps {
   onHoverStar: (starId: string | null) => void;
   onSelectStar: (star: LifeMapStar) => void;
   onOpenStar: (star: LifeMapStar) => void;
+  onSceneReady?: () => void;
+}
+
+function SceneReadyBeacon({ onReady }: { onReady?: () => void }) {
+  const didSignal = useRef(false);
+
+  useFrame(() => {
+    if (!onReady || didSignal.current) return;
+    didSignal.current = true;
+    onReady();
+  });
+
+  return null;
 }
 
 function EmotionalLightField({ selectedStar }: { selectedStar?: LifeMapStar }) {
@@ -55,7 +69,7 @@ function DepthReferencePlanes() {
   );
 }
 
-export default function LifeGalaxyScene({ stars, constellations, activeLayerIds, cameraState, selectedStarId, hoveredStarId, reducedMotion = false, onHoverStar, onSelectStar, onOpenStar }: LifeGalaxySceneProps) {
+export default function LifeGalaxyScene({ stars, constellations, activeLayerIds, cameraState, selectedStarId, hoveredStarId, reducedMotion = false, onHoverStar, onSelectStar, onOpenStar, onSceneReady }: LifeGalaxySceneProps) {
   const visibleStars = stars.filter((star) => activeLayerIds.includes(star.layer));
   const selectedStar = stars.find((star) => star.id === selectedStarId) ?? null;
 
@@ -66,6 +80,7 @@ export default function LifeGalaxyScene({ stars, constellations, activeLayerIds,
       camera={{ position: [0, 2.2, cameraState.zoom], fov: 47, near: 0.03, far: 120 }}
       className="spatial-canvas"
     >
+      <SceneReadyBeacon onReady={onSceneReady} />
       <color attach="background" args={["#00030b"]} />
       <fog attach="fog" args={["#030b18", 5.5, 38]} />
       <GalaxyCameraController cameraState={cameraState} reducedMotion={reducedMotion} />

--- a/src/components/spatial-life-map/SpatialLifeMap.tsx
+++ b/src/components/spatial-life-map/SpatialLifeMap.tsx
@@ -117,6 +117,7 @@ export default function SpatialLifeMap({ userId = "demo-user", initialMode, init
   const [mounted, setMounted] = useState(false);
   const [mode, setMode] = useState<LifeMapInteractionMode>(() => normalizeInitialMode(initialMode));
   const [returnPhase, setReturnPhase] = useState<ReturnPhase>("idle");
+  const [sceneReady, setSceneReady] = useState(false);
   const initialSelectionApplied = useRef(false);
 
   const { data, loading, error } = useLifeMapData(userId);
@@ -133,6 +134,10 @@ export default function SpatialLifeMap({ userId = "demo-user", initialMode, init
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    setSceneReady(false);
+  }, [sceneResetKey]);
 
   useEffect(() => {
     if (initialSelectionApplied.current || visibleStars.length === 0) return;
@@ -244,7 +249,7 @@ export default function SpatialLifeMap({ userId = "demo-user", initialMode, init
   }
 
   return (
-    <main className={`spatial-life-map urai-life-map-screen is-${mode} return-${returnPhase}`} aria-label="URAI Spatial Life Map Galaxy">
+    <main className={`spatial-life-map urai-life-map-screen is-${mode} return-${returnPhase} ${sceneReady ? "scene-ready" : "scene-loading"}`} aria-label="URAI Spatial Life Map Galaxy">
       <div className="spatial-atmosphere" aria-hidden />
       <div className="spatial-cinematic-vignette" aria-hidden />
       <button type="button" className="spatial-home-gate" onClick={returnHome} aria-label="Return to the Inner Sky Shrine">
@@ -252,6 +257,7 @@ export default function SpatialLifeMap({ userId = "demo-user", initialMode, init
       </button>
 
       <section className="spatial-stage" {...camera.bind}>
+        {!sceneReady && <SpatialSceneFallback message="URAI is warming the moonlit memory galaxy." />}
         <SceneErrorBoundary resetKey={sceneResetKey} fallback={<SpatialSceneFallback />}>
           <LifeGalaxyScene
             stars={data.stars}
@@ -264,6 +270,7 @@ export default function SpatialLifeMap({ userId = "demo-user", initialMode, init
             onHoverStar={selection.setHoveredStarId}
             onSelectStar={focusStar}
             onOpenStar={openBloom}
+            onSceneReady={() => setSceneReady(true)}
           />
         </SceneErrorBoundary>
       </section>

--- a/src/components/urai/home/HomeWorldCanvas.tsx
+++ b/src/components/urai/home/HomeWorldCanvas.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Canvas, useFrame } from "@react-three/fiber";
-import { Component, Suspense, useEffect, useMemo, useRef, type ReactNode } from "react";
+import { Component, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import * as THREE from "three";
 
 type SceneBoundaryProps = {
@@ -30,13 +30,25 @@ class SceneBoundary extends Component<SceneBoundaryProps, SceneBoundaryState> {
   }
 }
 
-function HomeCanvasFallback() {
+function HomeCanvasFallback({ status = "loading" }: { status?: "loading" | "error" }) {
   return (
-    <div className="urai-home-world-fallback" aria-hidden>
+    <div className={`urai-home-world-fallback is-${status}`} aria-hidden>
       <div className="urai-home-world-fallback-orb" />
       <div className="urai-home-world-fallback-ring" />
     </div>
   );
+}
+
+function SceneReadyBeacon({ onReady }: { onReady: () => void }) {
+  const didSignal = useRef(false);
+
+  useFrame(() => {
+    if (didSignal.current) return;
+    didSignal.current = true;
+    onReady();
+  });
+
+  return null;
 }
 
 function MoonlitStars() {
@@ -170,9 +182,10 @@ function ReflectiveGround() {
   );
 }
 
-function MoonlitHomeWorld() {
+function MoonlitHomeWorld({ onReady }: { onReady: () => void }) {
   return (
     <>
+      <SceneReadyBeacon onReady={onReady} />
       <color attach="background" args={["#00030b"]} />
       <fog attach="fog" args={["#06162c", 5, 18]} />
       <ambientLight intensity={0.42} color="#dffaff" />
@@ -188,9 +201,12 @@ function MoonlitHomeWorld() {
 }
 
 export function HomeWorldCanvas() {
+  const [worldReady, setWorldReady] = useState(false);
+
   return (
-    <SceneBoundary fallback={<HomeCanvasFallback />}>
-      <div className="urai-home-world-canvas" aria-hidden>
+    <SceneBoundary fallback={<HomeCanvasFallback status="error" />}>
+      <div className={`urai-home-world-canvas ${worldReady ? "is-ready" : "is-loading"}`} aria-hidden>
+        {!worldReady && <HomeCanvasFallback status="loading" />}
         <Canvas
           dpr={[1, 1.65]}
           gl={{ antialias: true, alpha: true, powerPreference: "high-performance", toneMapping: THREE.ACESFilmicToneMapping, outputColorSpace: THREE.SRGBColorSpace }}
@@ -198,7 +214,7 @@ export function HomeWorldCanvas() {
           shadows
         >
           <Suspense fallback={null}>
-            <MoonlitHomeWorld />
+            <MoonlitHomeWorld onReady={() => setWorldReady(true)} />
           </Suspense>
         </Canvas>
       </div>

--- a/src/styles/urai-3d-world-integration.css
+++ b/src/styles/urai-3d-world-integration.css
@@ -12,10 +12,36 @@
   filter: saturate(1.08) contrast(1.08) brightness(.9);
 }
 
+.urai-home-world-canvas {
+  overflow: hidden;
+  transform: translateZ(0);
+}
+
 .urai-home-world-canvas canvas {
   display: block;
   width: 100% !important;
   height: 100% !important;
+  opacity: 1;
+  transition: opacity .55s ease;
+}
+
+.urai-home-world-canvas.is-loading canvas {
+  opacity: 0;
+}
+
+.urai-home-world-canvas.is-ready canvas {
+  opacity: 1;
+}
+
+.urai-home-world-canvas .urai-home-world-fallback {
+  z-index: 1;
+  opacity: .86;
+  transition: opacity .55s ease, visibility .55s ease;
+}
+
+.urai-home-world-canvas.is-ready .urai-home-world-fallback {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .urai-home-world-fallback {
@@ -68,6 +94,7 @@
   min-height: 100vh;
   min-height: 100dvh;
   isolation: isolate;
+  overflow: hidden;
   background:
     radial-gradient(circle at 50% 42%, rgba(125, 211, 252, .2), transparent 23%),
     radial-gradient(circle at 68% 30%, rgba(196, 181, 253, .13), transparent 24%),
@@ -80,15 +107,34 @@ body:has(.urai-life-map-screen) {
 }
 
 .spatial-life-map .spatial-stage {
+  position: absolute;
+  inset: 0;
   z-index: 0;
   width: 100%;
   height: 100%;
+  overflow: hidden;
+  touch-action: none;
 }
 
 .spatial-life-map .spatial-stage canvas {
   display: block;
   width: 100% !important;
   height: 100% !important;
+  opacity: 1;
+  transition: opacity .55s ease;
+}
+
+.spatial-life-map.scene-loading .spatial-stage canvas {
+  opacity: 0;
+}
+
+.spatial-life-map.scene-ready .spatial-stage canvas {
+  opacity: 1;
+}
+
+.spatial-life-map.scene-ready .spatial-stage > .spatial-scene-fallback {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .spatial-cinematic-vignette {
@@ -291,10 +337,13 @@ body:has(.urai-life-map-screen) {
 .spatial-scene-fallback {
   position: absolute;
   inset: 0;
+  z-index: 1;
   display: grid;
   place-items: center;
   text-align: center;
   padding: 24px;
+  pointer-events: none;
+  transition: opacity .55s ease, visibility .55s ease;
   background:
     radial-gradient(circle at 50% 42%, rgba(191, 233, 255, .14), transparent 28%),
     radial-gradient(circle at 50% 62%, rgba(196, 181, 253, .1), transparent 36%),
@@ -401,5 +450,12 @@ body:has(.urai-life-map-screen) {
   .spatial-focus-orb,
   .spatial-return-orb {
     animation: none !important;
+  }
+
+  .urai-home-world-canvas canvas,
+  .urai-home-world-canvas .urai-home-world-fallback,
+  .spatial-life-map .spatial-stage canvas,
+  .spatial-scene-fallback {
+    transition: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- Keeps `/` and `/home` wired to the existing `HomeScene` / `HomeWorldCanvas` implementation.
- Keeps `/life-map` wired to the existing `LifeMapUniverse` / `SpatialLifeMap` / `LifeGalaxyScene` implementation.
- Adds real scene-ready signals for both R3F canvases so cinematic fallbacks display until WebGL has painted.
- Hardens canvas/fallback CSS for viewport sizing, z-index, pointer behavior, mobile touch stability, and reduced-motion support.
- Preserves existing product flows and avoids introducing fake replacement scenes.

## Inspection notes
- Existing App Router routes were already present for `/`, `/home`, `/life-map`, and `/app/life-map`.
- Candidate XR shell scripts in adjacent repos were not used because they are generated/prototype scripts and less complete than the existing first-party Spatial Life Map components.
- No external asset dependency was required; current scenes are procedural Three.js/R3F worlds with graceful procedural fallbacks.

## Verification
- GitHub connector compare: branch is 4 commits ahead of `main`, touching only 4 files.
- Local `npm install`, `npm run typecheck`, `npm run lint`, `npm run test`, and `npm run build` could not be run in this container because direct clone/install network access is blocked by DNS. CI can run from this PR if configured.