### PR TITLE
Final /home lock execution pass

### DIFF
--- a/HOME_COMPANION_CONTRACT.md
+++ b/HOME_COMPANION_CONTRACT.md
@@ -1,0 +1,211 @@
+# HOME COMPANION CONTRACT
+
+Status: PARTIALLY VERIFIED
+Route: `/home`
+Canonical companion surface: `/home` orb / field pulse, with `/narrator` as a connected route when present.
+Canonical client context source: `src/lib/use-urai-home-state.ts`
+
+## Purpose
+
+The `/home` orb is the living companion entrypoint. It must be grounded in current home state, memory stars, emotional weather, narrator insight, and user trust settings where available. It must not behave like a static button.
+
+## Current implementation baseline
+
+The resolved `/home` scene provides:
+
+- physical aura orb state through `aura-orb-button`, `data-orb-charge`, and orb charge UI
+- companion focus surface through `focusSurface === "companion"`
+- narrator/companion state through `home.companionMode` and `home.narratorWhisper`
+- life-map/open action from the field pulse
+- safe symbolic copy generated from normalized home state
+
+The older shrine `HomeScene` has a local static orb chat layer. The canonical `/home` route now mounts the resolved home scene, which is the safer live-data path.
+
+## Required companion states
+
+The orb companion must support these states in UI or fallback status:
+
+- `idle`
+- `hover`
+- `pressed`
+- `listening`
+- `thinking`
+- `speaking`
+- `insight-ready`
+- `memory-retrieving`
+- `error`
+- `fallback`
+- `offline`
+- `cooldown`
+- `disabled`
+
+## Request shape
+
+If a companion endpoint is connected, the client request should use this shape:
+
+```ts
+type HomeCompanionRequest = {
+  userId: string;
+  message?: string;
+  action:
+    | "open"
+    | "ask"
+    | "explain_weather"
+    | "explain_insight"
+    | "explain_memory_star"
+    | "reflect"
+    | "start_voice"
+    | "stop_voice";
+  context: {
+    moodWeather?: string;
+    rhythmState?: string;
+    visualState?: string;
+    auraColor?: string;
+    recoveryScore?: number;
+    recoveryDirection?: string;
+    forecastSummary?: string;
+    forecastMessage?: string;
+    narratorWhisper?: string;
+    companionMode?: string;
+    socialEnergy?: string;
+    shadowLoad?: number;
+    cognitiveLoad?: number;
+    thresholdRisk?: number;
+    moodConfidence?: number;
+    activeMemoryStar?: {
+      id: string;
+      type: string;
+      title: string;
+      subtitle?: string;
+      emotionalWeight?: number;
+    };
+    source: "firestore" | "demo" | "unconfigured";
+  };
+  preferences?: {
+    quietMode?: boolean;
+    voiceEnabled?: boolean;
+    ttsEnabled?: boolean;
+    passiveCuesEnabled?: boolean;
+    telemetryEnabled?: boolean;
+  };
+};
+```
+
+## Response shape
+
+```ts
+type HomeCompanionResponse = {
+  id: string;
+  text: string;
+  state?: "thinking" | "speaking" | "insight-ready" | "cooldown" | "error";
+  groundedSignals?: Array<{
+    label: string;
+    confidence?: number;
+    source: "mood" | "rhythm" | "forecast" | "memory" | "recovery" | "social" | "passive" | "companion";
+  }>;
+  suggestedAction?: {
+    label: string;
+    route?: string;
+    action?: string;
+  };
+  cooldownUntil?: string;
+  errorCode?: string;
+};
+```
+
+## Streaming behavior
+
+If a streaming endpoint exists:
+
+- set orb state to `thinking` before stream begins
+- progressively render assistant text
+- set orb state to `speaking` when text or TTS is active
+- set orb state to `idle` or `insight-ready` after completion
+- handle stream abort/cancel
+- handle network failure with `error` or `fallback` state
+
+If streaming is unavailable:
+
+- use non-streaming response
+- keep same request/response contract
+- document fallback status in `HOME_LOCK_REPORT.md`
+
+## Voice input behavior
+
+Voice input may be connected through browser speech recognition or another approved stack.
+
+Rules:
+
+- voice starts only after explicit user action
+- microphone permission denial is handled safely
+- unsupported browser gets a text fallback
+- listening state is visible
+- stop/cancel is available
+- no silent background recording
+- no raw audio logging unless explicitly consented and implemented
+
+## TTS behavior
+
+TTS may be connected through browser speech synthesis or another approved stack.
+
+Rules:
+
+- speaking state is visible
+- mute/stop is available where supported
+- no surprise autoplay
+- text equivalent is always present
+- quiet mode disables unsolicited speech
+- unsupported browser gets text-only fallback
+
+## Explainability behavior
+
+`Why am I seeing this?` must be available or planned for:
+
+- emotional weather
+- narrator insight
+- memory star
+- passive cue
+- companion suggestion
+- aura state when surfaced as insight
+
+Explanation copy must describe signal categories without exposing raw private logs. Use uncertainty language such as `signals suggest`, `recent rhythm may indicate`, and `this looks like`.
+
+## Cooldown and quiet mode
+
+The companion must respect:
+
+- dismissed insights
+- cooldown windows
+- repeated passive cue limits
+- quiet mode
+- voice/TTS preferences
+- trust/privacy settings
+
+If cooldown persistence is unavailable, it must fail closed: reduce nudges rather than increasing them.
+
+## Error states
+
+If a companion endpoint fails:
+
+- show safe fallback state
+- do not crash `/home`
+- allow retry
+- do not log private content
+- emit sanitized telemetry if telemetry is enabled
+
+## Privacy restrictions
+
+- Do not hallucinate private data.
+- Do not expose raw private logs.
+- Do not include raw messages/audio in telemetry.
+- Do not read another user's data.
+- Do not record audio without explicit permission.
+- Do not use clinical or diagnostic language.
+
+## Current verification status
+
+- `/home` is routed to the resolved home field.
+- The resolved home field exposes physical orb charge, companion focus, and home-state-grounded copy.
+- A production companion endpoint is not verified in this pass.
+- Voice input and TTS are not verified in this pass.
+- The final lock status remains PARTIALLY VERIFIED until endpoint, voice/TTS, emulator, runtime, and smoke evidence pass.

