### PR TITLE
Add focus session and replay evidence runtime contracts

### DIFF
--- a/src/lib/urai-canon/focus-replay-runtime.ts
+++ b/src/lib/urai-canon/focus-replay-runtime.ts
@@ -1,0 +1,142 @@
+import type { UraiPrivacyState, UraiRouteId } from "./system";
+
+export type UraiFocusSessionStatus = "idle" | "active" | "paused" | "completed" | "archived";
+export type UraiReplayEvidenceKind = "audio" | "transcript" | "location" | "device" | "calendar" | "relationship" | "derived_insight";
+export type UraiReplayEvidenceConfidence = "direct" | "inferred" | "low";
+export type UraiReplayRailVisibility = "visible" | "redacted" | "locked";
+
+export type UraiFocusSessionRuntimeContract = {
+  collection: "focusSessions";
+  route: Extract<UraiRouteId, "/focus/session/[sessionId]">;
+  ownerField: "ownerUid";
+  persistenceKey: "urai.focus.session.current";
+  sessionStateField: "status";
+  starLinkField: "starId";
+  replayLinkField: "activeReplayId";
+  privacyField: "privacyState";
+  lastOpenedField: "lastOpenedAt";
+  recoverOnRefresh: true;
+  mobileFallback: "static-focus-card";
+  reducedMotionFallback: "short-dissolve-to-focus-card";
+  loadingState: "focus-session-loading";
+  emptyState: "focus-session-empty";
+  errorState: "focus-session-error";
+};
+
+export type UraiReplayEvidenceRailContract = {
+  collection: "replayEvidence";
+  route: Extract<UraiRouteId, "/replay/[replayId]">;
+  ownerField: "ownerUid";
+  replayField: "replayId";
+  sourceRefField: "sourceRef";
+  kindField: "kind";
+  confidenceField: "confidence";
+  visibilityField: "visibility";
+  redactionField: "redactedReason";
+  displayOrderField: "displayOrder";
+  provenanceDrawerRequired: true;
+  exportDeleteLinked: true;
+  aiReadableOnlyWhenPermissioned: true;
+  mobileFallback: "horizontal-evidence-chips";
+  reducedMotionFallback: "static-provenance-rail";
+  loadingState: "replay-evidence-loading";
+  emptyState: "replay-evidence-empty";
+  errorState: "replay-evidence-error";
+};
+
+export type UraiReplayEvidenceItem = {
+  id: string;
+  ownerUid: string;
+  replayId: string;
+  sourceRef: string;
+  kind: UraiReplayEvidenceKind;
+  confidence: UraiReplayEvidenceConfidence;
+  visibility: UraiReplayRailVisibility;
+  displayOrder: number;
+  privacyState: UraiPrivacyState;
+  redactedReason?: string;
+};
+
+export const URAI_FOCUS_SESSION_RUNTIME: UraiFocusSessionRuntimeContract = {
+  collection: "focusSessions",
+  route: "/focus/session/[sessionId]",
+  ownerField: "ownerUid",
+  persistenceKey: "urai.focus.session.current",
+  sessionStateField: "status",
+  starLinkField: "starId",
+  replayLinkField: "activeReplayId",
+  privacyField: "privacyState",
+  lastOpenedField: "lastOpenedAt",
+  recoverOnRefresh: true,
+  mobileFallback: "static-focus-card",
+  reducedMotionFallback: "short-dissolve-to-focus-card",
+  loadingState: "focus-session-loading",
+  emptyState: "focus-session-empty",
+  errorState: "focus-session-error",
+};
+
+export const URAI_REPLAY_EVIDENCE_RAIL: UraiReplayEvidenceRailContract = {
+  collection: "replayEvidence",
+  route: "/replay/[replayId]",
+  ownerField: "ownerUid",
+  replayField: "replayId",
+  sourceRefField: "sourceRef",
+  kindField: "kind",
+  confidenceField: "confidence",
+  visibilityField: "visibility",
+  redactionField: "redactedReason",
+  displayOrderField: "displayOrder",
+  provenanceDrawerRequired: true,
+  exportDeleteLinked: true,
+  aiReadableOnlyWhenPermissioned: true,
+  mobileFallback: "horizontal-evidence-chips",
+  reducedMotionFallback: "static-provenance-rail",
+  loadingState: "replay-evidence-loading",
+  emptyState: "replay-evidence-empty",
+  errorState: "replay-evidence-error",
+};
+
+export const URAI_REPLAY_EVIDENCE_KIND_ORDER: readonly UraiReplayEvidenceKind[] = [
+  "audio",
+  "transcript",
+  "location",
+  "device",
+  "calendar",
+  "relationship",
+  "derived_insight",
+] as const;
+
+export function sortReplayEvidenceRail(items: readonly UraiReplayEvidenceItem[]): UraiReplayEvidenceItem[] {
+  return [...items].sort((a, b) => {
+    if (a.displayOrder !== b.displayOrder) return a.displayOrder - b.displayOrder;
+    return URAI_REPLAY_EVIDENCE_KIND_ORDER.indexOf(a.kind) - URAI_REPLAY_EVIDENCE_KIND_ORDER.indexOf(b.kind);
+  });
+}
+
+export function resolveReplayEvidenceVisibility(item: UraiReplayEvidenceItem): UraiReplayRailVisibility {
+  if (item.privacyState === "deleted" || item.privacyState === "vaulted") return "locked";
+  if (item.privacyState === "sensitive" || item.confidence === "low") return "redacted";
+  return item.visibility;
+}
+
+export function assertUraiFocusReplayRuntimeIntegrity(): string[] {
+  const failures: string[] = [];
+
+  if (URAI_FOCUS_SESSION_RUNTIME.collection !== "focusSessions") failures.push("Focus sessions must persist in focusSessions.");
+  if (URAI_FOCUS_SESSION_RUNTIME.ownerField !== "ownerUid") failures.push("Focus sessions must be owner-bound.");
+  if (!URAI_FOCUS_SESSION_RUNTIME.recoverOnRefresh) failures.push("Focus sessions must recover after refresh.");
+  if (!URAI_FOCUS_SESSION_RUNTIME.mobileFallback) failures.push("Focus session mobile fallback missing.");
+  if (!URAI_FOCUS_SESSION_RUNTIME.reducedMotionFallback) failures.push("Focus session reduced-motion fallback missing.");
+
+  if (URAI_REPLAY_EVIDENCE_RAIL.collection !== "replayEvidence") failures.push("Replay evidence rail must persist in replayEvidence.");
+  if (URAI_REPLAY_EVIDENCE_RAIL.ownerField !== "ownerUid") failures.push("Replay evidence must be owner-bound.");
+  if (!URAI_REPLAY_EVIDENCE_RAIL.provenanceDrawerRequired) failures.push("Replay evidence rail must require provenance drawer.");
+  if (!URAI_REPLAY_EVIDENCE_RAIL.exportDeleteLinked) failures.push("Replay evidence must link to export/delete cleanup.");
+  if (!URAI_REPLAY_EVIDENCE_RAIL.aiReadableOnlyWhenPermissioned) failures.push("Replay evidence AI access must remain permissioned.");
+
+  for (const kind of ["audio", "transcript", "location", "device", "calendar", "relationship", "derived_insight"] as const) {
+    if (!URAI_REPLAY_EVIDENCE_KIND_ORDER.includes(kind)) failures.push(`Missing evidence kind: ${kind}`);
+  }
+
+  return failures;
+}

