### PR TITLE
Add Tier 1 branded route signals

### DIFF
--- a/src/app/demo/life-map/page.tsx
+++ b/src/app/demo/life-map/page.tsx
@@ -1,5 +1,9 @@
 import LifeMapUniverse from "@/components/life-map/LifeMapUniverse";
 
+export const metadata = {
+  title: "URAI Life Map Demo",
+};
+
 export default function DemoLifeMapPage() {
   return <LifeMapUniverse />;
 }

--- a/src/app/focus/page.tsx
+++ b/src/app/focus/page.tsx
@@ -1,5 +1,9 @@
 import LifeMapUniverse from "@/components/life-map/LifeMapUniverse";
 
+export const metadata = {
+  title: "URAI Focus Chamber",
+};
+
 export default function FocusPage() {
   return <LifeMapUniverse initialView="focus" />;
 }

--- a/src/app/mirror/page.tsx
+++ b/src/app/mirror/page.tsx
@@ -1,5 +1,9 @@
 import LifeMapUniverse from "@/components/life-map/LifeMapUniverse";
 
+export const metadata = {
+  title: "URAI Cognitive Mirror",
+};
+
 export default function MirrorPage() {
   return <LifeMapUniverse initialOverlay="mirror" />;
 }

--- a/src/app/replay/page.tsx
+++ b/src/app/replay/page.tsx
@@ -1,5 +1,9 @@
 import LifeMapUniverse from "@/components/life-map/LifeMapUniverse";
 
+export const metadata = {
+  title: "URAI Replay",
+};
+
 export default function ReplayPage() {
   return <LifeMapUniverse initialView="replay" />;
 }


### PR DESCRIPTION
Fixes the current URAI Launch Gate Tier 1 blocker.

Why:
- Launch Gate preflight now passes.
- Tier 1 lock failed only on branded fallback signal detection for four thin route wrappers:
  - `src/app/demo/life-map/page.tsx`
  - `src/app/replay/page.tsx`
  - `src/app/mirror/page.tsx`
  - `src/app/focus/page.tsx`
- These routes all delegate to `LifeMapUniverse`, but the Tier 1 scanner checks the route files themselves for a URAI branded signal or shared fallback/shell boundary.

Change:
- Adds route metadata with URAI-branded titles to the four thin route files.

This does not loosen any gate, remove any test, or claim Tier 1/Tier 2 locked before CI evidence completes.