### PR TITLE
PR 1: Expand Firestore rules contract coverage

### DIFF
--- a/tests/rules/firestore.rules.test.js
+++ b/tests/rules/firestore.rules.test.js
@@ -9,6 +9,7 @@ const {
 const TEST_PROJECT = 'urai-security-rules-test';
 const OWNER_UID = 'owner-123';
 const OTHER_UID = 'other-456';
+const ADMIN_UID = 'admin-789';
 const SAMPLE_COLLECTIONS = [
   { name: 'rituals', sample: { name: 'Morning pages' } },
   { name: 'timelineEvents', sample: { type: 'milestone' } },
@@ -94,6 +95,100 @@ describe('Firestore security rules', () => {
         ownerDb.collection(name).doc(docId).update({ ownerUid: OTHER_UID }),
       );
       expect(error).toBeInstanceOf(PermissionDeniedError);
+    });
+  });
+
+  describe('admin-only collections', () => {
+    test('allows admins to read and write feature flags', async () => {
+      const adminDb = testEnv.authenticatedContext(ADMIN_UID, { admin: true }).firestore();
+      await expect(assertSucceeds(adminDb.collection('featureFlags').doc('cinematic').set({ enabled: false }))).resolves.toBeNull();
+      const snapshot = await assertSucceeds(adminDb.collection('featureFlags').doc('cinematic').get());
+      expect(snapshot.exists).toBe(true);
+    });
+
+    test('rejects non-admin access to feature flags', async () => {
+      await seedDocument(testEnv, 'featureFlags', 'cinematic', { enabled: false });
+      const ownerDb = testEnv.authenticatedContext(OWNER_UID).firestore();
+      await expect(assertFails(ownerDb.collection('featureFlags').doc('cinematic').get())).resolves.toBeInstanceOf(PermissionDeniedError);
+      await expect(assertFails(ownerDb.collection('featureFlags').doc('cinematic').set({ enabled: true }))).resolves.toBeInstanceOf(PermissionDeniedError);
+    });
+
+    test('keeps admin audit logs immutable after creation', async () => {
+      const adminDb = testEnv.authenticatedContext(ADMIN_UID, { admin: true }).firestore();
+      await expect(assertSucceeds(adminDb.collection('adminAuditLogs').doc('event-1').set({ action: 'seed' }))).resolves.toBeNull();
+      await expect(assertFails(adminDb.collection('adminAuditLogs').doc('event-1').update({ action: 'tamper' }))).resolves.toBeInstanceOf(PermissionDeniedError);
+    });
+  });
+
+  describe('server-only and denied collections', () => {
+    test.each(['features', 'entitlements', 'auditLogs', 'transactions', 'eventEnrichments'])('denies client access to %s', async (collection) => {
+      await seedDocument(testEnv, collection, 'doc-1', { ownerUid: OWNER_UID, value: true });
+      const ownerDb = testEnv.authenticatedContext(OWNER_UID).firestore();
+      const adminDb = testEnv.authenticatedContext(ADMIN_UID, { admin: true }).firestore();
+      await expect(assertFails(ownerDb.collection(collection).doc('doc-1').get())).resolves.toBeInstanceOf(PermissionDeniedError);
+      await expect(assertFails(adminDb.collection(collection).doc('doc-1').set({ ownerUid: ADMIN_UID }))).resolves.toBeInstanceOf(PermissionDeniedError);
+    });
+  });
+
+  describe('public and demo-readable collections', () => {
+    test('allows public reads of system status only', async () => {
+      await seedDocument(testEnv, 'systemStatus', 'public', { status: 'ok' });
+      const anonDb = testEnv.unauthenticatedContext().firestore();
+      const snapshot = await assertSucceeds(anonDb.collection('systemStatus').doc('public').get());
+      expect(snapshot.exists).toBe(true);
+      await expect(assertFails(anonDb.collection('systemStatus').doc('public').set({ status: 'bad' }))).resolves.toBeInstanceOf(PermissionDeniedError);
+    });
+
+    test('allows published marketplace item reads and rejects draft reads', async () => {
+      await seedDocument(testEnv, 'marketplaceItems', 'published', { status: 'published', title: 'Public ritual' });
+      await seedDocument(testEnv, 'marketplaceItems', 'draft', { status: 'draft', title: 'Private ritual' });
+      const anonDb = testEnv.unauthenticatedContext().firestore();
+      await expect(assertSucceeds(anonDb.collection('marketplaceItems').doc('published').get())).resolves.toMatchObject({ exists: true });
+      await expect(assertFails(anonDb.collection('marketplaceItems').doc('draft').get())).resolves.toBeInstanceOf(PermissionDeniedError);
+    });
+
+    test('allows public waitlist submissions but not reads or edits', async () => {
+      const anonDb = testEnv.unauthenticatedContext().firestore();
+      await expect(assertSucceeds(anonDb.collection('waitlistEntries').doc('entry-1').set({ createdAt: 'now', email: 'demo@example.com' }))).resolves.toBeNull();
+      await expect(assertFails(anonDb.collection('waitlistEntries').doc('entry-1').get())).resolves.toBeInstanceOf(PermissionDeniedError);
+      await expect(assertFails(anonDb.collection('waitlistEntries').doc('entry-1').update({ email: 'changed@example.com' }))).resolves.toBeInstanceOf(PermissionDeniedError);
+    });
+  });
+
+  describe('export, deletion, telemetry, safety, narrator, and replay protections', () => {
+    test('allows owner-created export and deletion requests but blocks mutation after submission', async () => {
+      const ownerDb = testEnv.authenticatedContext(OWNER_UID).firestore();
+      await expect(assertSucceeds(ownerDb.collection('dataExportRequests').doc('export-1').set({ ownerUid: OWNER_UID, createdAt: 'now' }))).resolves.toBeNull();
+      await expect(assertSucceeds(ownerDb.collection('accountDeletionRequests').doc('delete-1').set({ ownerUid: OWNER_UID, createdAt: 'now' }))).resolves.toBeNull();
+      await expect(assertFails(ownerDb.collection('dataExportRequests').doc('export-1').update({ status: 'changed' }))).resolves.toBeInstanceOf(PermissionDeniedError);
+      await expect(assertFails(ownerDb.collection('accountDeletionRequests').doc('delete-1').update({ status: 'changed' }))).resolves.toBeInstanceOf(PermissionDeniedError);
+    });
+
+    test('allows telemetry writes but blocks client reads and edits', async () => {
+      const ownerDb = testEnv.authenticatedContext(OWNER_UID).firestore();
+      await expect(assertSucceeds(ownerDb.collection('telemetryEvents').doc('event-1').set({ ownerUid: OWNER_UID, type: 'route_view' }))).resolves.toBeNull();
+      await expect(assertFails(ownerDb.collection('telemetryEvents').doc('event-1').get())).resolves.toBeInstanceOf(PermissionDeniedError);
+      await expect(assertFails(ownerDb.collection('telemetryEvents').doc('event-1').update({ type: 'tamper' }))).resolves.toBeInstanceOf(PermissionDeniedError);
+    });
+
+    test('protects narrator, replay, constellation, and passive signal docs by ownership', async () => {
+      for (const collection of ['narratorMessages', 'scrolls', 'constellations', 'passiveSignals']) {
+        await seedDocument(testEnv, collection, 'doc-1', { ownerUid: OWNER_UID, title: collection });
+        const ownerDb = testEnv.authenticatedContext(OWNER_UID).firestore();
+        const otherDb = testEnv.authenticatedContext(OTHER_UID).firestore();
+        await expect(assertSucceeds(ownerDb.collection(collection).doc('doc-1').get())).resolves.toMatchObject({ exists: true });
+        await expect(assertFails(otherDb.collection(collection).doc('doc-1').get())).resolves.toBeInstanceOf(PermissionDeniedError);
+      }
+    });
+
+    test('allows safety event owner creation and admin triage update only', async () => {
+      const ownerDb = testEnv.authenticatedContext(OWNER_UID).firestore();
+      const adminDb = testEnv.authenticatedContext(ADMIN_UID, { admin: true }).firestore();
+      const otherDb = testEnv.authenticatedContext(OTHER_UID).firestore();
+      await expect(assertSucceeds(ownerDb.collection('safetyEvents').doc('safety-1').set({ ownerUid: OWNER_UID, severity: 'low' }))).resolves.toBeNull();
+      await expect(assertFails(otherDb.collection('safetyEvents').doc('safety-1').get())).resolves.toBeInstanceOf(PermissionDeniedError);
+      await expect(assertSucceeds(adminDb.collection('safetyEvents').doc('safety-1').update({ triageStatus: 'reviewed', ownerUid: OWNER_UID }))).resolves.toBeNull();
+      await expect(assertFails(otherDb.collection('safetyEvents').doc('safety-1').update({ triageStatus: 'tamper', ownerUid: OTHER_UID }))).resolves.toBeInstanceOf(PermissionDeniedError);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds focused Tier-1/Tier-2 Firestore rules contract coverage without changing the canonical rules model.

## Coverage added

- Admin-only boundaries for feature flags and immutable admin audit logs.
- Server-only/denied collections: features, entitlements, audit logs, transactions, event enrichments.
- Public/demo-readable behavior for system status and published marketplace items.
- Public waitlist submission behavior.
- Export/deletion request immutability after owner submission.
- Telemetry write-only behavior.
- Safety event owner creation and admin triage update behavior.
- Narrator, replay, constellation, and passive signal ownership protections.

## Security model summary

- User-owned collections require `ownerUid`, `userId`, or `uid` ownership on resource/request data.
- Admin-only collections require `request.auth.token.admin == true`.
- Public/demo-readable collections expose only explicitly published/demo-readable resources or public system status.
- Server-only collections deny all client reads/writes.
- Export/deletion requests are owner-created and immutable from clients after submission.
- Telemetry is client-write-only and unreadable/uneditable by clients.
- Safety events are owner-created/readable by owner/admin; admin can triage.
- Narrator/replay/constellation/passive signal docs are owner-scoped.
- Default catch-all denies all unmodeled paths.

## Verification

Not run in this connector session. Next command:

```bash
npm run test:rules
```

Then continue the required gate order from the Tier Lock prompt.