### PR TITLE
Reconcile URAI contracts with cinematic canon

### DIFF
--- a/src/lib/urai/contracts/routeContracts.ts
+++ b/src/lib/urai/contracts/routeContracts.ts
@@ -1,3 +1,5 @@
+import { URAI_CINEMATIC_TRANSITIONS } from '@/lib/urai-canon/cinematic-controller';
+
 export type UraiRouteId = 'home' | 'life-map' | 'life-map-star' | 'focus' | 'focus-session' | 'replay' | 'replay-detail' | 'ochat';
 
 export type UraiRouteMode =
@@ -62,7 +64,7 @@ export const URAI_DIRECT_ROUTE_CONTRACTS: UraiDirectRouteContract[] = [
   },
   {
     route: 'life-map-star',
-    pathPattern: '/life-map/star/:starId',
+    pathPattern: '/life-map/star/[starId]',
     directLoad: true,
     refreshSafe: true,
     loadingState: true,
@@ -90,7 +92,7 @@ export const URAI_DIRECT_ROUTE_CONTRACTS: UraiDirectRouteContract[] = [
   },
   {
     route: 'focus-session',
-    pathPattern: '/focus/session/:sessionId',
+    pathPattern: '/focus/session/[sessionId]',
     directLoad: true,
     refreshSafe: true,
     loadingState: true,
@@ -118,7 +120,7 @@ export const URAI_DIRECT_ROUTE_CONTRACTS: UraiDirectRouteContract[] = [
   },
   {
     route: 'replay-detail',
-    pathPattern: '/replay/:replayId',
+    pathPattern: '/replay/[replayId]',
     directLoad: true,
     refreshSafe: true,
     loadingState: true,
@@ -130,10 +132,26 @@ export const URAI_DIRECT_ROUTE_CONTRACTS: UraiDirectRouteContract[] = [
     deletedBehavior: 'show removed replay notice',
     archivedBehavior: 'open only if user has permission',
   },
+  {
+    route: 'ochat',
+    pathPattern: '/ochat',
+    directLoad: true,
+    refreshSafe: true,
+    loadingState: true,
+    errorState: true,
+    emptyState: true,
+    returnHome: true,
+    invalidIdBehavior: 'show orb chat fallback with visible notice',
+    lockedBehavior: 'show locked chat state',
+    deletedBehavior: 'not applicable',
+    archivedBehavior: 'not applicable',
+  },
 ];
 
+export type UraiTransitionId = keyof typeof URAI_CINEMATIC_TRANSITIONS | 'homeToOchat' | 'ochatToHome';
+
 export interface UraiTransitionContract {
-  id: 'home-to-life-map' | 'life-map-to-focus' | 'focus-to-replay' | 'replay-to-focus' | 'focus-to-life-map' | 'life-map-to-home';
+  id: UraiTransitionId;
   from: UraiRouteMode;
   to: UraiRouteMode;
   inputLockedMs: number;
@@ -143,10 +161,12 @@ export interface UraiTransitionContract {
 }
 
 export const URAI_TRANSITION_CONTRACTS: UraiTransitionContract[] = [
-  { id: 'home-to-life-map', from: 'home', to: 'life-map', inputLockedMs: 1200, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'cancel before route commit, otherwise unwind to home', mobileBackBehavior: 'unwind to home' },
-  { id: 'life-map-to-focus', from: 'life-map', to: 'focus', inputLockedMs: 900, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to life-map', mobileBackBehavior: 'return to life-map' },
-  { id: 'focus-to-replay', from: 'focus', to: 'replay', inputLockedMs: 800, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to focus', mobileBackBehavior: 'return to focus' },
-  { id: 'replay-to-focus', from: 'replay', to: 'focus', inputLockedMs: 650, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle focus before accepting next escape', mobileBackBehavior: 'settle focus before accepting next back' },
-  { id: 'focus-to-life-map', from: 'focus', to: 'life-map', inputLockedMs: 850, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle life-map before accepting next escape', mobileBackBehavior: 'settle life-map before accepting next back' },
-  { id: 'life-map-to-home', from: 'life-map', to: 'home', inputLockedMs: 1000, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'continue home unwind', mobileBackBehavior: 'continue home unwind' },
+  { id: 'homeToLifeMap', from: 'home', to: 'life-map', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.homeToLifeMap.inputUnlockAtMs, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'cancel before route commit, otherwise unwind to home', mobileBackBehavior: 'unwind to home' },
+  { id: 'lifeMapStarToFocus', from: 'life-map', to: 'focus', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.lifeMapStarToFocus.inputUnlockAtMs, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to life-map', mobileBackBehavior: 'return to life-map' },
+  { id: 'focusToReplay', from: 'focus', to: 'replay', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.focusToReplay.inputUnlockAtMs, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to focus', mobileBackBehavior: 'return to focus' },
+  { id: 'replayToFocusEsc', from: 'replay', to: 'focus', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.replayToFocusEsc.inputUnlockAtMs, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle focus before accepting next escape', mobileBackBehavior: 'settle focus before accepting next back' },
+  { id: 'focusToLifeMapEsc', from: 'focus', to: 'life-map', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.focusToLifeMapEsc.inputUnlockAtMs, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle life-map before accepting next escape', mobileBackBehavior: 'settle life-map before accepting next back' },
+  { id: 'lifeMapToHome', from: 'life-map', to: 'home', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.lifeMapToHome.inputUnlockAtMs, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'continue home unwind', mobileBackBehavior: 'continue home unwind' },
+  { id: 'homeToOchat', from: 'home', to: 'ochat', inputLockedMs: 900, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to home', mobileBackBehavior: 'return to home' },
+  { id: 'ochatToHome', from: 'ochat', to: 'home', inputLockedMs: 650, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle home before accepting next escape', mobileBackBehavior: 'settle home before accepting next back' },
 ];

--- a/src/lib/urai/contracts/systemContracts.ts
+++ b/src/lib/urai/contracts/systemContracts.ts
@@ -1,8 +1,16 @@
+import type { UraiSystemOwnerId } from '@/lib/urai-canon/source-of-truth';
+
 export type UraiLifecycleState = 'active' | 'archived' | 'deleted' | 'locked';
 export type UraiVisibilityState = 'visible' | 'hidden' | 'shielded' | 'vaulted';
 export type UraiPrivacyState = 'public_to_user' | 'private' | 'sensitive' | 'vaulted' | 'shared' | 'archived' | 'deleted';
 export type UraiAiAccessState = 'allowed' | 'permissioned' | 'denied';
 export type UraiConfidence = 'low' | 'medium' | 'high';
+
+export const URAI_STATE_HIERARCHY = {
+  lifecycleState: 'canonical record lifecycle and availability owner',
+  privacyState: 'access policy owner constrained by lifecycleState',
+  rule: 'deleted lifecycle overrides every privacy permission; archived lifecycle may only expose explicitly permissioned archive views',
+} as const;
 
 export type UraiCanonicalObjectType =
   | 'LifeMapNode'
@@ -169,7 +177,15 @@ export interface UraiAssetManifestEntry {
   performanceClass: 'low' | 'medium' | 'high' | 'cinematic';
 }
 
-export const URAI_SOURCE_OF_TRUTH_RULES = {
+export const URAI_SOURCE_OF_TRUTH_RULES: {
+  routeStateOwner: UraiSystemOwnerId;
+  selectedSpatialEntityOwner: UraiSystemOwnerId;
+  cameraStateOwner: UraiSystemOwnerId;
+  transitionOwner: UraiSystemOwnerId;
+  dataNormalizationOwner: UraiSystemOwnerId;
+  visibilityOwner: UraiSystemOwnerId;
+  aiOwnsSuggestionsOnly: true;
+} = {
   routeStateOwner: 'route-state-machine',
   selectedSpatialEntityOwner: 'life-map-state-machine',
   cameraStateOwner: 'camera-controller',
@@ -177,4 +193,4 @@ export const URAI_SOURCE_OF_TRUTH_RULES = {
   dataNormalizationOwner: 'data-adapter',
   visibilityOwner: 'permission-layer',
   aiOwnsSuggestionsOnly: true,
-} as const;
+};

--- a/tests/unit/urai-canon/systemContracts.test.ts
+++ b/tests/unit/urai-canon/systemContracts.test.ts
@@ -1,3 +1,4 @@
+import { URAI_CINEMATIC_TRANSITIONS } from '@/lib/urai-canon/cinematic-controller';
 import { URAI_PERMISSION_MATRIX, URAI_SOURCE_OF_TRUTH_RULES } from '@/lib/urai/contracts/systemContracts';
 import { URAI_DIRECT_ROUTE_CONTRACTS, URAI_TRANSITION_CONTRACTS } from '@/lib/urai/contracts/routeContracts';
 
@@ -17,7 +18,7 @@ describe('URAI system contracts', () => {
   });
 
   test('required direct routes are recoverable', () => {
-    const requiredRoutes = ['/home', '/life-map', '/life-map/star/:starId', '/focus', '/focus/session/:sessionId', '/replay', '/replay/:replayId'];
+    const requiredRoutes = ['/home', '/life-map', '/life-map/star/[starId]', '/focus', '/focus/session/[sessionId]', '/replay', '/replay/[replayId]', '/ochat'];
     for (const pathPattern of requiredRoutes) {
       const contract = URAI_DIRECT_ROUTE_CONTRACTS.find((route) => route.pathPattern === pathPattern);
       expect(contract).toBeDefined();
@@ -29,8 +30,15 @@ describe('URAI system contracts', () => {
     }
   });
 
-  test('cinematic transitions define escape and mobile back behavior', () => {
-    expect(URAI_TRANSITION_CONTRACTS.map((transition) => transition.id)).toEqual(expect.arrayContaining(['home-to-life-map', 'life-map-to-focus', 'focus-to-replay', 'replay-to-focus', 'focus-to-life-map', 'life-map-to-home']));
+  test('cinematic transitions use canonical ids and input unlock timing', () => {
+    const transitionsById = Object.fromEntries(URAI_TRANSITION_CONTRACTS.map((transition) => [transition.id, transition]));
+    expect(Object.keys(transitionsById)).toEqual(expect.arrayContaining(['homeToLifeMap', 'lifeMapStarToFocus', 'focusToReplay', 'replayToFocusEsc', 'focusToLifeMapEsc', 'lifeMapToHome', 'homeToOchat', 'ochatToHome']));
+    expect(transitionsById.homeToLifeMap.inputLockedMs).toBe(URAI_CINEMATIC_TRANSITIONS.homeToLifeMap.inputUnlockAtMs);
+    expect(transitionsById.lifeMapStarToFocus.inputLockedMs).toBe(URAI_CINEMATIC_TRANSITIONS.lifeMapStarToFocus.inputUnlockAtMs);
+    expect(transitionsById.focusToReplay.inputLockedMs).toBe(URAI_CINEMATIC_TRANSITIONS.focusToReplay.inputUnlockAtMs);
+    expect(transitionsById.replayToFocusEsc.inputLockedMs).toBe(URAI_CINEMATIC_TRANSITIONS.replayToFocusEsc.inputUnlockAtMs);
+    expect(transitionsById.focusToLifeMapEsc.inputLockedMs).toBe(URAI_CINEMATIC_TRANSITIONS.focusToLifeMapEsc.inputUnlockAtMs);
+    expect(transitionsById.lifeMapToHome.inputLockedMs).toBe(URAI_CINEMATIC_TRANSITIONS.lifeMapToHome.inputUnlockAtMs);
     for (const transition of URAI_TRANSITION_CONTRACTS) {
       expect(transition.inputLockedMs).toBeGreaterThan(0);
       expect(transition.escapeBehavior.length).toBeGreaterThan(0);


### PR DESCRIPTION
Follow-up to PR #287 review.

Changes:
- Aligns dynamic route patterns with the existing Next.js-style cinematic canon (`[starId]`, `[sessionId]`, `[replayId]`).
- Uses existing `URAI_CINEMATIC_TRANSITIONS` as the timing source for shared transition input locks.
- Adds `/ochat` direct route and home/chat transition contracts.
- Clarifies lifecycle versus privacy hierarchy so deleted lifecycle overrides privacy permissions.
- Types source-of-truth owners against the existing `UraiSystemOwnerId` canon.
- Updates unit tests to verify canonical IDs, route patterns, and timing reconciliation.

No visual claims or Tier-4/Tier-5 completion claims are made here; this keeps the hard contract layer aligned before spatial runtime work.