### PR TITLE
Fix home page resolved scene import

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,4 +1,4 @@
-import { UraiResolvedHomeScene } from "@/components/urai/UraiResolvedHomeScene";
+import UraiResolvedHomeScene from "@/components/urai/UraiResolvedHomeScene";
 
 export const metadata = {
   title: "URAI Inner Sky Shrine",


### PR DESCRIPTION
Fixes the current main typecheck blocker introduced around the resolved home scene export style.

Why:
- CI on the Tier 2 Firestore policy PR reached `npm run typecheck` after rules passed.
- Typecheck failed because `src/app/home/page.tsx` imported `UraiResolvedHomeScene` as a named export, while `src/components/urai/UraiResolvedHomeScene.tsx` exports the scene as default.

Change:
- Switch `/home` page to default-import `UraiResolvedHomeScene`.

Expected gate impact:
- Keeps Tier 1/Tier 2 rules fixes merged.
- Unblocks `npm run typecheck` so CI can continue to lint/build/smoke verification.

No launch-ready or tier-lock claim is made until CI completes.