### PR TITLE
Redirect legacy home route to canonical root

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,6 +24,15 @@ const nextConfig = {
   reactStrictMode: true,
   images: { domains: [] },
   allowedDevOrigins: [...new Set([...cloudWorkstationDevOrigins, ...localDevOrigins, ...envDevOrigins])],
+  async redirects() {
+    return [
+      {
+        source: "/home",
+        destination: "/",
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Fixes the remaining full E2E production-smoke blocker in UrAi CI/CD.

Why:
- Post-#275 Launch Gate and standalone Playwright Smoke are passing.
- The broader `npm run test:e2e` workflow still failed 4 production-smoke assertions because `/home` stayed at `/home` instead of redirecting to canonical root `/`.
- The production smoke contract expects root and `/home` to resolve to the same canonical sanctuary shell and final URL `/`.

Change:
- Adds a Next.js redirect from `/home` to `/` in `next.config.mjs`.

Security/performance impact:
- No Firestore or auth rules changed.
- No tests loosened.
- No bundle/runtime visual expansion added.
- This preserves the canonical root home while keeping `/home` as a legacy entrypoint.

Expected gate impact:
- Full E2E production-smoke should pass the four URL assertions currently failing in UrAi CI/CD.

No launch-ready claim is made until CI/CD reruns clean or reports a real external credential/deploy blocker.