### PR TITLE
PR 2: Align home smoke tests with current controls

### DIFF
--- a/tests/e2e/v1-smoke.spec.ts
+++ b/tests/e2e/v1-smoke.spec.ts
@@ -13,8 +13,8 @@ async function expectBodyTextAttached(page: import("@playwright/test").Page, tex
   await expect(page.locator("body").getByText(text).first()).toHaveCount(1);
 }
 
-async function clickButtonByLabel(page: import("@playwright/test").Page, label: string) {
-  await page.locator(`button[aria-label="${label}"]`).first().evaluate((node) => {
+async function clickButtonByLabel(page: import("@playwright/test").Page, label: string | RegExp) {
+  await page.getByRole("button", { name: label }).first().evaluate((node) => {
     (node as HTMLButtonElement).click();
   });
 }
@@ -32,27 +32,26 @@ test.describe("URAI V1 smoke", () => {
   test("final /home field exposes sky, orb, ground, companion, and return-home surfaces @smoke", async ({ page }) => {
     await page.goto("/home", { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByRole("button", { name: "Open symbolic life map" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Charge orb" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Wake companion" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Tune body field" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open recovery bloom terrain" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Ascend through the sky into the URAI Life Map" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open URAI companion chat from the orb" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Enter the ground and foundation layer" })).toBeVisible();
 
-    await clickButtonByLabel(page, "Wake companion");
-    await expect(page.locator("aside").filter({ hasText: /quiet|listening|reflecting|forecasting|ritual|protective/i })).toBeVisible();
+    await clickButtonByLabel(page, "Open URAI companion chat from the orb");
+    await expect(page.getByRole("heading", { name: "URAI is listening." })).toBeVisible();
+    await expect(page.getByLabel("Message URAI companion")).toBeVisible();
+    await clickButtonByLabel(page, "Close companion chat");
 
-    await clickButtonByLabel(page, "Open life map");
-    await expect(page.getByRole("button", { name: "Return home" })).toBeVisible();
+    await clickButtonByLabel(page, "Ascend through the sky into the URAI Life Map");
+    await expect(page.getByRole("button", { name: "Reverse ascent and return home" })).toBeVisible();
   });
 
   test("final /home reduced-motion path keeps core controls available @smoke", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/home", { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByRole("button", { name: "Open symbolic life map" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Charge orb" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Wake companion" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open recovery bloom terrain" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Ascend through the sky into the URAI Life Map" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open URAI companion chat from the orb" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Enter the ground and foundation layer" })).toBeVisible();
   });
 
   test("public constellation route renders demo content @smoke", async ({ page }) => {


### PR DESCRIPTION
## Summary

Aligns the `/home` Playwright smoke test with the current HomeScene accessible control labels.

## Why

The implementation exposes current labels such as:

- `Ascend through the sky into the URAI Life Map`
- `Open URAI companion chat from the orb`
- `Enter the ground and foundation layer`
- `Reverse ascent and return home`

The smoke test still expected older labels like `Open symbolic life map`, `Charge orb`, and `Wake companion`, which made the smoke gate fragile against the current implementation.

## Coverage preserved

- Sky to Life Map path.
- Orb companion path.
- Ground/foundation control presence.
- Reduced-motion control availability.
- Public constellation route.
- Waitlist API dry-run.
- Waitlist invalid-email disabled state.
- Companion API response.

## Verification

Not run in this connector session. Required next command:

```bash
npm run test:smoke
```

Run after `npx playwright install chromium` per Tier Lock command order.