### PR TITLE
Allow completion audit to accept Firestore match variables

### DIFF
--- a/scripts/urai-completion-audit.mjs
+++ b/scripts/urai-completion-audit.mjs
@@ -161,6 +161,10 @@ function exists(file) {
   return fs.existsSync(path.join(root, file));
 }
 
+function hasCollectionMatch(rules, collection) {
+  return new RegExp(`match\\s+\\/${collection}\\/\\{[A-Za-z0-9_]+\\}`).test(rules);
+}
+
 const problems = [];
 
 for (const file of requiredFiles) {
@@ -184,7 +188,7 @@ for (const token of requiredContractTokens) {
 
 const firestoreRules = read("firestore.rules");
 for (const collection of requiredRulesCollections) {
-  if (!firestoreRules.includes(`match /${collection}/{id}`)) {
+  if (!hasCollectionMatch(firestoreRules, collection)) {
     problems.push(`Firestore rules missing canonical collection: ${collection}`);
   }
 }


### PR DESCRIPTION
Fixes the current Launch Gate preflight blocker after PR #282.

Root cause:
- `firestore.rules` correctly uses Firestore match variables such as `match /profiles/{uid}`.
- `scripts/urai-completion-audit.mjs` was hard-coded to only accept exact `match /<collection>/{id}` text.
- Launch Gate preflight failed with `Firestore rules missing canonical collection: profiles` even though `profiles` exists with `{uid}`.

Change:
- Adds `hasCollectionMatch()` to verify a canonical collection with any valid Firestore match variable name.
- Keeps every canonical collection required.
- Keeps deny-by-default verification unchanged.

Security impact:
- No Firestore rule access is loosened.
- No tests are removed.
- No evidence variables are set.
- This only fixes the audit script to understand standard Firestore match variables.

Expected verification:
- `npm run validate:completion` should pass the previous `profiles` false negative.
- Then CI should continue through rules, typecheck, lint, unit, build, smoke, tier freeze, and P1 gate.