--- a/HOME_DATA_CONTRACT.md
+++ b/HOME_DATA_CONTRACT.md
@@ -1,0 +1,253 @@
+# HOME DATA CONTRACT
+
+Status: PARTIALLY VERIFIED
+Route: `/home`
+Canonical component: `src/components/urai/UraiResolvedHomeScene.tsx`
+Canonical hook: `src/lib/use-urai-home-state.ts`
+
+## Purpose
+
+This document defines the data contract for the final URAI `/home` field. `/home` must prefer authenticated live Firebase/Firestore data and use demo/unconfigured data only as explicit fallback behavior.
+
+## Canonical client model
+
+`UraiHomeViewModel` is the normalized render model consumed by `/home`.
+
+Required normalized fields:
+
+- `moodWeather: string`
+- `rhythmState: stable | focused | overstimulated | offRhythm | recovering`
+- `visualState: calm | focused | overstimulated | offRhythm | recovery | threshold | socialHigh | socialSilence | empty`
+- `auraColor: string`
+- `auraSecondaryColor: string`
+- `recoveryScore: number`
+- `recoveryDirection: rising | flat | falling`
+- `bloomReady: boolean`
+- `memoryNodeCount: number`
+- `forecastSummary: string`
+- `forecastMessage: string`
+- `companionMode: quiet | listening | reflecting | forecasting | ritual | protective`
+- `narratorWhisper: string`
+- `socialEnergy: high | balanced | low | silent | strained`
+- `shadowLoad: number`
+- `cognitiveLoad: number`
+- `thresholdRisk: number`
+- `moodConfidence: number`
+- `insight: UraiHomeInsight`
+- `nodes: UraiLifeMapNode[]`
+- `source: firestore | demo | unconfigured`
+- `loading: boolean`
+- `error?: string`
+
+## Firestore paths
+
+All live reads are scoped under the authenticated user:
+
+- `users/{uid}/homeState/current`
+- `users/{uid}/moodForecasts/current`
+- `users/{uid}/companionState/current`
+- `users/{uid}/visualState/current`
+- `users/{uid}/lifeMapNodes/*` with a current query limit of 24
+
+## Expected document shapes
+
+### `users/{uid}/homeState/current`
+
+Supported nested fields:
+
+```ts
+{
+  mood?: {
+    label?: string;
+    confidence?: number;
+  };
+  rhythm?: {
+    state?: "stable" | "focused" | "overstimulated" | "offRhythm" | "off_rhythm" | "recovering";
+  };
+  stress?: {
+    thresholdRisk?: number;
+    shadowLoad?: number;
+    cognitiveLoad?: number;
+  };
+  recovery?: {
+    score?: number;
+    direction?: "rising" | "flat" | "falling";
+    bloomReady?: boolean;
+  };
+  forecast?: {
+    label?: string;
+    message?: string;
+  };
+  memory?: {
+    nodeCount?: number;
+    recentStars?: UraiLifeMapNodeLike[];
+  };
+  social?: {
+    energy?: "high" | "balanced" | "low" | "silent" | "strained";
+  };
+  insight?: {
+    id?: string;
+    title?: string;
+    body?: string;
+    ctaLabel?: string;
+    ctaRoute?: string;
+    confidence?: number;
+  };
+  companion?: {
+    state?: "quiet" | "listening" | "reflecting" | "forecasting" | "ritual" | "protective";
+    message?: string;
+  };
+  visual?: {
+    state?: string;
+    auraColor?: string;
+    auraSecondaryColor?: string;
+  };
+}
+```
+
+Top-level fallback aliases are also supported by `useUraiHomeState`, including `moodWeather`, `moodLabel`, `rhythmState`, `visualState`, `auraColor`, `auraSecondaryColor`, `recoveryScore`, `thresholdRisk`, `shadowLoad`, `cognitiveLoad`, `memoryNodeCount`, `forecastSummary`, `forecastMessage`, `companionMode`, `narratorWhisper`, `socialEnergy`, and `recentStars`.
+
+### `users/{uid}/moodForecasts/current`
+
+Supported fields:
+
+```ts
+{
+  summary?: string;
+  forecastSummary?: string;
+  message?: string;
+}
+```
+
+### `users/{uid}/companionState/current`
+
+Supported fields:
+
+```ts
+{
+  mode?: "quiet" | "listening" | "reflecting" | "forecasting" | "ritual" | "protective" | "ambient";
+  companionMode?: string;
+  narratorWhisper?: string;
+  whisper?: string;
+}
+```
+
+### `users/{uid}/visualState/current`
+
+Supported fields:
+
+```ts
+{
+  visualState?: string;
+  rhythmState?: string;
+  moodWeather?: string;
+  auraColor?: string;
+  auraSecondaryColor?: string;
+}
+```
+
+### `users/{uid}/lifeMapNodes/{nodeId}`
+
+Supported fields:
+
+```ts
+{
+  type?: string;
+  starType?: string;
+  title?: string;
+  label?: string;
+  subtitle?: string;
+  detail?: string;
+  summary?: string;
+  narratorLine?: string;
+  emotionalWeight?: number;
+  weight?: number;
+  importance?: number;
+  intensity?: number;
+  emotionalIntensity?: number;
+  glow?: number;
+  x?: number;
+  y?: number;
+  positionX?: number;
+  positionY?: number;
+  position?: { x?: number; y?: number };
+  auraColor?: string;
+  color?: string;
+}
+```
+
+## Normalization rules
+
+- Numeric probabilities are clamped to valid ranges.
+- Percentage-style coordinates are clamped between 5 and 95.
+- Missing strings use safe symbolic fallback copy.
+- Missing life-map nodes use explicit demo fallback nodes only when no live nodes exist.
+- Unsupported node types normalize to `memory`.
+- `off_rhythm` normalizes to `offRhythm`.
+- Companion `ambient` normalizes to `quiet`.
+
+## Fallback behavior
+
+Allowed fallback states:
+
+- `source: firestore`: authenticated live data is active.
+- `source: demo`: unauthenticated user or no live user context.
+- `source: unconfigured`: Firebase config is unavailable.
+
+Fallback data must not be represented as confirmed live user data.
+
+## Empty state behavior
+
+If live docs exist but specific fields are absent, `/home` must still render partial data using normalized safe defaults. Empty memory nodes fall back to demo constellation nodes until a dedicated empty-star UX is added.
+
+## Error state behavior
+
+Snapshot errors set `error` and return safe demo fallback UI. This protects runtime stability but does not satisfy final LOCKED status without emulator/rules proof.
+
+## Firestore rules expectations
+
+Rules must prove:
+
+- Authenticated users can read only their own `/home` data.
+- Users cannot read another user's home state.
+- Unauthenticated users cannot read private home state.
+- Telemetry writes, if present, are scoped and sanitized.
+- Trust/privacy settings are scoped to the user.
+- Companion logs, if stored, are scoped to the user.
+- Admin/debug surfaces require admin authorization.
+
+## Index expectations
+
+The current query on `lifeMapNodes` uses `limit(24)` without an explicit order. No composite index is expected for the current implementation. Add indexes if ordering/filtering is introduced.
+
+## Emulator seed sample
+
+```json
+{
+  "users/test-user/homeState/current": {
+    "mood": { "label": "Mirror Clarity", "confidence": 0.9 },
+    "rhythm": { "state": "focused" },
+    "recovery": { "score": 74, "direction": "rising", "bloomReady": true },
+    "stress": { "thresholdRisk": 0.12, "shadowLoad": 0.18, "cognitiveLoad": 0.31 },
+    "forecast": { "label": "Mirror Pattern active", "message": "Signals suggest a focused recovery rhythm." },
+    "social": { "energy": "balanced" },
+    "companion": { "state": "reflecting", "message": "Your patterns are becoming visible." },
+    "visual": { "state": "recovery", "auraColor": "#7ee7ff", "auraSecondaryColor": "#fbbf24" }
+  },
+  "users/test-user/lifeMapNodes/node-1": {
+    "type": "becoming",
+    "title": "Blueprint Locked",
+    "subtitle": "A foundation has formed.",
+    "emotionalWeight": 0.86,
+    "x": 38,
+    "y": 39,
+    "auraColor": "hsl(205deg 90% 72%)"
+  }
+}
+```
+
+## Current verification status
+
+- Client data hook exists and reads authenticated Firestore paths.
+- Normalization exists for live, partial, demo, and unconfigured states.
+- Emulator/rules proof still must be run before `/home` can be marked LOCKED.

