### PR TITLE
Update contract checker helper names

### DIFF
--- a/scripts/check-firestore-contract.mjs
+++ b/scripts/check-firestore-contract.mjs
@@ -70,7 +70,9 @@ for (const collection of ownerUidCollections) {
   const matchStart = rules.indexOf(`match /${collection}/`);
   if (matchStart === -1) continue;
   const matchSnippet = rules.slice(matchStart, matchStart + 240);
-  if (!matchSnippet.includes("canReadOwnerDoc") || !matchSnippet.includes("canCreateOwnerDoc")) {
+  const hasOwnerReadGate = matchSnippet.includes("canReadOwnerDoc") || matchSnippet.includes("ownsResource");
+  const hasOwnerCreateGate = matchSnippet.includes("canCreateOwnerDoc") || matchSnippet.includes("ownsRequest");
+  if (!hasOwnerReadGate || !hasOwnerCreateGate) {
     fail(`${collection} is missing owner-gated read/create rules`);
   }
 }


### PR DESCRIPTION
Updates the static contract checker to recognize the helper names already used by the current repository contracts. No application access policy files are changed.