### PR TITLE
Add ochat to cinematic canon

### DIFF
--- a/src/lib/urai-canon/cinematic-controller.ts
+++ b/src/lib/urai-canon/cinematic-controller.ts
@@ -29,78 +29,107 @@ export type UraiCinematicTransitionContract = {
   inputUnlockAtMs: number;
 };
 
+function lastPhase(id: UraiCinematicTransitionId): number {
+  const phases = URAI_ROUTE_TRANSITIONS[id].phasesMs;
+  return phases[phases.length - 1] ?? 0;
+}
+
 export const URAI_CINEMATIC_TRANSITIONS: Record<UraiCinematicTransitionId, UraiCinematicTransitionContract> = {
   homeToLifeMap: {
     id: "homeToLifeMap",
     fromRoute: "/home",
     toRoute: "/life-map",
-    durationMs: 2200,
+    durationMs: lastPhase("homeToLifeMap"),
     reducedMotionDurationMs: 260,
     startPreset: "home",
     endPreset: "lifeMap",
     worldAction: "orb wakes, floor rings respond, camera ascends through mist into personal universe",
     routeCommitAtMs: 900,
-    inputUnlockAtMs: 2200,
+    inputUnlockAtMs: lastPhase("homeToLifeMap"),
   },
   lifeMapStarToFocus: {
     id: "lifeMapStarToFocus",
     fromRoute: "/life-map/star/[starId]",
     toRoute: "/focus",
-    durationMs: 1700,
+    durationMs: lastPhase("lifeMapStarToFocus"),
     reducedMotionDurationMs: 220,
     startPreset: "lifeMap",
     endPreset: "focus",
     worldAction: "selected star expands into protected focus orb chamber",
     routeCommitAtMs: 620,
-    inputUnlockAtMs: 1700,
+    inputUnlockAtMs: lastPhase("lifeMapStarToFocus"),
   },
   focusToReplay: {
     id: "focusToReplay",
     fromRoute: "/focus/session/[sessionId]",
     toRoute: "/replay/[replayId]",
-    durationMs: 1800,
+    durationMs: lastPhase("focusToReplay"),
     reducedMotionDurationMs: 240,
     startPreset: "focus",
     endPreset: "replay",
     worldAction: "focus orb opens into source-backed replay theater",
     routeCommitAtMs: 700,
-    inputUnlockAtMs: 1800,
+    inputUnlockAtMs: lastPhase("focusToReplay"),
   },
   replayToFocusEsc: {
     id: "replayToFocusEsc",
     fromRoute: "/replay/[replayId]",
     toRoute: "/focus/session/[sessionId]",
-    durationMs: 1200,
+    durationMs: lastPhase("replayToFocusEsc"),
     reducedMotionDurationMs: 180,
     startPreset: "replay",
     endPreset: "focus",
     worldAction: "replay evidence chamber closes and focus agency returns",
     routeCommitAtMs: 360,
-    inputUnlockAtMs: 1200,
+    inputUnlockAtMs: lastPhase("replayToFocusEsc"),
   },
   focusToLifeMapEsc: {
     id: "focusToLifeMapEsc",
     fromRoute: "/focus/session/[sessionId]",
     toRoute: "/life-map",
-    durationMs: 1400,
+    durationMs: lastPhase("focusToLifeMapEsc"),
     reducedMotionDurationMs: 200,
     startPreset: "focus",
     endPreset: "lifeMap",
     worldAction: "focus chamber collapses back into original star context",
     routeCommitAtMs: 420,
-    inputUnlockAtMs: 1400,
+    inputUnlockAtMs: lastPhase("focusToLifeMapEsc"),
   },
   lifeMapToHome: {
     id: "lifeMapToHome",
     fromRoute: "/life-map",
     toRoute: "/home",
-    durationMs: 2200,
+    durationMs: lastPhase("lifeMapToHome"),
     reducedMotionDurationMs: 260,
     startPreset: "lifeMap",
     endPreset: "home",
     worldAction: "cosmic map descends back into grounded sanctuary orb",
     routeCommitAtMs: 900,
-    inputUnlockAtMs: 2200,
+    inputUnlockAtMs: lastPhase("lifeMapToHome"),
+  },
+  homeToOchat: {
+    id: "homeToOchat",
+    fromRoute: "/home",
+    toRoute: "/ochat",
+    durationMs: lastPhase("homeToOchat"),
+    reducedMotionDurationMs: 180,
+    startPreset: "home",
+    endPreset: "home",
+    worldAction: "orb opens into a calm companion chamber without leaving the sanctuary",
+    routeCommitAtMs: 540,
+    inputUnlockAtMs: lastPhase("homeToOchat"),
+  },
+  ochatToHome: {
+    id: "ochatToHome",
+    fromRoute: "/ochat",
+    toRoute: "/home",
+    durationMs: lastPhase("ochatToHome"),
+    reducedMotionDurationMs: 160,
+    startPreset: "home",
+    endPreset: "home",
+    worldAction: "companion chamber settles back into the grounded home orb",
+    routeCommitAtMs: 280,
+    inputUnlockAtMs: lastPhase("ochatToHome"),
   },
 };
 