--- a/HOME_E2E_AUDIT.md
+++ b/HOME_E2E_AUDIT.md
@@ -1,0 +1,337 @@
+# HOME E2E AUDIT
+
+Date: 2026-05-18
+Branch: `final/home-lock-execution`
+Status: PARTIALLY VERIFIED
+Final release lock decision: NOT LOCKED
+
+## Executive summary
+
+This audit executes the repository-facing portion of the URAI FINAL HOME LOCK. The active `/home` route is now wired to the Firestore-backed resolved home field instead of the older static shrine scene. Static gate scripts were added for `check:home` and `check:ascent`.
+
+The implementation is not marked LOCKED because this environment cannot run the full command matrix, browser smoke tests, Firebase emulator proof, deployment verification, production companion endpoint proof, or voice/TTS runtime proof.
+
+## Route-by-route audit
+
+| Route | Status | Notes |
+| --- | --- | --- |
+| `/home` | PARTIALLY VERIFIED | `src/app/home/page.tsx` now mounts `UraiResolvedHomeScene`. |
+| `/` | EXISTING | `src/app/page.tsx` still mounts `HomeScene`; root remains a cinematic entrypoint. |
+| `/life-map` | STATIC CHECK REQUIRED | `UraiResolvedHomeScene` imports and renders `LifeMapScene` in lifemap mode. Run `npm run check:ascent`. |
+| `/forecast` | NOT RUNTIME VERIFIED | Connected as an expected route in the final lock contract; must be browser-smoked. |
+| `/cognitive-mirror` | NOT RUNTIME VERIFIED | Connected as an expected route in the final lock contract; must be browser-smoked. |
+| `/narrator` | NOT RUNTIME VERIFIED | Companion/narrator route must be browser-smoked if retained as a separate route. |
+| `/homeview` | LEGACY / NOT VERIFIED | Older cinematic shell remains present; not the canonical final `/home` route in this pass. |
+
+## State-by-state audit
+
+| State | Status | Evidence |
+| --- | --- | --- |
+| loading | PARTIALLY VERIFIED | `UraiHomeViewModel.loading` and initial loading state exist in `useUraiHomeState`. |
+| live/firestore | PARTIALLY VERIFIED | Firestore snapshots are used after auth resolves. |
+| demo fallback | PARTIALLY VERIFIED | `source: "demo"` exists for unauthenticated fallback. |
+| unconfigured fallback | PARTIALLY VERIFIED | `source: "unconfigured"` exists for missing Firebase config. |
+| error | PARTIALLY VERIFIED | Snapshot errors set a safe fallback with `error`. |
+| offline | NOT VERIFIED | Explicit offline cache/runtime behavior must still be browser-tested. |
+| partial data | PARTIALLY VERIFIED | Normalizers use fallback values for missing fields. |
+| empty data | PARTIALLY VERIFIED | Missing nodes fall back to demo constellation nodes; dedicated empty UX remains future hardening. |
+
+## Live data audit
+
+Canonical hook: `src/lib/use-urai-home-state.ts`
+
+Live data paths observed/defined:
+
+- `users/{uid}/homeState/current`
+- `users/{uid}/moodForecasts/current`
+- `users/{uid}/companionState/current`
+- `users/{uid}/visualState/current`
+- `users/{uid}/lifeMapNodes/*`
+
+Status: PARTIALLY VERIFIED
+
+Reason: The hook contains live Auth and Firestore snapshot wiring, but emulator/rules/runtime proof has not been executed in this pass.
+
+## Fallback data audit
+
+Fallback states:
+
+- demo fallback
+- unconfigured Firebase fallback
+- normalized partial-data fallback
+- snapshot-error fallback
+
+Status: PARTIALLY VERIFIED
+
+Required follow-up before LOCKED:
+
+- Confirm fallback mode is visually labeled or non-misleading in runtime UX.
+- Confirm production config never defaults to demo when authenticated live data is available.
+
+## Auth audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- `onAuthStateChanged(auth(), ...)` is used in `useUraiHomeState`.
+- Firestore reads are scoped under `users/{uid}`.
+
+Required follow-up:
+
+- Run emulator tests for authenticated own-user reads.
+- Run emulator tests for cross-user denials.
+- Run emulator tests for unauthenticated denials.
+
+## Firestore rules audit
+
+Status: NOT VERIFIED
+
+Required before LOCKED:
+
+- Run `npm run test:rules` or equivalent.
+- Verify user-owned read/write scope.
+- Verify trust/privacy settings scope.
+- Verify telemetry write safety.
+- Verify companion logs scope if used.
+- Verify admin/debug protection.
+
+## Emulator audit
+
+Status: NOT VERIFIED
+
+Required before LOCKED:
+
+- Run Firebase emulator/rules tests.
+- Attach command output in `HOME_LOCK_REPORT.md`.
+- Do not mark LOCKED without emulator proof or equivalent rules proof.
+
+## Companion audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- Resolved scene has companion focus state.
+- Resolved scene derives companion mode from live home state.
+- `HOME_COMPANION_CONTRACT.md` defines the production endpoint contract.
+
+Not verified:
+
+- Streaming endpoint.
+- Non-streaming endpoint.
+- Memory retrieval endpoint.
+- Voice input.
+- TTS.
+- Cooldown persistence.
+
+## Voice/TTS audit
+
+Status: NOT VERIFIED
+
+Required before LOCKED:
+
+- Browser test voice permission states.
+- Unsupported browser fallback.
+- TTS speaking/stop/mute state if supported.
+- Quiet mode behavior.
+
+## Visual/motion audit
+
+Status: PARTIALLY VERIFIED
+
+Observed in `UraiResolvedHomeScene`:
+
+- aura orb physical CSS and data-state behavior
+- sky layer
+- constellation memory stars
+- ground hotspots
+- body/silhouette field
+- reduced-motion path
+- lifemap transition mode
+- return-home behavior
+
+Required before LOCKED:
+
+- Browser visual smoke.
+- Mobile viewport smoke.
+- Reduced-motion browser smoke.
+- WebGL/fallback asset smoke.
+
+## Sky ascent audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- `Mode = "home" | "transitioning" | "lifemap"`
+- `openLifeMap`
+- `returnHome`
+- reduced-motion shortcut to `lifemap`
+- transition CSS for `.is-transitioning`
+
+Required:
+
+- Run `npm run check:ascent`.
+- Run browser smoke for ascent and return-home.
+
+## Life-map continuity audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- Resolved scene renders `<LifeMapScene />` in lifemap mode.
+- Return button returns to home mode.
+
+Required:
+
+- Confirm `/life-map` route itself loads.
+- Confirm memory star focus/bloom/replay behavior where implemented.
+
+## Memory star audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- `Constellation` renders memory stars from normalized `home.nodes`.
+- Nodes open a focus surface.
+- Nodes share the resolved scene's visual language.
+
+Required:
+
+- Browser smoke star open/close.
+- Verify empty node state with real empty Firestore data.
+
+## Emotional weather audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- `moodWeather`, `forecastSummary`, and `forecastMessage` are normalized in `useUraiHomeState`.
+- Visuals derive from `visualState`, threshold, recovery, and rhythm.
+
+Required:
+
+- Browser smoke emotional weather display.
+- Copy review for all connected forecast/narrator surfaces.
+
+## Mobile audit
+
+Status: NOT VERIFIED
+
+Required:
+
+- iOS Safari smoke.
+- Android Chrome smoke.
+- Small viewport smoke.
+- Touch-target check.
+- Safe-area check.
+
+## Reduced-motion audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- `prefers-reduced-motion` listener exists.
+- Reduced motion skips transition timer and enters lifemap directly.
+
+Required:
+
+- Browser smoke with reduced motion enabled.
+
+## Accessibility audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- main zones are buttons with aria labels.
+- return-home has aria label.
+- scene pulse uses `aria-live`.
+
+Required:
+
+- Keyboard-only browser smoke.
+- Focus-visible visual check.
+- Color contrast review.
+
+## Telemetry audit
+
+Status: NOT VERIFIED
+
+Required:
+
+- Confirm telemetry utility exists.
+- Add or verify sanitized home events.
+- Confirm telemetry failure is non-breaking.
+- Confirm privacy setting behavior if configurable.
+
+## Privacy/safety copy audit
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- Existing resolved scene and hook copy is symbolic and avoids direct diagnostic claims.
+- `HOME_COMPANION_CONTRACT.md` defines diagnostic-language restrictions.
+
+Required:
+
+- Full connected-route copy scan.
+- `npm run check:public-copy`.
+
+## Admin/debug protection audit
+
+Status: NOT VERIFIED
+
+Required:
+
+- Inspect admin/debug routes.
+- Confirm admin auth guard.
+- Run rules/route tests where available.
+
+## Console/logging audit
+
+Status: NOT VERIFIED
+
+Required:
+
+- Run browser smoke and inspect console.
+- Ensure no raw private data is logged.
+
+## Evidence checklist
+
+| Evidence item | Status |
+| --- | --- |
+| `/home` route wired to resolved scene | COMPLETE |
+| `check:home` script added | COMPLETE |
+| `check:ascent` script added | COMPLETE |
+| `HOME_DATA_CONTRACT.md` produced | COMPLETE |
+| `HOME_COMPANION_CONTRACT.md` produced | COMPLETE |
+| `HOME_LOCK_REPORT.md` produced | COMPLETE |
+| `HOME_E2E_AUDIT.md` produced | COMPLETE |
+| Typecheck run | NOT RUN IN THIS ENVIRONMENT |
+| Lint run | NOT RUN IN THIS ENVIRONMENT |
+| Unit tests run | NOT RUN IN THIS ENVIRONMENT |
+| Build run | NOT RUN IN THIS ENVIRONMENT |
+| Firestore rules/emulator proof | NOT RUN IN THIS ENVIRONMENT |
+| Browser smoke | NOT RUN IN THIS ENVIRONMENT |
+| Deployment proof | NOT RUN IN THIS ENVIRONMENT |
+
+## Final pass/fail table
+
+| Area | Result |
+| --- | --- |
+| Repo inspection | PASS |
+| `/home` route wiring | PASS |
+| Static gate scripts | PASS |
+| Data contract | PASS |
+| Companion contract | PASS |
+| Runtime verification | FAIL - not executed here |
+| Emulator/rules verification | FAIL - not executed here |
+| Deploy evidence | FAIL - not executed here |
+| Final LOCKED status | FAIL - do not mark LOCKED yet |