--- a/tests/unit/urai-canon/focus-replay-runtime.test.ts
+++ b/tests/unit/urai-canon/focus-replay-runtime.test.ts
@@ -1,0 +1,63 @@
+import {
+  URAI_FOCUS_SESSION_RUNTIME,
+  URAI_REPLAY_EVIDENCE_RAIL,
+  assertUraiFocusReplayRuntimeIntegrity,
+  resolveReplayEvidenceVisibility,
+  sortReplayEvidenceRail,
+  type UraiReplayEvidenceItem,
+} from "@/lib/urai-canon/focus-replay-runtime";
+
+describe("URAI focus and replay evidence runtime", () => {
+  it("locks persistent focus session and replay evidence rail contracts", () => {
+    expect(URAI_FOCUS_SESSION_RUNTIME).toMatchObject({
+      collection: "focusSessions",
+      route: "/focus/session/[sessionId]",
+      ownerField: "ownerUid",
+      recoverOnRefresh: true,
+      mobileFallback: "static-focus-card",
+      reducedMotionFallback: "short-dissolve-to-focus-card",
+    });
+    expect(URAI_REPLAY_EVIDENCE_RAIL).toMatchObject({
+      collection: "replayEvidence",
+      route: "/replay/[replayId]",
+      ownerField: "ownerUid",
+      provenanceDrawerRequired: true,
+      exportDeleteLinked: true,
+      aiReadableOnlyWhenPermissioned: true,
+    });
+    expect(assertUraiFocusReplayRuntimeIntegrity()).toEqual([]);
+  });
+
+  it("sorts replay evidence deterministically for rail rendering", () => {
+    const items: UraiReplayEvidenceItem[] = [
+      evidence("derived", "derived_insight", 4),
+      evidence("audio", "audio", 1),
+      evidence("transcript", "transcript", 1),
+      evidence("location", "location", 2),
+    ];
+
+    expect(sortReplayEvidenceRail(items).map((item) => item.id)).toEqual(["audio", "transcript", "location", "derived"]);
+  });
+
+  it("protects sensitive, vaulted, and deleted evidence visibility", () => {
+    expect(resolveReplayEvidenceVisibility(evidence("safe", "audio", 1))).toBe("visible");
+    expect(resolveReplayEvidenceVisibility({ ...evidence("sensitive", "transcript", 1), privacyState: "sensitive" })).toBe("redacted");
+    expect(resolveReplayEvidenceVisibility({ ...evidence("low", "device", 1), confidence: "low" })).toBe("redacted");
+    expect(resolveReplayEvidenceVisibility({ ...evidence("vaulted", "audio", 1), privacyState: "vaulted" })).toBe("locked");
+    expect(resolveReplayEvidenceVisibility({ ...evidence("deleted", "audio", 1), privacyState: "deleted" })).toBe("locked");
+  });
+});
+
+function evidence(id: string, kind: UraiReplayEvidenceItem["kind"], displayOrder: number): UraiReplayEvidenceItem {
+  return {
+    id,
+    ownerUid: "owner-1",
+    replayId: "replay-1",
+    sourceRef: `source:${id}`,
+    kind,
+    confidence: "direct",
+    visibility: "visible",
+    displayOrder,
+    privacyState: "private",
+  };
+}


### PR DESCRIPTION
Adds the next implementation contract layer for the highest-value cinematic/runtime gap: persistent focus state and source-backed replay evidence.

Why:
- The current spatial runtime ledger explicitly lists persistent replay evidence rail, provenance drawer, and artifact/export/delete cleanup as remaining evidence-system gaps.
- This PR does not jump straight into shader/R3F complexity before contracts exist. It locks the data/state contract first so visual work can bind to one canon instead of creating parallel systems.

Changes:
- Adds `src/lib/urai-canon/focus-replay-runtime.ts` with:
  - persistent focus session runtime contract
  - replay evidence rail contract
  - deterministic evidence rail sorting
  - privacy-aware evidence visibility resolution
  - integrity assertions for owner binding, provenance, export/delete linkage, mobile fallback, and reduced-motion fallback
- Adds unit tests covering the contracts, deterministic ordering, and redacted/locked visibility behavior.

Safety/performance notes:
- Contract-only runtime layer, no heavy bundle impact.
- Explicit mobile fallback and reduced-motion fallback fields are required.
- Replay evidence remains permissioned and privacy-aware.

No launch-readiness, P0/P1 readiness, or Tier completion claim is made here.