### PR TITLE
Fix HomeScene lint gate

### DIFF
--- a/src/components/HomeScene.tsx
+++ b/src/components/HomeScene.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import HomeWebGLSky from "@/components/HomeWebGLSky";
 import LifeMapScene from "@/components/lifemap/LifeMapScene";
 import { useEmotionalTone } from "@/components/lifemap/useEmotionalTone";
@@ -88,26 +88,26 @@ export default function HomeScene() {
     return () => mq.removeEventListener("change", syncMotion);
   }, []);
 
-  const settleHome = (replace = false) => {
+  const settleHome = useCallback((replace = false) => {
     historyGuard.current = replace;
     setState("home");
     if (replace && typeof window !== "undefined") window.history.replaceState({ uraiImmersive: "home" }, "", window.location.pathname);
-  };
+  }, []);
 
-  const pushState = (next: ImmersiveState) => {
+  const pushState = useCallback((next: ImmersiveState) => {
     if (typeof window !== "undefined") window.history.pushState({ uraiImmersive: next }, "", window.location.pathname);
     setState(next);
-  };
+  }, []);
 
-  const beginAscent = () => {
+  const beginAscent = useCallback(() => {
     if (state !== "home") return;
     const next = reduceMotion ? "lifeMap" : "ascendingToLifeMap";
     pushState(next);
     if (reduceMotion) return;
     window.setTimeout(() => setState("lifeMap"), emotionalTone === "restorative" ? 1850 : 1550);
-  };
+  }, [emotionalTone, pushState, reduceMotion, state]);
 
-  const beginUnwind = () => {
+  const beginUnwind = useCallback(() => {
     if (state !== "lifeMap") {
       settleHome();
       return;
@@ -118,7 +118,7 @@ export default function HomeScene() {
     }
     setState("unwindingToHome");
     window.setTimeout(() => settleHome(true), 1050);
-  };
+  }, [reduceMotion, settleHome, state]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -136,7 +136,7 @@ export default function HomeScene() {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [state, reduceMotion]);
+  }, [beginUnwind, settleHome, state]);
 
   useEffect(() => {
     const onPopState = () => {
@@ -148,7 +148,7 @@ export default function HomeScene() {
     };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
-  }, [state]);
+  }, [settleHome, state]);
 
   const submitOrbMessage = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION
Fixes the HomeScene react-hooks exhaustive-deps warning by stabilizing callbacks instead of suppressing lint.

Local evidence provided by Adam:
- HomeScene lint patch committed and pushed as a049da55.
- Playwright install remained blocked by local ENOSPC while downloading Chromium Headless Shell.
- Smoke did not pass because the production build was deleted before rerunning smoke and Playwright browser install was incomplete.
- Tier freeze remains blocked.
- P1 remains not ready due smoke failure and unverified staging/production/release evidence.

This PR should be reviewed as a lint-gate fix only, not launch readiness.