### PR TITLE
Provide CI OpenAI placeholder for launch gate

### DIFF
--- a/.github/workflows/urai-launch-gate.yml
+++ b/.github/workflows/urai-launch-gate.yml
@@ -24,6 +24,7 @@ jobs:
       NEXT_PUBLIC_FIREBASE_APP_ID: "1:000000000000:web:ci-placeholder"
       NEXT_PUBLIC_URAI_NARRATOR_FALLBACK: speech
       URAI_ENABLE_CHRONO_FIRESTORE: "0"
+      OPENAI_API_KEY: ci-placeholder-openai-key
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Fixes the current URAI Launch Gate env-readiness blocker.

Why:
- The current Launch Gate now passes preflight and Tier 1 lock.
- It fails during Tier 4 deploy check because `env-readiness-audit` sees `OPENAI_API_KEY` referenced and not present in the workflow environment.

Change:
- Adds a CI-only placeholder `OPENAI_API_KEY` to the Launch Gate workflow, matching the existing placeholder Firebase public env pattern.

Security notes:
- This is not a real secret.
- It is only used for env presence/audit checks in CI.
- Production still needs a real deployment secret before strict deploy approval.

Expected gate impact:
- Allows the Launch Gate to continue from Tier 4 deploy check to tier report and smoke.

No launch-ready claim is made until the full Launch Gate and smoke complete.