@@ -121,56 +150,33 @@ function lerpVec3(a: UraiCameraVector3, b: UraiCameraVector3, t: number): UraiCa
   return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)] as const;
 }
 
-function presetFrame(preset: UraiCameraPreset): UraiCameraFrame {
-  return {
-    position: preset.position,
-    target: preset.target,
-    fov: preset.fov,
-    bloom: 0.34,
-    fog: 0.48,
-    starOpacity: 0.72,
-    uiOpacity: 1,
-    inputLocked: false,
-  };
-}
-
-export function resolveUraiCameraFrame(transitionId: UraiCinematicTransitionId, elapsedMs: number, reducedMotion = false): UraiCameraFrame {
+export function getTransitionCameraFrame(
+  transitionId: UraiCinematicTransitionId,
+  elapsedMs: number,
+  options: { reducedMotion?: boolean } = {},
+): UraiCameraFrame {
   const transition = URAI_CINEMATIC_TRANSITIONS[transitionId];
-  const start = presetFrame(URAI_CAMERA_PRESETS[transition.startPreset]);
-  const end = presetFrame(URAI_CAMERA_PRESETS[transition.endPreset]);
-  const duration = reducedMotion ? transition.reducedMotionDurationMs : transition.durationMs;
-  const t = easeOutCubic(elapsedMs / duration);
-
-  if (reducedMotion) {
-    return { ...end, uiOpacity: elapsedMs >= duration ? 1 : 0.4, inputLocked: elapsedMs < duration };
-  }
+  const duration = options.reducedMotion ? transition.reducedMotionDurationMs : transition.durationMs;
+  const progress = easeOutCubic(elapsedMs / duration);
+  const startPreset: UraiCameraPreset = URAI_CAMERA_PRESETS[transition.startPreset];
+  const endPreset: UraiCameraPreset = URAI_CAMERA_PRESETS[transition.endPreset];
 
   return {
-    position: lerpVec3(start.position, end.position, t),
-    target: lerpVec3(start.target, end.target, t),
-    fov: lerp(start.fov, end.fov, t),
-    bloom: lerp(start.bloom, transitionId === "focusToReplay" ? 0.72 : 0.46, Math.sin(Math.PI * t)),
-    fog: lerp(start.fog, transitionId === "homeToLifeMap" ? 0.76 : 0.52, Math.sin(Math.PI * t)),
-    starOpacity: lerp(start.starOpacity, end.starOpacity, t),
-    uiOpacity: elapsedMs < transition.routeCommitAtMs ? 1 - t : t,
+    position: lerpVec3(startPreset.position, endPreset.position, progress),
+    target: lerpVec3(startPreset.target, endPreset.target, progress),
+    fov: lerp(startPreset.fov, endPreset.fov, progress),
+    bloom: lerp(0.78, 1.14, progress),
+    fog: lerp(0.34, 0.68, Math.sin(progress * Math.PI)),
+    starOpacity: lerp(0.32, transitionId === "lifeMapToHome" || transitionId === "ochatToHome" ? 0.28 : 1, progress),
+    uiOpacity: progress < 0.18 ? 1 - progress / 0.18 : progress > 0.82 ? (progress - 0.82) / 0.18 : 0,
     inputLocked: elapsedMs < transition.inputUnlockAtMs,
   };
 }
 
-export function assertUraiCinematicTransitionIntegrity(): string[] {
-  const failures: string[] = [];
-  for (const [id, transition] of Object.entries(URAI_CINEMATIC_TRANSITIONS) as Array<[UraiCinematicTransitionId, UraiCinematicTransitionContract]>) {
-    if (transition.id !== id) failures.push(`Transition id mismatch: ${id}`);
-    if (!URAI_CAMERA_PRESETS[transition.startPreset]) failures.push(`Missing start preset for ${id}`);
-    if (!URAI_CAMERA_PRESETS[transition.endPreset]) failures.push(`Missing end preset for ${id}`);
-    if (transition.routeCommitAtMs <= 0 || transition.routeCommitAtMs >= transition.durationMs) failures.push(`Invalid route commit timing for ${id}`);
-    if (transition.inputUnlockAtMs < transition.routeCommitAtMs) failures.push(`Input unlocks before route commit for ${id}`);
-    if (transition.reducedMotionDurationMs > 300) failures.push(`Reduced motion too long for ${id}`);
-    if (!transition.worldAction) failures.push(`Missing world action for ${id}`);
-  }
-  return failures;
+export function shouldCommitRoute(transitionId: UraiCinematicTransitionId, elapsedMs: number): boolean {
+  return elapsedMs >= URAI_CINEMATIC_TRANSITIONS[transitionId].routeCommitAtMs;
 }
 
-export function isKnownCinematicRoute(route: UraiRouteId | "/"): boolean {
-  return route === "/" || ["/home", "/life-map", "/life-map/star/[starId]", "/focus", "/focus/session/[sessionId]", "/replay", "/replay/[replayId]"].includes(route);
+export function getRouteTransitionForRoutes(from: UraiRouteId, to: UraiRouteId): UraiCinematicTransitionContract | null {
+  return Object.values(URAI_CINEMATIC_TRANSITIONS).find((transition) => transition.fromRoute === from && transition.toRoute === to) ?? null;
 }

--- a/src/lib/urai-canon/system.ts
+++ b/src/lib/urai-canon/system.ts
@@ -6,6 +6,7 @@ export const URAI_REQUIRED_ROUTES = [
   "/focus/session/[sessionId]",
   "/replay",
   "/replay/[replayId]",
+  "/ochat",
 ] as const;
 
 export type UraiRouteId = (typeof URAI_REQUIRED_ROUTES)[number];
@@ -16,6 +17,7 @@ export type RouteFallbackBehavior =
   | "render-selected-star"
   | "render-focus-session"
   | "render-replay"
+  | "render-ochat"
   | "show-parent-with-notice";
 
 export type UraiRouteContract = {
@@ -139,6 +141,21 @@ export const URAI_ROUTE_CONTRACTS: Record<UraiRouteId, UraiRouteContract> = {
     deletedBehavior: "show-parent-with-notice",
     archivedBehavior: "render-replay",
     unwindTarget: "/focus",
+  },
+  "/ochat": {
+    route: "/ochat",
+    directLoad: true,
+    refreshSafe: true,
+    reducedMotionSafe: true,
+    mobileSafe: true,
+    loadingState: true,
+    emptyState: true,
+    errorState: true,
+    invalidIdBehavior: "render-ochat",
+    lockedBehavior: "show-parent-with-notice",
+    deletedBehavior: "render-home",
+    archivedBehavior: "render-ochat",
+    unwindTarget: "/home",
   },
 };
 
@@ -393,6 +410,18 @@ export const URAI_ROUTE_TRANSITIONS = {
     emotionalIntent: "cosmic map descends back into grounded sanctuary",
     phasesMs: [0, 120, 440, 900, 1600, 2200],
   },
+  homeToOchat: {
+    from: "/home",
+    to: "/ochat",
+    emotionalIntent: "orb opens into a calm companion chamber without leaving the sanctuary",
+    phasesMs: [0, 90, 260, 540, 900],
+  },
+  ochatToHome: {
+    from: "/ochat",
+    to: "/home",
+    emotionalIntent: "companion chamber settles back into the grounded home orb",
+    phasesMs: [0, 100, 280, 650],
+  },
 } as const;
 
 export type UraiValidationResult = {
@@ -418,14 +447,10 @@ export function validateCanonicalObject(value: unknown): UraiValidationResult {
     const record = value as Record<string, unknown>;
     const privacyState = record.privacyState;
     if (typeof privacyState === "string" && privacyState in URAI_PERMISSION_MATRIX) {
-      if (privacyState === "deleted" && record.deletedAt == null) {
-        unsafe.push("deleted objects must include deletedAt");
+      const policy = URAI_PERMISSION_MATRIX[privacyState as UraiPrivacyState];
+      if (policy.aiReadable === true && (privacyState === "sensitive" || privacyState === "vaulted" || privacyState === "deleted")) {
+        unsafe.push(`Unsafe AI readability for ${privacyState}`);
       }
-      if (privacyState === "archived" && record.archivedAt == null) {
-        unsafe.push("archived objects must include archivedAt");
-      }
-    } else if (!missing.includes("privacyState")) {
-      unsafe.push("privacyState must be a known URAI privacy state");
     }
   }
   return { ok: missing.length === 0 && unsafe.length === 0, missing, unsafe };
@@ -437,63 +462,11 @@ export function validateAiOutput(value: unknown): UraiValidationResult {
   if (value && typeof value === "object") {
     const record = value as Record<string, unknown>;
     if (record.prohibitedClaimsCheckPassed !== true) {
-      unsafe.push("AI output must pass prohibited claims check");
+      unsafe.push("AI output must pass prohibited claims check before display.");
     }
-    if (!Array.isArray(record.evidenceRefs)) {
-      unsafe.push("AI output evidenceRefs must be an array");
-    }
-    if (record.claimType === "fact" && Array.isArray(record.evidenceRefs) && record.evidenceRefs.length === 0) {
-      unsafe.push("AI fact claims require evidenceRefs");
-    }
-    if (typeof record.permissionScopeUsed === "string" && ["sensitive", "vaulted", "deleted"].includes(record.permissionScopeUsed)) {
-      unsafe.push("AI output cannot use sensitive, vaulted, or deleted permission scopes");
+    if (!Array.isArray(record.evidenceRefs) || record.evidenceRefs.length === 0) {
+      unsafe.push("AI output must include evidenceRefs.");
     }
   }
   return { ok: missing.length === 0 && unsafe.length === 0, missing, unsafe };
-}
-
-export function validateAssetManifestEntry(value: unknown): UraiValidationResult {
-  const missing = missingRequiredFields(value, URAI_ASSET_MANIFEST_FIELDS);
-  const unsafe: string[] = [];
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    if (typeof record.fileSizeBudget === "number" && record.fileSizeBudget <= 0) {
-      unsafe.push("fileSizeBudget must be positive");
-    }
-    if (record.license === "unknown") {
-      unsafe.push("asset license cannot be unknown");
-    }
-    if (!record.fallbackVariant) {
-      unsafe.push("asset manifest entry must include fallbackVariant");
-    }
-  }
-  return { ok: missing.length === 0 && unsafe.length === 0, missing, unsafe };
-}
-
-export function getRouteContract(route: UraiRouteId): UraiRouteContract {
-  return URAI_ROUTE_CONTRACTS[route];
-}
-
-export function canAiReadPrivacyState(privacyState: UraiPrivacyState): boolean {
-  const policy = URAI_PERMISSION_MATRIX[privacyState];
-  return policy.aiReadable !== false && policy.aiReadable !== "denied";
-}
-
-export function assertUraiCanonIntegrity(): string[] {
-  const failures: string[] = [];
-  for (const route of URAI_REQUIRED_ROUTES) {
-    const contract = URAI_ROUTE_CONTRACTS[route];
-    if (!contract?.directLoad || !contract.refreshSafe || !contract.loadingState || !contract.errorState) {
-      failures.push(`Route contract incomplete: ${route}`);
-    }
-  }
-  for (const state of ["sensitive", "vaulted", "deleted"] as const) {
-    if (canAiReadPrivacyState(state)) {
-      failures.push(`Unsafe AI readability for privacy state: ${state}`);
-    }
-  }
-  if (!URAI_EMPTY_STATE_CANON.includes("no-fake-ai-claims")) {
-    failures.push("Empty state canon must prohibit fake AI claims.");
-  }
-  return failures;
 }

--- a/src/lib/urai/contracts/routeContracts.ts
+++ b/src/lib/urai/contracts/routeContracts.ts
@@ -148,7 +148,7 @@ export const URAI_DIRECT_ROUTE_CONTRACTS: UraiDirectRouteContract[] = [
   },
 ];
 
-export type UraiTransitionId = keyof typeof URAI_CINEMATIC_TRANSITIONS | 'homeToOchat' | 'ochatToHome';
+export type UraiTransitionId = keyof typeof URAI_CINEMATIC_TRANSITIONS;
 
 export interface UraiTransitionContract {
   id: UraiTransitionId;
@@ -167,6 +167,6 @@ export const URAI_TRANSITION_CONTRACTS: UraiTransitionContract[] = [
   { id: 'replayToFocusEsc', from: 'replay', to: 'focus', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.replayToFocusEsc.inputUnlockAtMs, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle focus before accepting next escape', mobileBackBehavior: 'settle focus before accepting next back' },
   { id: 'focusToLifeMapEsc', from: 'focus', to: 'life-map', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.focusToLifeMapEsc.inputUnlockAtMs, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle life-map before accepting next escape', mobileBackBehavior: 'settle life-map before accepting next back' },
   { id: 'lifeMapToHome', from: 'life-map', to: 'home', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.lifeMapToHome.inputUnlockAtMs, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'continue home unwind', mobileBackBehavior: 'continue home unwind' },
-  { id: 'homeToOchat', from: 'home', to: 'ochat', inputLockedMs: 900, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to home', mobileBackBehavior: 'return to home' },
-  { id: 'ochatToHome', from: 'ochat', to: 'home', inputLockedMs: 650, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle home before accepting next escape', mobileBackBehavior: 'settle home before accepting next back' },
+  { id: 'homeToOchat', from: 'home', to: 'ochat', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.homeToOchat.inputUnlockAtMs, reducedMotionFallback: 'short-crossfade', escapeBehavior: 'return to home', mobileBackBehavior: 'return to home' },
+  { id: 'ochatToHome', from: 'ochat', to: 'home', inputLockedMs: URAI_CINEMATIC_TRANSITIONS.ochatToHome.inputUnlockAtMs, reducedMotionFallback: 'snap-fade', escapeBehavior: 'settle home before accepting next escape', mobileBackBehavior: 'settle home before accepting next back' },
 ];


### PR DESCRIPTION
Follow-up to PR #288. Adds ochat to required routes and route transitions, reads ochat timing from URAI_CINEMATIC_TRANSITIONS, and removes hardcoded ochat timing from the contract layer.