--- a/HOME_LOCK_REPORT.md
+++ b/HOME_LOCK_REPORT.md
@@ -1,0 +1,359 @@
+# HOME LOCK REPORT
+
+Date: 2026-05-18
+Branch: `final/home-lock-execution`
+Final status: PARTIALLY LOCKED / NOT LOCKED
+
+## Summary
+
+This execution pass performed the repository-facing portion of the URAI FINAL HOME LOCK. The active `/home` route now mounts the Firestore-backed resolved home scene, and static final-lock scripts and required contract/audit documents were added.
+
+The final release status is not LOCKED because runtime commands, Firebase emulator/rules proof, browser smoke tests, deployment proof, production companion endpoint proof, and voice/TTS verification were not executable through this connector-only environment.
+
+## Baseline findings
+
+- Main repo: `LifeLoggerAI/UrAi`
+- Default branch: `main`
+- Working branch: `final/home-lock-execution`
+- Framework: Next.js
+- Firebase dependencies are present in `package.json`.
+- Three/Fiber, Three.js, and Framer Motion dependencies are present.
+- Jest, Playwright, and Firestore rules test scripts are present.
+- Existing `/home` route file: `src/app/home/page.tsx`
+- Existing root home entry: `src/app/page.tsx`
+- Older cinematic shrine component: `src/components/urai/home/HomeScene.tsx`
+- Resolved Firestore-backed home field: `src/components/urai/UraiResolvedHomeScene.tsx`
+- Live home data hook: `src/lib/use-urai-home-state.ts`
+
+## Canonical /home route path
+
+`src/app/home/page.tsx`
+
+## Connected route inventory
+
+Expected home-connected routes/surfaces:
+
+- `/home`
+- `/life-map`
+- `/forecast`
+- `/cognitive-mirror`
+- `/narrator`
+- `/homeview` if retained as legacy/cinematic route
+- memory star focus/bloom/replay route if implemented
+
+## Files changed
+
+- `src/app/home/page.tsx`
+- `package.json`
+- `scripts/check-home-lock.mjs`
+- `scripts/check-ascent-lock.mjs`
+- `HOME_DATA_CONTRACT.md`
+- `HOME_COMPANION_CONTRACT.md`
+- `HOME_E2E_AUDIT.md`
+- `HOME_LOCK_REPORT.md`
+
+## Features implemented
+
+### `/home` canonical route wiring
+
+`/home` now imports and renders `UraiResolvedHomeScene`, which is the Firestore-backed resolved scene with:
+
+- home/transition/lifemap state model
+- live home state hook
+- reduced-motion ascent behavior
+- memory constellation nodes
+- physical aura orb charge behavior
+- ground/body interaction zones
+- return-home behavior from embedded lifemap mode
+
+### Static verification gates
+
+Added:
+
+- `npm run check:home`
+- `npm run check:ascent`
+
+These scripts statically verify key final-lock requirements are present in the repository.
+
+## Data wiring completed
+
+Existing live data hook verified and documented:
+
+- `onAuthStateChanged(auth(), ...)`
+- Firestore snapshots through `onSnapshot`
+- user-scoped paths under `users/{uid}`
+- normalized home view model
+- demo/unconfigured fallback source states
+- normalized life-map nodes
+
+Live data paths documented in `HOME_DATA_CONTRACT.md`:
+
+- `users/{uid}/homeState/current`
+- `users/{uid}/moodForecasts/current`
+- `users/{uid}/companionState/current`
+- `users/{uid}/visualState/current`
+- `users/{uid}/lifeMapNodes/*`
+
+## Firebase/Auth/Firestore status
+
+Status: PARTIALLY VERIFIED
+
+Completed:
+
+- Confirmed Firebase client dependency exists.
+- Confirmed auth state binding exists in the live hook.
+- Confirmed Firestore reads are user-scoped in the hook.
+- Documented expected rules and emulator proof requirements.
+
+Not completed in this environment:
+
+- Firebase emulator execution.
+- Rules test output capture.
+- Production Firebase runtime proof.
+- Deployment proof.
+
+## Firestore rules status
+
+Status: NOT VERIFIED
+
+Required before LOCKED:
+
+- Run `npm run test:rules` or repository equivalent.
+- Prove authenticated own-user reads pass.
+- Prove cross-user reads fail.
+- Prove unauthenticated reads fail.
+- Prove telemetry/trust/companion/admin scopes.
+
+## Emulator proof status
+
+Status: NOT VERIFIED
+
+Reason: The connector environment allowed GitHub file changes but did not provide a live clone/runtime command environment for executing Firebase emulators.
+
+## Companion/orb status
+
+Status: PARTIALLY VERIFIED
+
+Completed:
+
+- `/home` now routes to the resolved scene with physical aura orb behavior.
+- Resolved scene has companion focus surface.
+- Home view model includes companion mode and narrator whisper.
+- Companion contract produced.
+
+Not completed:
+
+- Production companion endpoint not verified.
+- Streaming response not verified.
+- Memory retrieval endpoint not verified.
+- Cooldown persistence not verified.
+
+## Voice/TTS status
+
+Status: NOT VERIFIED
+
+Voice input and TTS hooks were documented but not proven in this pass.
+
+## Explainability status
+
+Status: PARTIALLY VERIFIED
+
+- Contract requires explainability for emotional weather, narrator insight, memory star, passive cue, companion suggestion, and aura state.
+- Runtime UI proof is still required.
+
+## Asset system status
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- Existing Three/Fiber home world canvas exists.
+- Resolved scene includes CSS/procedural visual field.
+- Fallback expectations are documented.
+
+Still required:
+
+- Final authored Rive/Lottie/GLB asset registry proof.
+- Browser smoke for WebGL/fallback failures.
+- Mobile performance proof.
+
+## Visual/motion status
+
+Status: PARTIALLY VERIFIED
+
+Observed in resolved scene:
+
+- physical orb CSS
+- memory stars
+- constellation path
+- ground hotspots
+- body/silhouette field
+- lifemap transition mode
+- reduced-motion shortcut
+- return-home behavior
+
+Still required:
+
+- Runtime browser visual smoke.
+- Reduced-motion browser smoke.
+- Mobile viewport smoke.
+
+## Route continuity status
+
+Status: PARTIALLY VERIFIED
+
+Completed:
+
+- `/home` routes to resolved scene.
+- Resolved scene can enter embedded lifemap mode and return home.
+
+Still required:
+
+- Browser-smoke `/life-map`, `/forecast`, `/cognitive-mirror`, `/narrator`, `/homeview` if retained.
+- Verify memory star focus/bloom/replay routes if implemented.
+
+## Privacy/trust status
+
+Status: PARTIALLY VERIFIED
+
+Completed:
+
+- Contracts document privacy, no raw private logs, no diagnostic copy, no hidden recording.
+- Existing home copy is symbolic and non-diagnostic.
+
+Still required:
+
+- Full route copy scan.
+- `npm run check:public-copy`.
+- Trust/privacy persistence proof.
+- Admin/debug guard proof.
+
+## Telemetry status
+
+Status: NOT VERIFIED
+
+Required:
+
+- Identify telemetry utility.
+- Add or verify sanitized `/home` event payloads.
+- Prove telemetry failure is non-breaking.
+- Prove privacy preference behavior if configurable.
+
+## Accessibility/mobile status
+
+Status: PARTIALLY VERIFIED
+
+Observed:
+
+- Key home scene elements are buttons with aria labels.
+- Scene pulse uses `aria-live`.
+- Reduced-motion logic exists.
+
+Still required:
+
+- Keyboard-only browser smoke.
+- Focus-visible check.
+- Color contrast review.
+- iOS Safari / Android Chrome smoke.
+
+## Tests added/updated
+
+Added static gate scripts:
+
+- `scripts/check-home-lock.mjs`
+- `scripts/check-ascent-lock.mjs`
+
+No Jest/Playwright tests were added in this pass because runtime verification could not be executed here.
+
+## Commands run
+
+Commands were not run in this connector-only environment. The following commands must be run from a local/CI checkout before marking `/home` LOCKED:
+
+```bash
+npm install
+npm run typecheck
+npm run lint
+npm run test
+npm run build
+npm run check:home
+npm run check:ascent
+npm run test:rules
+npm run test:smoke
+npm run launch:p0
+```
+
+If using pnpm in your environment, run the pnpm equivalents.
+
+## Command results
+
+Not available from this connector-only execution pass.
+
+## Smoke test results
+
+Not available from this connector-only execution pass.
+
+## Known limitations
+
+- Full runtime proof was not run.
+- Emulator/rules proof was not run.
+- Deploy proof was not produced.
+- Voice/TTS was not verified.
+- Companion streaming/memory endpoint was not verified.
+- Telemetry implementation was not verified.
+- Admin/debug protection was not verified.
+- Mobile browser behavior was not verified.
+
+## Failures/blockers
+
+Critical blockers preventing LOCKED:
+
+1. Build/typecheck/lint/test results are not attached.
+2. Firebase emulator/rules proof is not attached.
+3. Browser smoke proof is not attached.
+4. Deploy proof is not attached.
+5. Companion endpoint proof is not attached.
+6. Voice/TTS proof is not attached or explicitly finalized as unsupported fallback.
+7. Telemetry/privacy/admin checks are not attached.
+
+## Evidence summary
+
+Complete:
+
+- Route wiring commit exists.
+- Static gate scripts exist.
+- Data contract exists.
+- Companion contract exists.
+- E2E audit exists.
+- Lock report exists.
+
+Incomplete:
+
+- Runtime command output.
+- Firebase emulator output.
+- Browser smoke output.
+- Deployment output.
+
+## Release lock decision
+
+Final status: PARTIALLY LOCKED / NOT LOCKED
+
+Do not mark `/home` LOCKED yet.
+
+## Whether /home can be marked LOCKED
+
+No. `/home` cannot be marked LOCKED until all required runtime, emulator, smoke, deployment, privacy, telemetry, companion, voice/TTS, and documentation evidence passes.
+
+## Exact next actions
+
+1. Pull branch `final/home-lock-execution`.
+2. Run `npm install`.
+3. Run `npm run check:home`.
+4. Run `npm run check:ascent`.
+5. Run `npm run typecheck`.
+6. Run `npm run lint`.
+7. Run `npm run test`.
+8. Run `npm run build`.
+9. Run `npm run test:rules`.
+10. Run smoke tests for `/home`, `/life-map`, `/forecast`, `/cognitive-mirror`, `/narrator`, `/homeview` if retained.
+11. Attach outputs to this report.
+12. Only then update release/status docs to LOCKED if all criteria pass.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "check:firebase": "node scripts/check-firebase-target.mjs",
     "check:firebase:staging": "URAI_EXPECTED_FIREBASE_PROJECT=urai-staging URAI_EXPECTED_FIREBASE_SITE=urai-staging node scripts/check-firebase-target.mjs --config firebase.staging.json",
     "check:types": "tsc --noEmit",
