### PR TITLE
Run /home lock gates in CI and P0 reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Check V1 wiring
         run: npm run check:v1
 
+      - name: Check final home lock
+        run: npm run check:home
+
+      - name: Check final home ascent
+        run: npm run check:ascent
+
       - name: Check P0 launch gate
         run: npm run launch:p0
 

--- a/HOME_LOCK_REPORT.md
+++ b/HOME_LOCK_REPORT.md
@@ -1,20 +1,23 @@
 # HOME LOCK REPORT
 
 Date: 2026-05-18
-Branch: `final/home-lock-execution`
+Branch: `fix/home-lock-ci-p0-gates`
 Final status: PARTIALLY LOCKED / NOT LOCKED
 
 ## Summary
 
-This execution pass performed the repository-facing portion of the URAI FINAL HOME LOCK. The active `/home` route now mounts the Firestore-backed resolved home scene, and static final-lock scripts and required contract/audit documents were added.
+This follow-up pass makes the merged URAI `/home` final-lock work harder to regress by wiring the new home lock gates into CI and P0 launch reporting.
 
-The final release status is not LOCKED because runtime commands, Firebase emulator/rules proof, browser smoke tests, deployment proof, production companion endpoint proof, and voice/TTS verification were not executable through this connector-only environment.
+The active `/home` route was already moved to the Firestore-backed resolved home scene in PR #247. This pass adds the next repo-level lock step: CI now runs `npm run check:home` and `npm run check:ascent`, and the P0 launch gate now tracks those checks, `/home` contract docs, and `/home` manual evidence variables.
+
+The final release status remains not LOCKED because full runtime command output, Firebase emulator/rules proof, browser smoke tests, deployment proof, production companion endpoint proof, telemetry proof, admin/debug proof, and voice/TTS verification still need to be produced from CI/local/runtime evidence.
 
 ## Baseline findings
 
 - Main repo: `LifeLoggerAI/UrAi`
 - Default branch: `main`
-- Working branch: `final/home-lock-execution`
+- Prior merged PR: #247, `Final /home lock execution pass`
+- Current follow-up branch: `fix/home-lock-ci-p0-gates`
 - Framework: Next.js
 - Firebase dependencies are present in `package.json`.
 - Three/Fiber, Three.js, and Framer Motion dependencies are present.
@@ -41,7 +44,7 @@ Expected home-connected routes/surfaces:
 - `/homeview` if retained as legacy/cinematic route
 - memory star focus/bloom/replay route if implemented
 
-## Files changed
+## Files changed in PR #247
 
 - `src/app/home/page.tsx`
 - `package.json`
@@ -52,11 +55,17 @@ Expected home-connected routes/surfaces:
 - `HOME_E2E_AUDIT.md`
 - `HOME_LOCK_REPORT.md`
 
+## Files changed in this follow-up branch
+
+- `.github/workflows/ci.yml`
+- `scripts/p0-launch-gate.mjs`
+- `HOME_LOCK_REPORT.md`
+
 ## Features implemented
 
 ### `/home` canonical route wiring
 
-`/home` now imports and renders `UraiResolvedHomeScene`, which is the Firestore-backed resolved scene with:
+`/home` imports and renders `UraiResolvedHomeScene`, which is the Firestore-backed resolved scene with:
 
 - home/transition/lifemap state model
 - live home state hook
@@ -68,12 +77,42 @@ Expected home-connected routes/surfaces:
 
 ### Static verification gates
 
-Added:
+Added in PR #247:
 
 - `npm run check:home`
 - `npm run check:ascent`
 
