### PR TITLE
Add /home smoke coverage and conflict marker guard

### DIFF
--- a/tests/e2e/v1-smoke.spec.ts
+++ b/tests/e2e/v1-smoke.spec.ts
@@ -19,6 +19,33 @@ test.describe("URAI V1 smoke", () => {
     await expectBodyText(page, /^Early Access$/);
   });
 
+  test("final /home field exposes sky, orb, ground, companion, and return-home surfaces @smoke", async ({ page }) => {
+    await page.goto("/home", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("button", { name: "Open symbolic life map" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Charge orb" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Wake companion" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Tune body field" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open recovery bloom terrain" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Wake companion" }).click();
+    await expect(page.locator("aside").filter({ hasText: /quiet|listening|reflecting|forecasting|ritual|protective/i })).toBeVisible();
+
+    await page.getByRole("button", { name: "Open life map" }).click();
+    await expect(page.getByRole("button", { name: "Return home" })).toBeVisible();
+  });
+
+  test("final /home reduced-motion path can enter and return from life map @smoke", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/home", { waitUntil: "domcontentloaded" });
+
+    await page.getByRole("button", { name: "Open symbolic life map" }).click();
+    await expect(page.getByRole("button", { name: "Return home" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Return home" }).click();
+    await expect(page.getByRole("button", { name: "Open symbolic life map" })).toBeVisible();
+  });
+
   test("public constellation route renders demo content @smoke", async ({ page }) => {
     await page.goto("/u/adamclamp", { waitUntil: "domcontentloaded" });
 


### PR DESCRIPTION
## Summary

Continues the `/home` final lock hardening after PR #247 and PR #249 by adding real Playwright smoke coverage for the final `/home` field and adding a repo-wide merge conflict marker guard.

## Added /home smoke coverage

- `/home` loads the final resolved field.
- Sky/life-map entry button is visible.
- Aura orb button is visible.
- Companion wake button is visible.
- Body/ground portal controls are visible.
- Companion field pulse opens.
- Life-map entry from the field pulse shows return-home control.
- Reduced-motion users can enter life-map mode and return home.

## Added build failure prevention

The uploaded build log showed TypeScript/Next failing on unresolved merge conflict markers in:

- `src/components/spatial-life-map/SpatialLifeMap.tsx`

The current repo copy of that file is clean, but this PR adds a permanent guard so future conflict markers fail fast before noisy TypeScript/Next output:

- Adds `scripts/check-conflicts.mjs`.
- Adds `npm run check:conflicts`.
- Wires `check:conflicts` into `npm run ci`.
- Wires `check:conflicts` into `npm run preflight`.
- Wires `check:conflicts` into `npm run urai:tier3:audit`.
- Wires `check:conflicts` into GitHub Actions before typecheck/build.

## Files changed

- `tests/e2e/v1-smoke.spec.ts`
- `scripts/check-conflicts.mjs`
- `package.json`
- `.github/workflows/ci.yml`

## Verification to run in CI/local

```bash
npm run check:conflicts
npm run test:smoke
npm run check:home
npm run check:ascent
npm run typecheck
npm run build
```

## Lock status

Still not marking `/home` LOCKED. This adds browser smoke coverage and a build-blocker guard so the lock can be evidence-based once the suite passes in CI/local.