+    "check:home": "node scripts/check-home-lock.mjs",
+    "check:ascent": "node scripts/check-ascent-lock.mjs",
     "check:tier2-access": "node scripts/tier-lock/tier2-access-check.mjs",
     "typecheck": "tsc --noEmit",
     "validate": "npm run validate:completion",

--- a/scripts/check-ascent-lock.mjs
+++ b/scripts/check-ascent-lock.mjs
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const checks = [];
+
+function read(relativePath) {
+  const absolute = path.join(root, relativePath);
+  if (!fs.existsSync(absolute)) return '';
+  return fs.readFileSync(absolute, 'utf8');
+}
+
+function assertCheck(name, passed, detail) {
+  checks.push({ name, passed, detail });
+}
+
+const resolvedScene = read('src/components/urai/UraiResolvedHomeScene.tsx');
+const lifeMapScene = read('src/components/lifemap/LifeMapScene.tsx');
+const homePage = read('src/app/home/page.tsx');
+const lifeMapPage = read('src/app/life-map/page.tsx');
+const packageJson = read('package.json');
+
+assertCheck('home page uses resolved scene', homePage.includes('UraiResolvedHomeScene'), '/home must mount the resolved scene that owns the ascent state machine.');
+assertCheck('life-map page exists', Boolean(lifeMapPage.trim()) || Boolean(lifeMapScene.trim()), 'Life Map target route/component must exist.');
+assertCheck('resolved scene has transition mode', resolvedScene.includes('transitioning'), 'Resolved scene must include transition mode.');
+assertCheck('resolved scene enters lifemap mode', resolvedScene.includes('setMode("lifemap")'), 'Resolved scene must enter lifemap mode.');
+assertCheck('resolved scene renders LifeMapScene', resolvedScene.includes('<LifeMapScene />'), 'Resolved scene must render LifeMapScene after ascent.');
+assertCheck('resolved scene has openLifeMap action', resolvedScene.includes('const openLifeMap') && resolvedScene.includes('setMode(reduceMotion ? "lifemap" : "transitioning")'), 'Resolved scene must expose deterministic openLifeMap action.');
+assertCheck('resolved scene has returnHome action', resolvedScene.includes('const returnHome') && resolvedScene.includes('setMode("home")'), 'Resolved scene must return from lifemap to home.');
+assertCheck('resolved scene supports reduced motion', resolvedScene.includes('prefers-reduced-motion') && resolvedScene.includes('reduceMotion'), 'Reduced-motion users must bypass disorienting ascent.');
+assertCheck('resolved scene animates transition CSS', resolvedScene.includes('is-transitioning') && resolvedScene.includes('.is-transitioning .aura-orb-button'), 'Ascent transition CSS must exist.');
+assertCheck('package exposes check:ascent', packageJson.includes('"check:ascent"'), 'package.json must expose npm run check:ascent.');
+
+const failed = checks.filter((check) => !check.passed);
+for (const check of checks) {
+  const icon = check.passed ? 'PASS' : 'FAIL';
+  console.log(`[${icon}] ${check.name}`);
+  if (!check.passed) console.log(`       ${check.detail}`);
+}
+
+if (failed.length) {
+  console.error(`\nURAI ascent lock check failed: ${failed.length} failing check(s).`);
+  process.exit(1);
+}
+
+console.log('\nURAI ascent static checks passed. Full visual smoke and reduced-motion browser verification are still required before marking /home LOCKED.');

