### PR TITLE
Add Tier freeze system ledger

### DIFF
--- a/docs/audits/URAI_TIER_FREEZE_SYSTEM_AUDIT.md
+++ b/docs/audits/URAI_TIER_FREEZE_SYSTEM_AUDIT.md
@@ -1,0 +1,135 @@
+# URAI Tier-1 / Tier-2 Freeze System Audit
+
+Date: 2026-05-19
+Repository: `LifeLoggerAI/UrAi`
+Branch: `audit/tier-freeze-system-ledger`
+Base branch: `main`
+Base SHA used for this audit branch: `01d72b5aac0f0ef480bad24f31e852252e540c37`
+
+## Executive summary
+
+This audit pass implements a repo-native Tier-1 / Tier-2 freeze ledger so URAI cannot be declared locked, frozen, or production-ready without explicit evidence. It adds a command that inventories the key launch systems, separates `Completed but not verified` from `Blocked`, writes a Markdown ledger to `tmp/tier-freeze-ledger.md`, and fails in strict mode while unresolved blockers remain.
+
+This is intentionally conservative. The current repo has extensive V1, P0/P1/P2, Tier-2 access, completion, deployment, and closeout documentation, but several docs still require live runtime evidence, staging/production deployment proof, visual proof, and closure of open launch gates before Tier-1 or Tier-2 can honestly be called frozen.
+
+## Baseline found
+
+- Main app repository: `LifeLoggerAI/UrAi`.
+- Default branch: `main`.
+- Package manager: npm.
+- App framework: Next.js 15, React 19, Firebase/Firestore, Firebase Functions.
+- Existing package scripts include `check:v1`, `check:tier2-access`, `validate:completion`, `preflight`, `launch:p0`, `release:p1`, `test:unit`, `test:rules`, `typecheck`, `lint`, `build`, `test:smoke`, and deploy scripts.
+- Existing V1 launch status says the V1 demo spine is implemented and repo-wired, but runtime/build/deploy validation is still pending.
+- Existing closeout runbook requires release candidate SHA, rollback SHA, local structural gates, strict P1 evidence, staging checks, production readiness checks, visual proof, and a final demo recording.
+- Existing launch gate register says production-readiness and deploy claims are blocked until fresh post-merge CI/deployment evidence is captured, and live-data/final-animation claims require separate gates.
+
+## What changed in this pass
+
+### Added
+
+- `scripts/tier-lock/tier-freeze-ledger.mjs`
+  - Generates `tmp/tier-freeze-ledger.md`.
+  - Inventories Tier-1 and Tier-2 freeze-critical items.
+  - Labels items as `Completed but not verified` or `Blocked` based on repo evidence.
+  - Identifies whether each item blocks Tier-1 freeze, Tier-2 freeze, or both.
+  - Provides required verification commands before freeze.
+  - Supports `--strict` mode, which exits non-zero when blockers remain.
+
+### Updated
+
+- `package.json`
+  - Adds `check:tier-freeze`.
+  - Adds `check:tier-freeze:strict`.
+
+### Added documentation
+
+- `docs/audits/URAI_TIER_FREEZE_SYSTEM_AUDIT.md`
+  - Captures this audit baseline, changed files, ledger behavior, blockers, and next commands.
+
+## Tier-1 completion ledger summary
+
+| Area | Current status | Evidence | Freeze impact |
+| --- | --- | --- | --- |
+| Public home route | Completed but not verified if route file exists | `src/app/page.tsx` | Needs smoke/visual proof before freeze |
+| Public constellation route | Completed but not verified if route file exists | `src/app/u/[handle]/page.tsx` or `src/app/u/adamclamp/page.tsx` | Needs smoke/visual proof before freeze |
+| Companion API | Completed but not verified if route exists | `src/app/api/companion/route.ts` | Needs valid/invalid prompt proof |
+| Waitlist API | Completed but not verified if route exists | `src/app/api/waitlist/route.ts` | Needs dry-run and Firestore persistence proof |
+| Firestore rules/indexes | Completed but not verified if files exist | `firestore.rules`, `firestore.indexes.json` | Needs rules test and staging deploy proof |
+| V1 launch gates | Completed but not verified if scripts exist | `package.json` scripts | Needs command evidence |
+| Release/deploy runbooks | Completed but not verified if docs exist | Launch/deploy/rollback docs | Needs filled release evidence |
+| Fresh post-merge CI/deploy evidence | Blocked | Launch gate register gate #33 | Blocks Tier-1 freeze |
+
+## Tier-2 completion ledger summary
+
+| Area | Current status | Evidence | Freeze impact |
+| --- | --- | --- | --- |
+| Tier-2 canon standards | Completed but not verified if files exist | `docs/canon/TIER_2_CANON_STANDARDS.md`, `src/canon/tier2.ts` | Needs command evidence |
+| Tier-2 access evaluator and API | Completed but not verified if files exist | `src/lib/tier-locks/evaluateTierLock.ts`, `src/app/api/tier-lock/tier2/route.ts` | Needs denied/allowed/API proof |
+| Tier-2 seed and audit tooling | Completed but not verified if scripts exist | `seed:tier2`, `seed:tier2:firestore`, `check:tier2-access` | Needs dry-run/staging evidence |
+| Tier-2 public route isolation | Completed but not verified if check exists | `scripts/tier-lock/tier2-access-check.mjs` | Needs check output evidence |
+| Live-data and final-animation production claims | Blocked | Launch gate register gates #31 and #32 | Blocks final Tier-2 freeze |
+| Fresh post-merge CI/deploy evidence | Blocked | Launch gate register gate #33 | Blocks Tier-2 freeze |
+
+## Required commands after pulling this branch
+
+Run the new ledger:
+
+```bash
+npm run check:tier-freeze
+```
+
+Run strict freeze gate. This is expected to fail until blockers are closed and evidence is attached:
+
+```bash
+npm run check:tier-freeze:strict
+```
+
+Run the release proof path:
+
+```bash
+npm install
+npm run check:lockfile
+npm run check:v1
+npm run check:tier2-access
+npm run launch:p0
+npm run release:p1
+npm run seed:demo
+npm run test:unit
+npm run test:rules
+npm run typecheck
+npm run lint
+npm run build
+npm run test:smoke
+```
+
+Run Functions verification:
+
+```bash
+cd functions
+npm install
+npm run build
+cd ..
+```
+
+## Blockers that cannot be honestly bypassed
+
+Tier-1 and Tier-2 cannot be called locked/frozen until these are resolved:
+
+1. Fresh post-merge CI/deployment evidence must be captured and attached.
+2. Staging route smoke evidence must be captured for the launch routes.
+3. Production deploy approval and deploy URL must be recorded.
+4. Rollback target SHA must be recorded.
+5. Firestore rules/indexes/functions deploy proof must be captured when applicable.
+6. Live Firebase client data claims must remain blocked until the live-data gate is closed.
+7. Final Rive/Lottie animation claims must remain blocked until wrapper, fallback, reduced-motion, and visual evidence are committed.
+8. Tier-2 public exposure must remain gated until Tier-1 is sealed and Tier-2 allowed/denied states pass tests.
+
+## Final decision
+
+Current decision after this implementation pass:
+
+- Tier-1 freeze: **BLOCKED PENDING VERIFICATION EVIDENCE**.
+- Tier-2 freeze: **BLOCKED PENDING VERIFICATION EVIDENCE AND OPEN GATE CLOSURE**.
+- Deployment: **not appropriate to claim as final production-ready from this session alone** because this environment cannot run local npm/build/browser/Firebase deploy validation and the repo itself requires external CI/deployment evidence before production-readiness claims.
+
+This branch improves the repo by making the freeze state explicit, repeatable, and failure-driven instead of subjective.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "check:firebase": "node scripts/check-firebase-target.mjs",
     "check:types": "tsc --noEmit",
     "check:tier2-access": "node scripts/tier-lock/tier2-access-check.mjs",
