### PR TITLE
Document cinematic runtime depth plan

### DIFF
--- a/docs/CINEMATIC_RUNTIME_DEPTH.md
+++ b/docs/CINEMATIC_RUNTIME_DEPTH.md
@@ -1,0 +1,18 @@
+# Cinematic Runtime Depth
+
+This document records the next implementation layer for URAI transitions.
+
+## Runtime requirements
+
+- Camera transitions must use deterministic interpolation.
+- Mobile devices must use a lower particle and constellation budget.
+- Reduced motion must use a static/short dissolve path.
+- Loading, empty, and error states must exist before visual promotion.
+
+## Next implementation targets
+
+- Home to life map camera controller.
+- Life map to focus transition state.
+- Focus to replay evidence rail binding.
+- Reflective floor fallback.
+- Constellation level-of-detail budget.


### PR DESCRIPTION
Adds the next cinematic runtime depth planning doc after the focus/replay contracts and Firestore protections landed.

Why:
- Gate fixes are still being monitored in CI, but the next implementation layer needs a clear repo-local plan that avoids parallel canon.
- This documents the required constraints for camera interpolation, mobile budgets, reduced-motion paths, loading/empty/error states, and evidence rail binding before heavier visual work.

Changes:
- Adds `docs/CINEMATIC_RUNTIME_DEPTH.md` with runtime requirements and implementation targets.

No launch-readiness, P0/P1 readiness, or Tier completion claim is made here.