-These scripts statically verify key final-lock requirements are present in the repository.
+This follow-up adds those checks to CI and P0 reporting.
+
+### CI gate integration
+
+`.github/workflows/ci.yml` now runs:
+
+- `npm run check:home`
+- `npm run check:ascent`
+
+These run after V1 wiring and before P0/P1 release gates, seed data, unit tests, rules tests, typecheck, lint, and build.
+
+### P0 launch gate integration
+
+`scripts/p0-launch-gate.mjs` now tracks:
+
+- `scripts/check-home-lock.mjs`
+- `scripts/check-ascent-lock.mjs`
+- `src/app/home/page.tsx`
+- `src/components/urai/UraiResolvedHomeScene.tsx`
+- `src/lib/use-urai-home-state.ts`
+- `HOME_LOCK_REPORT.md`
+- `HOME_E2E_AUDIT.md`
+- `HOME_DATA_CONTRACT.md`
+- `HOME_COMPANION_CONTRACT.md`
+- `npm run check:home`
+- `npm run check:ascent`
+- `CI includes npm run check:home`
+- `CI includes npm run check:ascent`
+- `/home` desktop/mobile/reduced-motion/emulator/companion fallback evidence env vars
+
+Passed checks now report: `No action required; this item is already covered by the listed evidence.`
 
 ## Data wiring completed
 
@@ -100,10 +139,11 @@ Status: PARTIALLY VERIFIED
 
 Completed:
 
-- Confirmed Firebase client dependency exists.
-- Confirmed auth state binding exists in the live hook.
-- Confirmed Firestore reads are user-scoped in the hook.
-- Documented expected rules and emulator proof requirements.
+- Firebase client dependency exists.
+- Auth state binding exists in the live hook.
+- Firestore reads are user-scoped in the hook.
+- Expected rules and emulator proof requirements are documented.
+- P0 now tracks `/home` emulator proof as an explicit manual evidence variable.
 
 Not completed in this environment:
 
@@ -123,6 +163,7 @@ Required before LOCKED:
 - Prove cross-user reads fail.
 - Prove unauthenticated reads fail.
 - Prove telemetry/trust/companion/admin scopes.
+- Set `URAI_HOME_FIREBASE_EMULATOR_VERIFIED=1` only after real proof exists.
 
 ## Emulator proof status
 
@@ -136,10 +177,11 @@ Status: PARTIALLY VERIFIED
 
 Completed:
 
-- `/home` now routes to the resolved scene with physical aura orb behavior.
+- `/home` routes to the resolved scene with physical aura orb behavior.
 - Resolved scene has companion focus surface.
 - Home view model includes companion mode and narrator whisper.
-- Companion contract produced.
+- Companion contract exists.
+- P0 now tracks `/home` companion fallback evidence.
 
 Not completed:
 
@@ -197,6 +239,7 @@ Still required:
 - Runtime browser visual smoke.
 - Reduced-motion browser smoke.
 - Mobile viewport smoke.
+- Set `URAI_HOME_DESKTOP_VERIFIED=1`, `URAI_HOME_MOBILE_VERIFIED=1`, and `URAI_HOME_REDUCED_MOTION_VERIFIED=1` only after real proof exists.
 
 ## Route continuity status
 
@@ -206,6 +249,7 @@ Completed:
 
 - `/home` routes to resolved scene.
 - Resolved scene can enter embedded lifemap mode and return home.
+- `npm run check:ascent` exists and is now in CI.
 
 Still required:
 
@@ -258,10 +302,16 @@ Still required:
 
 ## Tests added/updated
 
-Added static gate scripts:
+Added static gate scripts in PR #247:
 
 - `scripts/check-home-lock.mjs`
 - `scripts/check-ascent-lock.mjs`
+
+Added gate integration in this follow-up branch:
+
+- CI runs `npm run check:home`.
+- CI runs `npm run check:ascent`.
+- P0 report tracks both scripts and both commands.
 
 No Jest/Playwright tests were added in this pass because runtime verification could not be executed here.
 