--- a/scripts/check-home-lock.mjs
+++ b/scripts/check-home-lock.mjs
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const checks = [];
+
+function read(relativePath) {
+  const absolute = path.join(root, relativePath);
+  if (!fs.existsSync(absolute)) return '';
+  return fs.readFileSync(absolute, 'utf8');
+}
+
+function assertCheck(name, passed, detail) {
+  checks.push({ name, passed, detail });
+}
+
+const homePage = read('src/app/home/page.tsx');
+const rootPage = read('src/app/page.tsx');
+const resolvedScene = read('src/components/urai/UraiResolvedHomeScene.tsx');
+const stateHook = read('src/lib/use-urai-home-state.ts');
+const packageJson = read('package.json');
+const lockReport = read('HOME_LOCK_REPORT.md');
+const e2eAudit = read('HOME_E2E_AUDIT.md');
+const dataContract = read('HOME_DATA_CONTRACT.md');
+const companionContract = read('HOME_COMPANION_CONTRACT.md');
+
+assertCheck('home route mounts UraiResolvedHomeScene', homePage.includes('UraiResolvedHomeScene') && homePage.includes('return <UraiResolvedHomeScene />'), 'src/app/home/page.tsx should route /home to the resolved home scene.');
+assertCheck('root page remains a home scene entrypoint', rootPage.includes('HomeScene') || rootPage.includes('UraiResolvedHomeScene'), 'src/app/page.tsx should remain a valid home entrypoint.');
+assertCheck('resolved scene imports live home state hook', resolvedScene.includes('useUraiHomeState'), 'Resolved scene must consume the live home view model hook.');
+assertCheck('resolved scene exposes life-map mode', resolvedScene.includes('Mode = "home" | "transitioning" | "lifemap"') || resolvedScene.includes('lifemap'), 'Resolved scene must include home/transition/lifemap flow.');
+assertCheck('resolved scene has reduced-motion path', resolvedScene.includes('prefers-reduced-motion') && resolvedScene.includes('reduceMotion'), 'Resolved scene must support reduced-motion ascent.');
+assertCheck('resolved scene has return-home behavior', resolvedScene.includes('returnHome') && resolvedScene.includes('Return home'), 'Resolved scene must provide return-home behavior.');
+assertCheck('resolved scene has memory stars', resolvedScene.includes('memory-star') && resolvedScene.includes('Constellation'), 'Resolved scene must surface memory stars/constellation nodes.');
+assertCheck('resolved scene has orb physical states', resolvedScene.includes('aura-orb-button') && resolvedScene.includes('data-orb-charge') && resolvedScene.includes('orb-core'), 'Resolved scene must include physical orb interaction state.');
+assertCheck('resolved scene has ground hotspots', resolvedScene.includes('GROUND_ZONES') && resolvedScene.includes('ground-hotspot'), 'Resolved scene must include ground/body interaction zones.');
+assertCheck('home state hook uses Firebase auth', stateHook.includes('onAuthStateChanged') && stateHook.includes('auth()'), 'Home state must bind to authenticated Firebase user.');
+assertCheck('home state hook uses Firestore snapshots', stateHook.includes('onSnapshot') && stateHook.includes('db()'), 'Home state must use Firestore reads/snapshots.');
+assertCheck('home state hook normalizes life-map nodes', stateHook.includes('normalizeNode') && stateHook.includes('lifeMapNodes'), 'Home state must normalize memory/life-map nodes.');
+assertCheck('home state hook has explicit fallback source states', stateHook.includes('source: "firestore"') && stateHook.includes('source: "demo"') && stateHook.includes('source: "unconfigured"'), 'Home state must distinguish live, demo, and unconfigured data.');
+assertCheck('package exposes check:home', packageJson.includes('"check:home"'), 'package.json must expose npm run check:home.');
+assertCheck('home lock report exists', lockReport.includes('HOME LOCK REPORT'), 'HOME_LOCK_REPORT.md must exist.');
+assertCheck('home e2e audit exists', e2eAudit.includes('HOME E2E AUDIT'), 'HOME_E2E_AUDIT.md must exist.');
+assertCheck('home data contract exists', dataContract.includes('HOME DATA CONTRACT'), 'HOME_DATA_CONTRACT.md must exist.');
+assertCheck('home companion contract exists', companionContract.includes('HOME COMPANION CONTRACT'), 'HOME_COMPANION_CONTRACT.md must exist.');
+
+const failed = checks.filter((check) => !check.passed);
+for (const check of checks) {
+  const icon = check.passed ? 'PASS' : 'FAIL';
+  console.log(`[${icon}] ${check.name}`);
+  if (!check.passed) console.log(`       ${check.detail}`);
+}
+
+if (failed.length) {
+  console.error(`\nURAI home lock check failed: ${failed.length} failing check(s).`);
+  process.exit(1);
+}
+
+console.log('\nURAI home lock static checks passed. Runtime, emulator, and deploy evidence are still required before marking /home LOCKED.');

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,11 +1,11 @@
-import { HomeScene } from "@/components/urai/home/HomeScene";
+import UraiResolvedHomeScene from "@/components/urai/UraiResolvedHomeScene";
 
 export const metadata = {
-  title: "URAI Inner Sky Shrine",
+  title: "URAI Final Home Field",
   description:
-    "The cinematic URAI home shrine: orb, avatar, symbolic ground, ascent transition, and Memory Galaxy gateway.",
+    "The resolved URAI /home field: live emotional weather, aura orb, symbolic ground, memory stars, reduced-motion ascent, and Life Map gateway.",
 };
 
 export default function HomePage() {
-  return <HomeScene />;
+  return <UraiResolvedHomeScene />;
 }


