### PR TITLE
Add canonical URAI system contracts

### DIFF
--- a/src/lib/urai/contracts/routeContracts.ts
+++ b/src/lib/urai/contracts/routeContracts.ts
@@ -1,0 +1,152 @@
+export type UraiRouteId = 'home' | 'life-map' | 'life-map-star' | 'focus' | 'focus-session' | 'replay' | 'replay-detail' | 'ochat';
+
+export type UraiRouteMode =
+  | 'home'
+  | 'home-entering'
+  | 'life-map-entering'
+  | 'life-map'
+  | 'life-map-focus'
+  | 'focus-entering'
+  | 'focus'
+  | 'replay-entering'
+  | 'replay'
+  | 'ochat-entering'
+  | 'ochat'
+  | 'returning-home';
+
+export type UraiRouteRecoveryState = 'ok' | 'loading' | 'empty' | 'invalid-id' | 'locked' | 'deleted' | 'archived' | 'error';
+
+export interface UraiDirectRouteContract {
+  route: UraiRouteId;
+  pathPattern: string;
+  directLoad: boolean;
+  refreshSafe: boolean;
+  loadingState: boolean;
+  errorState: boolean;
+  emptyState: boolean;
+  returnHome: boolean;
+  invalidIdBehavior: string;
+  lockedBehavior: string;
+  deletedBehavior: string;
+  archivedBehavior: string;
+}
+
+export const URAI_DIRECT_ROUTE_CONTRACTS: UraiDirectRouteContract[] = [
+  {
+    route: 'home',
+    pathPattern: '/home',
+    directLoad: true,
+    refreshSafe: true,
+    loadingState: true,
+    errorState: true,
+    emptyState: true,
+    returnHome: false,
+    invalidIdBehavior: 'not applicable',
+    lockedBehavior: 'not applicable',
+    deletedBehavior: 'not applicable',
+    archivedBehavior: 'not applicable',
+  },
+  {
+    route: 'life-map',
+    pathPattern: '/life-map',
+    directLoad: true,
+    refreshSafe: true,
+    loadingState: true,
+    errorState: true,
+    emptyState: true,
+    returnHome: true,
+    invalidIdBehavior: 'show life-map shell with visible notice',
+    lockedBehavior: 'show locked shell instead of 404',
+    deletedBehavior: 'show removed or unavailable notice',
+    archivedBehavior: 'open only with permission',
+  },
+  {
+    route: 'life-map-star',
+    pathPattern: '/life-map/star/:starId',
+    directLoad: true,
+    refreshSafe: true,
+    loadingState: true,
+    errorState: true,
+    emptyState: true,
+    returnHome: true,
+    invalidIdBehavior: 'show parent life-map with invalid-star notice',
+    lockedBehavior: 'show locked star state instead of 404',
+    deletedBehavior: 'show removed star notice',
+    archivedBehavior: 'open only if user has permission',
+  },
+  {
+    route: 'focus',
+    pathPattern: '/focus',
+    directLoad: true,
+    refreshSafe: true,
+    loadingState: true,
+    errorState: true,
+    emptyState: true,
+    returnHome: true,
+    invalidIdBehavior: 'show focus setup or return to life-map when no valid context exists',
+    lockedBehavior: 'show locked focus context',
+    deletedBehavior: 'show removed focus context notice',
+    archivedBehavior: 'open only if user has permission',
+  },
+  {
+    route: 'focus-session',
+    pathPattern: '/focus/session/:sessionId',
+    directLoad: true,
+    refreshSafe: true,
+    loadingState: true,
+    errorState: true,
+    emptyState: true,
+    returnHome: true,
+    invalidIdBehavior: 'show focus with missing-session notice',
+    lockedBehavior: 'show locked session state',
+    deletedBehavior: 'show removed session notice',
+    archivedBehavior: 'open only if user has permission',
+  },
+  {
+    route: 'replay',
+    pathPattern: '/replay',
+    directLoad: true,
+    refreshSafe: true,
+    loadingState: true,
+    errorState: true,
+    emptyState: true,
+    returnHome: true,
+    invalidIdBehavior: 'show replay library or return to life-map when no valid replay exists',
+    lockedBehavior: 'show locked replay state',
+    deletedBehavior: 'show removed replay notice',
+    archivedBehavior: 'open only if user has permission',
+  },
+  {
+    route: 'replay-detail',
+    pathPattern: '/replay/:replayId',
+    directLoad: true,
+    refreshSafe: true,
+    loadingState: true,
+    errorState: true,
+    emptyState: true,
+    returnHome: true,
+    invalidIdBehavior: 'show replay parent with invalid-replay notice',
+    lockedBehavior: 'show locked replay state',
+    deletedBehavior: 'show removed replay notice',
+    archivedBehavior: 'open only if user has permission',
+  },
+];
+
+export interface UraiTransitionContract {
+  id: 'home-to-life-map' | 'life-map-to-focus' | 'focus-to-replay' | 'replay-to-focus' | 'focus-to-life-map' | 'life-map-to-home';
+  from: UraiRouteMode;
+  to: UraiRouteMode;
+  inputLockedMs: number;
+  reducedMotionFallback: 'snap-fade' | 'short-crossfade';
+  escapeBehavior: string;
+  mobileBackBehavior: string;
+}
+
+export const URAI_TRANSITION_CONTRACTS: UraiTransitionContract[] = [
+  { id: 'home-to-life-map', from: 'home', to: 'life-map', inputLockedMs: 1200, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'cancel before route commit, otherwise unwind to home', mobileBackBehavior: 'unwind to home' },
+  { id: 'life-map-to-focus', from: 'life-map', to: 'focus', inputLockedMs: 900, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to life-map', mobileBackBehavior: 'return to life-map' },
+  { id: 'focus-to-replay', from: 'focus', to: 'replay', inputLockedMs: 800, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to focus', mobileBackBehavior: 'return to focus' },
+  { id: 'replay-to-focus', from: 'replay', to: 'focus', inputLockedMs: 650, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle focus before accepting next escape', mobileBackBehavior: 'settle focus before accepting next back' },
+  { id: 'focus-to-life-map', from: 'focus', to: 'life-map', inputLockedMs: 850, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle life-map before accepting next escape', mobileBackBehavior: 'settle life-map before accepting next back' },
+  { id: 'life-map-to-home', from: 'life-map', to: 'home', inputLockedMs: 1000, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'continue home unwind', mobileBackBehavior: 'continue home unwind' },
+];

--- a/src/lib/urai/contracts/systemContracts.ts
+++ b/src/lib/urai/contracts/systemContracts.ts
@@ -1,0 +1,180 @@
+export type UraiLifecycleState = 'active' | 'archived' | 'deleted' | 'locked';
+export type UraiVisibilityState = 'visible' | 'hidden' | 'shielded' | 'vaulted';
+export type UraiPrivacyState = 'public_to_user' | 'private' | 'sensitive' | 'vaulted' | 'shared' | 'archived' | 'deleted';
+export type UraiAiAccessState = 'allowed' | 'permissioned' | 'denied';
+export type UraiConfidence = 'low' | 'medium' | 'high';
+
+export type UraiCanonicalObjectType =
+  | 'LifeMapNode'
+  | 'MemoryNode'
+  | 'GoalNode'
+  | 'RelationshipNode'
+  | 'HabitPath'
+  | 'LifeChapter'
+  | 'GraphEdge'
+  | 'AIInsight'
+  | 'FocusSession'
+  | 'Replay'
+  | 'ReplayScene'
+  | 'ReplayJourney'
+  | 'Artifact'
+  | 'PrivateVaultObject'
+  | 'PermissionRule'
+  | 'AuditLogEvent'
+  | 'UserPreference';
+
+export interface UraiSourceRef {
+  id: string;
+  sourceType: 'manual' | 'firestore' | 'media' | 'calendar' | 'task' | 'journal' | 'focus' | 'replay' | 'life-map' | 'external';
+  label: string;
+  uri?: string;
+  capturedAt?: string;
+}
+
+export interface UraiProvenanceEntry {
+  id: string;
+  action: 'created' | 'imported' | 'edited' | 'inferred' | 'confirmed' | 'redacted' | 'archived' | 'deleted';
+  actor: 'user' | 'system' | 'ai' | 'admin';
+  at: string;
+  sourceRefs?: UraiSourceRef[];
+  note?: string;
+}
+
+export interface UraiCanonicalObjectBase {
+  id: string;
+  userId: string;
+  schemaVersion: number;
+  createdAt: string;
+  updatedAt: string;
+  type: UraiCanonicalObjectType;
+  title: string;
+  summary: string;
+  sourceRefs: UraiSourceRef[];
+  privacyState: UraiPrivacyState;
+  aiAccessState: UraiAiAccessState;
+  visibilityState: UraiVisibilityState;
+  lifecycleState: UraiLifecycleState;
+  confidence: UraiConfidence;
+  provenance: UraiProvenanceEntry[];
+  deletedAt?: string | null;
+  archivedAt?: string | null;
+  lastOpenedAt?: string | null;
+}
+
+export interface UraiGraphEdge extends UraiCanonicalObjectBase {
+  type: 'GraphEdge';
+  fromId: string;
+  toId: string;
+  relationship: 'related' | 'caused' | 'influenced' | 'contains' | 'precedes' | 'supports' | 'blocks';
+  strength: number;
+}
+
+export interface UraiLifeMapNode extends UraiCanonicalObjectBase {
+  type: 'LifeMapNode' | 'MemoryNode' | 'GoalNode' | 'RelationshipNode' | 'HabitPath' | 'LifeChapter';
+  x: number;
+  y: number;
+  z: number;
+  unlocked: boolean;
+  pinned?: boolean;
+  hidden?: boolean;
+  linkedFocusSessionIds?: string[];
+  linkedReplayIds?: string[];
+}
+
+export interface UraiFocusSession extends UraiCanonicalObjectBase {
+  type: 'FocusSession';
+  mode: 'quick' | 'deep-work' | 'creative-flow' | 'admin-sprint' | 'study' | 'recovery' | 'manual';
+  status: 'planning' | 'active' | 'paused' | 'completed' | 'abandoned';
+  startedAt?: string;
+  completedAt?: string;
+  targetMinutes: number;
+  linkedLifeMapNodeIds: string[];
+}
+
+export interface UraiReplayScene extends UraiCanonicalObjectBase {
+  type: 'ReplayScene';
+  replayId: string;
+  order: number;
+  truthMode: 'evidence' | 'reflection' | 'cinematic' | 'private-journal' | 'export';
+  sensitive: boolean;
+  redacted: boolean;
+}
+
+export interface UraiReplayJourney extends UraiCanonicalObjectBase {
+  type: 'Replay' | 'ReplayJourney';
+  sceneIds: string[];
+  truthMode: 'evidence' | 'reflection' | 'cinematic' | 'private-journal' | 'export';
+  exportEligible: boolean;
+}
+
+export type UraiCanonicalObject =
+  | UraiCanonicalObjectBase
+  | UraiLifeMapNode
+  | UraiGraphEdge
+  | UraiFocusSession
+  | UraiReplayScene
+  | UraiReplayJourney;
+
+export type UraiPermissionCapability = 'visibleInMap' | 'searchable' | 'aiReadable' | 'replayable' | 'shareable' | 'analyticsAllowed';
+
+export const URAI_PERMISSION_MATRIX: Record<UraiPrivacyState, Record<UraiPermissionCapability, boolean>> = {
+  public_to_user: { visibleInMap: true, searchable: true, aiReadable: true, replayable: true, shareable: false, analyticsAllowed: true },
+  private: { visibleInMap: true, searchable: true, aiReadable: true, replayable: true, shareable: false, analyticsAllowed: true },
+  sensitive: { visibleInMap: true, searchable: false, aiReadable: false, replayable: false, shareable: false, analyticsAllowed: false },
+  vaulted: { visibleInMap: true, searchable: false, aiReadable: false, replayable: false, shareable: false, analyticsAllowed: false },
+  shared: { visibleInMap: true, searchable: true, aiReadable: true, replayable: true, shareable: true, analyticsAllowed: true },
+  archived: { visibleInMap: false, searchable: false, aiReadable: false, replayable: true, shareable: false, analyticsAllowed: true },
+  deleted: { visibleInMap: false, searchable: false, aiReadable: false, replayable: false, shareable: false, analyticsAllowed: false },
+};
+
+export type UraiAiClaimType = 'fact' | 'inference' | 'pattern' | 'suggestion' | 'scenario';
+
+export interface UraiAiInsightContract {
+  insightId: string;
+  claim: string;
+  claimType: UraiAiClaimType;
+  evidenceRefs: UraiSourceRef[];
+  confidence: UraiConfidence;
+  permissionScopeUsed: UraiPrivacyState[];
+  generatedAt: string;
+  userActions: Array<'confirm' | 'edit' | 'reject' | 'hide' | 'vault' | 'delete'>;
+  explanationText: string;
+  prohibitedClaimsCheckPassed: boolean;
+}
+
+export const URAI_AI_PROHIBITED_CLAIMS = [
+  'diagnosis',
+  'moral_failure',
+  'another_person_inner_state_as_fact',
+  'unconfirmed_permanent_identity_label',
+  'uses_hidden_or_deleted_content',
+  'simulation_presented_as_prediction',
+  'vaulted_or_sensitive_data_without_permission',
+] as const;
+
+export interface UraiAssetManifestEntry {
+  assetId: string;
+  type: 'image' | 'model' | 'texture' | 'shader' | 'audio' | 'video' | 'lottie' | 'rive';
+  routeUsed: Array<'home' | 'life-map' | 'focus' | 'replay' | 'ochat'>;
+  tierIntroduced: 1 | 2 | 3 | 4 | 5;
+  desktopVariant: string;
+  mobileVariant: string;
+  reducedMotionVariant: string;
+  fallbackVariant: string;
+  fileSizeBudgetKb: number;
+  licenseOrSource: string;
+  owner: string;
+  version: string;
+  preloadPolicy: 'eager' | 'route' | 'interaction' | 'lazy';
+  performanceClass: 'low' | 'medium' | 'high' | 'cinematic';
+}
+
+export const URAI_SOURCE_OF_TRUTH_RULES = {
+  routeStateOwner: 'route-state-machine',
+  selectedSpatialEntityOwner: 'life-map-state-machine',
+  cameraStateOwner: 'camera-controller',
+  transitionOwner: 'animation-controller',
+  dataNormalizationOwner: 'data-adapter',
+  visibilityOwner: 'permission-layer',
+  aiOwnsSuggestionsOnly: true,
+} as const;

--- a/tests/unit/urai-canon/systemContracts.test.ts
+++ b/tests/unit/urai-canon/systemContracts.test.ts
@@ -1,0 +1,40 @@
+import { URAI_PERMISSION_MATRIX, URAI_SOURCE_OF_TRUTH_RULES } from '@/lib/urai/contracts/systemContracts';
+import { URAI_DIRECT_ROUTE_CONTRACTS, URAI_TRANSITION_CONTRACTS } from '@/lib/urai/contracts/routeContracts';
+
+describe('URAI system contracts', () => {
+  test('protects private safety states', () => {
+    expect(URAI_PERMISSION_MATRIX.sensitive.aiReadable).toBe(false);
+    expect(URAI_PERMISSION_MATRIX.vaulted.aiReadable).toBe(false);
+    expect(URAI_PERMISSION_MATRIX.deleted.visibleInMap).toBe(false);
+    expect(URAI_PERMISSION_MATRIX.deleted.analyticsAllowed).toBe(false);
+  });
+
+  test('keeps state ownership centralized', () => {
+    expect(URAI_SOURCE_OF_TRUTH_RULES.routeStateOwner).toBe('route-state-machine');
+    expect(URAI_SOURCE_OF_TRUTH_RULES.cameraStateOwner).toBe('camera-controller');
+    expect(URAI_SOURCE_OF_TRUTH_RULES.visibilityOwner).toBe('permission-layer');
+    expect(URAI_SOURCE_OF_TRUTH_RULES.aiOwnsSuggestionsOnly).toBe(true);
+  });
+
+  test('required direct routes are recoverable', () => {
+    const requiredRoutes = ['/home', '/life-map', '/life-map/star/:starId', '/focus', '/focus/session/:sessionId', '/replay', '/replay/:replayId'];
+    for (const pathPattern of requiredRoutes) {
+      const contract = URAI_DIRECT_ROUTE_CONTRACTS.find((route) => route.pathPattern === pathPattern);
+      expect(contract).toBeDefined();
+      expect(contract?.directLoad).toBe(true);
+      expect(contract?.refreshSafe).toBe(true);
+      expect(contract?.loadingState).toBe(true);
+      expect(contract?.errorState).toBe(true);
+      expect(contract?.emptyState).toBe(true);
+    }
+  });
+
+  test('cinematic transitions define escape and mobile back behavior', () => {
+    expect(URAI_TRANSITION_CONTRACTS.map((transition) => transition.id)).toEqual(expect.arrayContaining(['home-to-life-map', 'life-map-to-focus', 'focus-to-replay', 'replay-to-focus', 'focus-to-life-map', 'life-map-to-home']));
+    for (const transition of URAI_TRANSITION_CONTRACTS) {
+      expect(transition.inputLockedMs).toBeGreaterThan(0);
+      expect(transition.escapeBehavior.length).toBeGreaterThan(0);
+      expect(transition.mobileBackBehavior.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Implements the first completion slice for the system-of-systems pass.

Changes:
- Adds canonical URAI data/security/source-of-truth contracts.
- Adds direct-route and transition contracts for /home, /life-map, /life-map/star/:starId, /focus, /focus/session/:sessionId, /replay, and /replay/:replayId.
- Adds unit coverage for permission protections, centralized ownership, recoverable direct routes, and cinematic transition behavior.

This does not claim the full AAA visual stack is complete. It creates the hard contract layer needed before deeper Tier-3/Tier-4/Tier-5 implementation.