@@ -271,18 +321,34 @@ Commands were not run in this connector-only environment. The following commands
 
 ```bash
 npm install
+npm run check:home
+npm run check:ascent
 npm run typecheck
 npm run lint
 npm run test
 npm run build
-npm run check:home
-npm run check:ascent
 npm run test:rules
 npm run test:smoke
 npm run launch:p0
 ```
 
-If using pnpm in your environment, run the pnpm equivalents.
+Full P0 evidence gate:
+
+```bash
+URAI_P0_RUN_COMMANDS=1 \
+URAI_P0_DESKTOP_VERIFIED=1 \
+URAI_P0_MOBILE_VERIFIED=1 \
+URAI_P0_WAITLIST_PERSISTENCE_VERIFIED=1 \
+URAI_P0_FIREBASE_RULES_INDEXES_DEPLOYED=1 \
+URAI_P0_PRIVATE_DATA_SAFETY_VERIFIED=1 \
+URAI_HOME_DESKTOP_VERIFIED=1 \
+URAI_HOME_MOBILE_VERIFIED=1 \
+URAI_HOME_REDUCED_MOTION_VERIFIED=1 \
+URAI_HOME_FIREBASE_EMULATOR_VERIFIED=1 \
+URAI_HOME_COMPANION_FALLBACK_VERIFIED=1 \
+URAI_P0_DEMO_RECORDING_URL="https://example.com/demo.mp4" \
+npm run launch:p0
+```
 
 ## Command results
 
@@ -321,6 +387,8 @@ Complete:
 
 - Route wiring commit exists.
 - Static gate scripts exist.
+- CI includes `check:home` and `check:ascent` in this follow-up branch.
+- P0 tracks `check:home` and `check:ascent` in this follow-up branch.
 - Data contract exists.
 - Companion contract exists.
 - E2E audit exists.
@@ -345,7 +413,7 @@ No. `/home` cannot be marked LOCKED until all required runtime, emulator, smoke,
 
 ## Exact next actions
 
-1. Pull branch `final/home-lock-execution`.
+1. Merge this follow-up branch after CI passes.
 2. Run `npm install`.
 3. Run `npm run check:home`.
 4. Run `npm run check:ascent`.
@@ -355,5 +423,6 @@ No. `/home` cannot be marked LOCKED until all required runtime, emulator, smoke,
 8. Run `npm run build`.
 9. Run `npm run test:rules`.
 10. Run smoke tests for `/home`, `/life-map`, `/forecast`, `/cognitive-mirror`, `/narrator`, `/homeview` if retained.
-11. Attach outputs to this report.
-12. Only then update release/status docs to LOCKED if all criteria pass.
+11. Run the full P0 evidence gate with the new `/home` evidence env vars.
+12. Attach outputs to this report.
+13. Only then update release/status docs to LOCKED if all criteria pass.

