### PR TITLE
Add Playwright smoke validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   app:
     name: App validation
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
 
     steps:
       - name: Checkout
@@ -67,6 +67,12 @@ jobs:
 
       - name: Build app
         run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Smoke tests
+        run: npm run test:smoke
 
   functions:
     name: Firebase Functions validation


### PR DESCRIPTION
Adds Playwright browser dependency installation and smoke tests to the app CI job so smoke is verified on GitHub-hosted Ubuntu instead of relying on the constrained local shell.

Why:
- Local /tmp verification reached browser launch but failed because the host is missing Chromium shared libraries.
- Build and unit evidence passed locally; API-only smoke cases passed, but page smoke cases require a browser-capable host.
- CI already runs on ubuntu-latest, so `npx playwright install --with-deps chromium` is the right place to satisfy browser system dependencies.

Changes:
- Increase app job timeout from 25 to 35 minutes.
- Add `npx playwright install --with-deps chromium` after build.
- Add `npm run test:smoke` after Playwright installation.

No launch-readiness claim is made here. This PR only moves smoke verification into a host that can actually run Chromium.