### PR DESCRIPTION
## Summary

This PR executes the repository-facing portion of `URAI_FINAL_HOME_LOCK_IMPLEMENTATION_PROMPT` for `/home`.

Implemented:

- Routes `/home` to the Firestore-backed `UraiResolvedHomeScene` instead of the older static shrine shell.
- Adds `npm run check:home` static gate.
- Adds `npm run check:ascent` static gate.
- Adds `HOME_DATA_CONTRACT.md`.
- Adds `HOME_COMPANION_CONTRACT.md`.
- Adds `HOME_E2E_AUDIT.md`.
- Adds `HOME_LOCK_REPORT.md`.

## Important lock status

This PR intentionally does **not** mark `/home` as `LOCKED`.

Current status: `PARTIALLY LOCKED / NOT LOCKED`

Reason: the connector environment allowed repository edits, but did not allow running the full local/CI command matrix, Firebase emulator proof, browser smoke, deployment verification, companion endpoint proof, voice/TTS proof, telemetry audit, or admin/debug protection proof.

## Required verification before marking LOCKED

Run from a checkout or CI:

```bash
npm install
npm run check:home
npm run check:ascent
npm run typecheck
npm run lint
npm run test
npm run build
npm run test:rules
npm run test:smoke
npm run launch:p0
```

Then update `HOME_LOCK_REPORT.md` with command outputs and only mark `/home` LOCKED if all acceptance criteria pass.

## Files changed

- `src/app/home/page.tsx`
- `package.json`
- `scripts/check-home-lock.mjs`
- `scripts/check-ascent-lock.mjs`
- `HOME_DATA_CONTRACT.md`
- `HOME_COMPANION_CONTRACT.md`
- `HOME_E2E_AUDIT.md`
- `HOME_LOCK_REPORT.md`

## Notes

The active `/home` route now uses the existing resolved home field that already consumes `useUraiHomeState`, including Firebase Auth and Firestore snapshot wiring, normalized home data, memory nodes, reduced-motion ascent, physical orb state, ground/body zones, embedded life-map mode, and return-home behavior.