--- a/scripts/p0-launch-gate.mjs
+++ b/scripts/p0-launch-gate.mjs
@@ -53,16 +53,25 @@ const requiredFiles = [
   ["firestore.rules", "Protect private and server-only data."],
   ["firestore.indexes.json", "Deploy required Firestore indexes."],
   ["src/app/page.tsx", "Serve the public home demo spine at /."],
+  ["src/app/home/page.tsx", "Serve the final resolved /home field."],
   ["src/app/u/[handle]/page.tsx", "Serve the public Adam Clamp constellation route."],
   ["src/app/api/companion/route.ts", "Serve the companion narrator API."],
   ["src/app/api/waitlist/route.ts", "Serve the waitlist capture API."],
-  ["src/components/HomeScene.tsx", "Render the home demo scene."],
+  ["src/components/HomeScene.tsx", "Render the public home demo scene."],
+  ["src/components/urai/UraiResolvedHomeScene.tsx", "Render the final live-data /home field."],
+  ["src/lib/use-urai-home-state.ts", "Normalize and bind final /home state to Firebase/Auth/Firestore."],
   ["src/components/CompanionChat.tsx", "Render and exercise the companion flow."],
   ["src/components/WaitlistForm.tsx", "Render and exercise waitlist capture."],
   ["src/lib/firebase-admin.ts", "Support configured Firestore writes for waitlist persistence."],
   ["scripts/check-v1.mjs", "Verify required V1 wiring."],
   ["scripts/check-lockfile.mjs", "Fail stale lockfiles before launch."],
+  ["scripts/check-home-lock.mjs", "Verify final /home lock static requirements."],
+  ["scripts/check-ascent-lock.mjs", "Verify final /home ascent static requirements."],
   ["scripts/seed-demo.mjs", "Generate deterministic demo seed data."],
+  ["HOME_LOCK_REPORT.md", "Track final /home lock evidence and blockers."],
+  ["HOME_E2E_AUDIT.md", "Track final /home route, state, Firebase, motion, mobile, and audit evidence."],
+  ["HOME_DATA_CONTRACT.md", "Document final /home Firestore data contract."],
+  ["HOME_COMPANION_CONTRACT.md", "Document final /home companion contract."],
   ["docs/V1_DEPLOY_CHECKLIST.md", "Keep deploy readiness checklist in repo."],
   ["docs/V1_QA_CHECKLIST.md", "Keep QA checklist in repo."],
   ["docs/V1_MANUAL_TESTS.md", "Keep manual API/browser recipes in repo."],
@@ -78,6 +87,8 @@ if (exists("package.json")) {
   for (const script of [
     "check:v1",
     "check:lockfile",
+    "check:home",
+    "check:ascent",
     "seed:demo",
     "test:unit",
     "test:rules",
@@ -119,11 +130,15 @@ const routeChecks = [
   ["README documents waitlist API", "README.md", /\/api\/waitlist/],
   ["manual tests include companion curl", "docs/V1_MANUAL_TESTS.md", /curl -X POST http:\/\/localhost:3014\/api\/companion/],
   ["manual tests include waitlist curl", "docs/V1_MANUAL_TESTS.md", /curl -X POST http:\/\/localhost:3014\/api\/waitlist/],
-  ["QA checklist includes mobile and desktop coverage", "docs/V1_QA_CHECKLIST.md", /mobile and desktop/]
+  ["QA checklist includes mobile and desktop coverage", "docs/V1_QA_CHECKLIST.md", /mobile and desktop/],
+  ["home lock report carries not-locked decision", "HOME_LOCK_REPORT.md", /PARTIALLY LOCKED \/ NOT LOCKED/],
+  ["home e2e audit carries not-locked decision", "HOME_E2E_AUDIT.md", /Final release lock decision: NOT LOCKED/],
+  ["home data contract documents Firestore paths", "HOME_DATA_CONTRACT.md", /users\/\{uid\}\/homeState\/current/],
+  ["home companion contract documents orb states", "HOME_COMPANION_CONTRACT.md", /listening[\s\S]*thinking[\s\S]*speaking/]
 ];
 
 for (const [name, file, pattern] of routeChecks) {
-  add(name, hasText(file, pattern), file, `Update ${file} so this route or test is explicitly covered.`);
+  add(name, hasText(file, pattern), file, `Update ${file} so this route, test, or lock evidence is explicitly covered.`);
 }
 
 if (exists(".github/workflows/ci.yml")) {
@@ -131,6 +146,8 @@ if (exists(".github/workflows/ci.yml")) {
   for (const token of [
     "npm run check:lockfile",
     "npm run check:v1",
+    "npm run check:home",
+    "npm run check:ascent",
     "npm run launch:p0",
     "npm run seed:demo",
     "npm run test:unit",
@@ -147,6 +164,8 @@ if (exists(".github/workflows/ci.yml")) {
 const commands = [
   "npm run check:lockfile",
   "npm run check:v1",
+  "npm run check:home",
+  "npm run check:ascent",
   "npm run seed:demo",
   "npm run test:unit",
   "npm run test:rules",
@@ -174,6 +193,11 @@ const manualEvidence = [
   ["Configured waitlist Firestore persistence verified", process.env.URAI_P0_WAITLIST_PERSISTENCE_VERIFIED],
   ["Firestore rules and indexes deployed", process.env.URAI_P0_FIREBASE_RULES_INDEXES_DEPLOYED],
   ["Private data read safety verified", process.env.URAI_P0_PRIVATE_DATA_SAFETY_VERIFIED],
+  ["/home desktop smoke verified", process.env.URAI_HOME_DESKTOP_VERIFIED],
+  ["/home mobile smoke verified", process.env.URAI_HOME_MOBILE_VERIFIED],
+  ["/home reduced-motion smoke verified", process.env.URAI_HOME_REDUCED_MOTION_VERIFIED],
+  ["/home Firebase emulator proof captured", process.env.URAI_HOME_FIREBASE_EMULATOR_VERIFIED],
+  ["/home companion fallback verified", process.env.URAI_HOME_COMPANION_FALLBACK_VERIFIED],
   ["30-60 second demo recording captured", process.env.URAI_P0_DEMO_RECORDING_URL]
 ];
 
@@ -190,12 +214,17 @@ const verdict = failed.length === 0 && unverified.length === 0
     ? "P0 STRUCTURALLY READY - EVIDENCE STILL REQUIRED"
     : "P0 NOT READY";
 
-function section(title, rows) {
-  if (!rows.length) return `## ${title}\n\nNone.\n`;
-  return `## ${title}\n\n${rows.map((check) => `- **${check.name}**\n  - Status: ${check.status}\n  - Evidence: ${check.evidence || "none"}\n  - Next action: ${check.remediation || "none"}`).join("\n")}\n`;
+function nextActionFor(check) {
+  if (check.status === "pass") return "No action required; this item is already covered by the listed evidence.";
+  return check.remediation || "Review and resolve this check.";
 }
 
-const report = `# URAI P0 Launch Gate Report\n\nGenerated: ${new Date().toISOString()}\n\nVerdict: **${verdict}**\n\nSummary:\n\n- Passed: ${passed.length}\n- Failed: ${failed.length}\n- Unverified: ${unverified.length}\n\n${section("Failed checks", failed)}\n${section("Unverified evidence", unverified)}\n${section("Passed checks", passed)}\n## Commands\n\nStatic gate:\n\n\`\`\`bash\nnpm run launch:p0\n\`\`\`\n\nFull local gate:\n\n\`\`\`bash\nURAI_P0_RUN_COMMANDS=1 npm run launch:p0\n\`\`\`\n\nFull evidence gate example:\n\n\`\`\`bash\nURAI_P0_RUN_COMMANDS=1 \\\nURAI_P0_DESKTOP_VERIFIED=1 \\\nURAI_P0_MOBILE_VERIFIED=1 \\\nURAI_P0_WAITLIST_PERSISTENCE_VERIFIED=1 \\\nURAI_P0_FIREBASE_RULES_INDEXES_DEPLOYED=1 \\\nURAI_P0_PRIVATE_DATA_SAFETY_VERIFIED=1 \\\nURAI_P0_DEMO_RECORDING_URL=\"https://example.com/demo.mp4\" \\\nnpm run launch:p0\n\`\`\`\n`;
+function section(title, rows) {
+  if (!rows.length) return `## ${title}\n\nNone.\n`;
+  return `## ${title}\n\n${rows.map((check) => `- **${check.name}**\n  - Status: ${check.status}\n  - Evidence: ${check.evidence || "none"}\n  - Next action: ${nextActionFor(check)}`).join("\n")}\n`;
+}
+
+const report = `# URAI P0 Launch Gate Report\n\nGenerated: ${new Date().toISOString()}\n\nVerdict: **${verdict}**\n\nSummary:\n\n- Passed: ${passed.length}\n- Failed: ${failed.length}\n- Unverified: ${unverified.length}\n\n${section("Failed checks", failed)}\n${section("Unverified evidence", unverified)}\n${section("Passed checks", passed)}\n## Commands\n\nStatic gate:\n\n\`\`\`bash\nnpm run launch:p0\n\`\`\`\n\nFull local gate:\n\n\`\`\`bash\nURAI_P0_RUN_COMMANDS=1 npm run launch:p0\n\`\`\`\n\nFull evidence gate example:\n\n\`\`\`bash\nURAI_P0_RUN_COMMANDS=1 \\\nURAI_P0_DESKTOP_VERIFIED=1 \\\nURAI_P0_MOBILE_VERIFIED=1 \\\nURAI_P0_WAITLIST_PERSISTENCE_VERIFIED=1 \\\nURAI_P0_FIREBASE_RULES_INDEXES_DEPLOYED=1 \\\nURAI_P0_PRIVATE_DATA_SAFETY_VERIFIED=1 \\\nURAI_HOME_DESKTOP_VERIFIED=1 \\\nURAI_HOME_MOBILE_VERIFIED=1 \\\nURAI_HOME_REDUCED_MOTION_VERIFIED=1 \\\nURAI_HOME_FIREBASE_EMULATOR_VERIFIED=1 \\\nURAI_HOME_COMPANION_FALLBACK_VERIFIED=1 \\\nURAI_P0_DEMO_RECORDING_URL=\"https://example.com/demo.mp4\" \\\nnpm run launch:p0\n\`\`\`\n`;
 
 fs.writeFileSync(path.join(reportDir, "p0-launch-gate-report.md"), report);
 console.log(report);


### PR DESCRIPTION
## Summary

Follow-up after PR #247. This makes the merged `/home` lock work harder to regress by wiring the new final home gates into CI and P0 launch reporting.

Implemented:

- CI now runs `npm run check:home`.
- CI now runs `npm run check:ascent`.
- P0 launch gate now tracks `check:home` and `check:ascent` scripts.
- P0 launch gate now tracks `/home` lock docs and contracts.
- P0 launch gate now tracks `/home` desktop, mobile, reduced-motion, emulator, and companion fallback evidence variables.
- Passed P0 report checks now say no action is required instead of showing stale remediation text.
- `HOME_LOCK_REPORT.md` updated for this follow-up branch and the new evidence gate.

## Still not claiming LOCKED

This still intentionally does **not** mark `/home` as LOCKED. It strengthens CI/P0 coverage and keeps the lock decision evidence-based.

Required before LOCKED:

```bash
npm install
npm run check:home
npm run check:ascent
npm run typecheck
npm run lint
npm run test
npm run build
npm run test:rules
npm run test:smoke
npm run launch:p0
```

Full P0 evidence gate now includes:

```bash
URAI_P0_RUN_COMMANDS=1 \
URAI_P0_DESKTOP_VERIFIED=1 \
URAI_P0_MOBILE_VERIFIED=1 \
URAI_P0_WAITLIST_PERSISTENCE_VERIFIED=1 \
URAI_P0_FIREBASE_RULES_INDEXES_DEPLOYED=1 \
URAI_P0_PRIVATE_DATA_SAFETY_VERIFIED=1 \
URAI_HOME_DESKTOP_VERIFIED=1 \
URAI_HOME_MOBILE_VERIFIED=1 \
URAI_HOME_REDUCED_MOTION_VERIFIED=1 \
URAI_HOME_FIREBASE_EMULATOR_VERIFIED=1 \
URAI_HOME_COMPANION_FALLBACK_VERIFIED=1 \
URAI_P0_DEMO_RECORDING_URL="https://example.com/demo.mp4" \
npm run launch:p0
```

## Files changed

- `.github/workflows/ci.yml`
- `scripts/p0-launch-gate.mjs`
- `HOME_LOCK_REPORT.md`