### PR TITLE
Add Playwright smoke workflow

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -1,0 +1,59 @@
+name: Playwright Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to test"
+        required: false
+        default: "main"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/e2e/**"
+      - "playwright.config.ts"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/playwright-smoke.yml"
+
+jobs:
+  smoke:
+    name: Browser smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout requested ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium and OS dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        env:
+          PLAYWRIGHT_OUTPUT_DIR: test-results
+          NEXT_CACHE_DIR: .next/cache
+        run: npm run test:smoke
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-results
+          path: |
+            test-results
+            playwright-report
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
Adds a GitHub Actions workflow for running Playwright smoke tests on ubuntu-latest.

Changes:
- Adds `.github/workflows/playwright-smoke.yml`
- Installs dependencies with `npm ci`
- Installs Chromium with `npx playwright install --with-deps chromium`
- Runs `npm run test:smoke`
- Uploads Playwright artifacts

Use this workflow for browser smoke verification.