+    "check:tier-freeze": "node scripts/tier-lock/tier-freeze-ledger.mjs",
+    "check:tier-freeze:strict": "node scripts/tier-lock/tier-freeze-ledger.mjs --strict",
     "typecheck": "tsc --noEmit",
     "validate": "npm run validate:completion",
     "validate:completion": "node scripts/urai-completion-audit.mjs",

--- a/scripts/tier-lock/tier-freeze-ledger.mjs
+++ b/scripts/tier-lock/tier-freeze-ledger.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const strict = process.argv.includes('--strict');
+const outDir = path.join(root, 'tmp');
+const outPath = path.join(outDir, 'tier-freeze-ledger.md');
+
+function exists(file) {
+  return fs.existsSync(path.join(root, file));
+}
+
+function read(file) {
+  return exists(file) ? fs.readFileSync(path.join(root, file), 'utf8') : '';
+}
+
+function has(file, token) {
+  return read(file).includes(token);
+}
+
+function pkgScripts() {
+  try {
+    return JSON.parse(read('package.json')).scripts || {};
+  } catch {
+    return {};
+  }
+}
+
+const scripts = pkgScripts();
+
+const checks = [
+  {
+    tier: 'Tier-1',
+    item: 'Public home route',
+    status: exists('src/app/page.tsx') ? 'Completed but not verified' : 'Blocked',
+    evidence: 'src/app/page.tsx',
+    blocksTier1: !exists('src/app/page.tsx'),
+    blocksTier2: true,
+    next: exists('src/app/page.tsx') ? 'Run route smoke tests and capture desktop/mobile proof.' : 'Restore the public home route.',
+  },
+  {
+    tier: 'Tier-1',
+    item: 'Public constellation route',
+    status: exists('src/app/u/[handle]/page.tsx') || exists('src/app/u/adamclamp/page.tsx') ? 'Completed but not verified' : 'Blocked',
+    evidence: 'src/app/u/[handle]/page.tsx or src/app/u/adamclamp/page.tsx',
+    blocksTier1: !(exists('src/app/u/[handle]/page.tsx') || exists('src/app/u/adamclamp/page.tsx')),
+    blocksTier2: true,
+    next: 'Run Playwright smoke coverage for /u/adamclamp.',
+  },
+  {
+    tier: 'Tier-1',
+    item: 'Companion API route',
+    status: exists('src/app/api/companion/route.ts') ? 'Completed but not verified' : 'Blocked',
+    evidence: 'src/app/api/companion/route.ts',
+    blocksTier1: !exists('src/app/api/companion/route.ts'),
+    blocksTier2: true,
+    next: 'Verify valid prompt and empty prompt guard with smoke/API tests.',
+  },
+  {
+    tier: 'Tier-1',
+    item: 'Waitlist API route',
+    status: exists('src/app/api/waitlist/route.ts') ? 'Completed but not verified' : 'Blocked',
+    evidence: 'src/app/api/waitlist/route.ts',
+    blocksTier1: !exists('src/app/api/waitlist/route.ts'),
+    blocksTier2: true,
+    next: 'Verify dry-run and configured Firestore persistence paths.',
+  },
+  {
+    tier: 'Tier-1',
+    item: 'Firestore rules and indexes',
+    status: exists('firestore.rules') && exists('firestore.indexes.json') ? 'Completed but not verified' : 'Blocked',
+    evidence: 'firestore.rules, firestore.indexes.json',
+    blocksTier1: !(exists('firestore.rules') && exists('firestore.indexes.json')),
+    blocksTier2: true,
+    next: 'Run npm run test:rules and deploy rules/indexes to staging before public freeze.',
+  },
+  {
+    tier: 'Tier-1',
+    item: 'V1 launch gates',
+    status: scripts['check:v1'] && scripts['launch:p0'] && scripts['release:p1'] ? 'Completed but not verified' : 'Blocked',
+    evidence: 'package.json scripts check:v1, launch:p0, release:p1',
+    blocksTier1: !(scripts['check:v1'] && scripts['launch:p0'] && scripts['release:p1']),
+    blocksTier2: true,
+    next: 'Run npm run check:v1, npm run launch:p0, and npm run release:p1 with evidence.',
+  },
+  {
+    tier: 'Tier-1',
+    item: 'Release/deploy runbooks',
+    status: exists('docs/LAUNCH_CLOSEOUT_RUNBOOK.md') && exists('docs/deployment/PRODUCTION_DEPLOYMENT.md') && exists('docs/deployment/ROLLBACK.md') ? 'Completed but not verified' : 'Blocked',
+    evidence: 'docs/LAUNCH_CLOSEOUT_RUNBOOK.md, docs/deployment/PRODUCTION_DEPLOYMENT.md, docs/deployment/ROLLBACK.md',
+    blocksTier1: !(exists('docs/LAUNCH_CLOSEOUT_RUNBOOK.md') && exists('docs/deployment/PRODUCTION_DEPLOYMENT.md') && exists('docs/deployment/ROLLBACK.md')),
+    blocksTier2: true,
+    next: 'Capture release candidate SHA, rollback SHA, staging URL, production URL, and gate outputs.',
+  },
+  {
+    tier: 'Tier-2',
+    item: 'Tier-2 canon standards',
+    status: exists('docs/canon/TIER_2_CANON_STANDARDS.md') && exists('src/canon/tier2.ts') ? 'Completed but not verified' : 'Blocked',
+    evidence: 'docs/canon/TIER_2_CANON_STANDARDS.md, src/canon/tier2.ts',
+    blocksTier1: false,
+    blocksTier2: !(exists('docs/canon/TIER_2_CANON_STANDARDS.md') && exists('src/canon/tier2.ts')),
+    next: 'Confirm canon constants match access matrix and public-copy rules.',
+  },
+  {
+    tier: 'Tier-2',
+    item: 'Tier-2 access evaluator and API',
+    status: exists('src/lib/tier-locks/evaluateTierLock.ts') && exists('src/app/api/tier-lock/tier2/route.ts') ? 'Completed but not verified' : 'Blocked',
+    evidence: 'src/lib/tier-locks/evaluateTierLock.ts, src/app/api/tier-lock/tier2/route.ts',
+    blocksTier1: false,
+    blocksTier2: !(exists('src/lib/tier-locks/evaluateTierLock.ts') && exists('src/app/api/tier-lock/tier2/route.ts')),
+    next: 'Run unit tests for allowed/denied states and API invalid feature handling.',
+  },
+  {
+    tier: 'Tier-2',
+    item: 'Tier-2 seed and audit tooling',
+    status: scripts['seed:tier2'] && scripts['seed:tier2:firestore'] && scripts['check:tier2-access'] ? 'Completed but not verified' : 'Blocked',
+    evidence: 'package.json scripts seed:tier2, seed:tier2:firestore, check:tier2-access',
+    blocksTier1: false,
+    blocksTier2: !(scripts['seed:tier2'] && scripts['seed:tier2:firestore'] && scripts['check:tier2-access']),
+    next: 'Run npm run check:tier2-access and seed dry-run; only seed Firestore in staging with Admin env.',
+  },
+  {
+    tier: 'Tier-2',
+    item: 'Tier-2 public route isolation',
+    status: scripts['check:tier2-access'] ? 'Completed but not verified' : 'Blocked',
+    evidence: 'scripts/tier-lock/tier2-access-check.mjs',
+    blocksTier1: false,
+    blocksTier2: !scripts['check:tier2-access'],
+    next: 'Run npm run check:tier2-access and confirm public Tier-1 routes do not expose internal Tier-2 labels.',
+  },
+  {
+    tier: 'Tier-2',
+    item: 'Live-data and animation production claims',
+    status: 'Blocked',
+    evidence: 'docs/launch/LAUNCH_GATE_REGISTER.md gates #31 and #32',
+    blocksTier1: false,
+    blocksTier2: true,
+    next: 'Close live Firebase client data and Rive/Lottie wrapper gates with test and visual evidence before claiming final Tier-2 freeze.',
+  },
+  {
+    tier: 'Both',
+    item: 'Fresh post-merge CI/deployment evidence',
+    status: 'Blocked',
+    evidence: 'docs/launch/LAUNCH_GATE_REGISTER.md gate #33',
+    blocksTier1: true,
+    blocksTier2: true,
+    next: 'Attach current main CI, install, typecheck, lint, build, smoke, launch gate, deploy URL, and route smoke evidence.',
+  },
+];
+
+const blockers = checks.filter((check) => check.status === 'Blocked' || check.blocksTier1 || check.blocksTier2);
+const tier1Blocked = checks.some((check) => check.blocksTier1);
+const tier2Blocked = checks.some((check) => check.blocksTier2);
+
+fs.mkdirSync(outDir, { recursive: true });
+const now = new Date().toISOString();
+const lines = [];
+lines.push('# URAI Tier-1 / Tier-2 Freeze Ledger');
+lines.push('');
+lines.push(`Generated: ${now}`);
+lines.push('');
+lines.push('## Decision');
+lines.push('');
+lines.push(`- Tier-1 freeze: ${tier1Blocked ? 'BLOCKED' : 'READY FOR HUMAN SIGNOFF AFTER EVIDENCE REVIEW'}`);
+lines.push(`- Tier-2 freeze: ${tier2Blocked ? 'BLOCKED' : 'READY FOR HUMAN SIGNOFF AFTER EVIDENCE REVIEW'}`);
+lines.push(`- Strict mode: ${strict ? 'enabled' : 'disabled'}`);
+lines.push('');
+lines.push('A tier can only be called locked/frozen when every required item is Completed and verified, with no unresolved blockers, no partial required systems, no unverified critical paths, and no undocumented deployment assumptions.');
+lines.push('');
+lines.push('## Ledger');
+lines.push('');
+lines.push('| Tier | Item | Status | Evidence | Blocks Tier-1 | Blocks Tier-2 | Next action |');
+lines.push('| --- | --- | --- | --- | --- | --- | --- |');
+for (const check of checks) {
+  lines.push(`| ${check.tier} | ${check.item} | ${check.status} | ${check.evidence} | ${check.blocksTier1 ? 'Yes' : 'No'} | ${check.blocksTier2 ? 'Yes' : 'No'} | ${check.next} |`);
+}
+lines.push('');
+lines.push('## Required verification commands before freeze');
+lines.push('');
+lines.push('```bash');
+lines.push('npm install');
+lines.push('npm run check:lockfile');
+lines.push('npm run check:v1');
+lines.push('npm run check:tier2-access');
+lines.push('npm run launch:p0');
+lines.push('npm run release:p1');
+lines.push('npm run seed:demo');
+lines.push('npm run test:unit');
+lines.push('npm run test:rules');
+lines.push('npm run typecheck');
+lines.push('npm run lint');
+lines.push('npm run build');
+lines.push('npm run test:smoke');
+lines.push('```');
+lines.push('');
+lines.push('## Blockers');
+lines.push('');
+if (blockers.length === 0) {
+  lines.push('- None detected by static ledger. Human release evidence review still required.');
+} else {
+  for (const blocker of blockers) {
+    lines.push(`- ${blocker.tier}: ${blocker.item} — ${blocker.next}`);
+  }
+}
+lines.push('');
+
+fs.writeFileSync(outPath, `${lines.join('\n')}\n`);
+console.log(`URAI tier freeze ledger written to ${path.relative(root, outPath)}`);
+console.log(`Tier-1 freeze: ${tier1Blocked ? 'BLOCKED' : 'READY FOR HUMAN SIGNOFF AFTER EVIDENCE REVIEW'}`);
+console.log(`Tier-2 freeze: ${tier2Blocked ? 'BLOCKED' : 'READY FOR HUMAN SIGNOFF AFTER EVIDENCE REVIEW'}`);
+
+if (strict && (tier1Blocked || tier2Blocked)) {
+  console.error('Strict freeze ledger failed: unresolved blockers remain.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Adds a repo-native Tier-1 / Tier-2 freeze ledger and audit record.

## Changes

- Adds `scripts/tier-lock/tier-freeze-ledger.mjs`
- Adds `check:tier-freeze` and `check:tier-freeze:strict` scripts
- Adds `docs/audits/URAI_TIER_FREEZE_SYSTEM_AUDIT.md`

## Verification

Files were written through the connected GitHub API. Local repo execution was unavailable in this session.

Recommended verification:

```bash
npm install
npm run check:tier-freeze
npm run check:tier-freeze:strict
npm run check:v1
npm run check:tier2-access
npm run typecheck
npm run lint
npm run test:unit
npm run test:rules
npm run build
npm run test:smoke
```