### PR TITLE
Mount persistent spatial universe provider

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import * as React from 'react';
+import { SpatialUniverseProvider } from '@/components/urai/SpatialUniverseProvider';
 
 export default function AppProviders({ children }: { children?: React.ReactNode }) {
-  // Add any real providers here later (theme, query, auth, etc.)
-  return <>{children}</>;
+  return <SpatialUniverseProvider>{children}</SpatialUniverseProvider>;
 }

--- a/src/components/urai/SpatialUniverseProvider.tsx
+++ b/src/components/urai/SpatialUniverseProvider.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { getSpatialRuntimeContract, type UraiSpatialMode } from '@/lib/urai-canon/spatial-runtime';
+import { URAI_ROUTE_CONTRACTS, type UraiRouteId } from '@/lib/urai-canon/system';
+
+export type UraiQualityProfile = 'mobile-safe' | 'reduced-motion' | 'desktop-cinematic';
+
+export type SpatialUniverseState = {
+  route: UraiRouteId;
+  pathname: string;
+  mode: UraiSpatialMode;
+  cameraPreset: string;
+  canonicalScreen: string;
+  primaryObject: string;
+  qualityProfile: UraiQualityProfile;
+  loadingState: true;
+  emptyState: true;
+  errorState: true;
+  directLoadSafe: true;
+  returnHomeHref: '/home' | null;
+};
+
+const SpatialUniverseContext = createContext<SpatialUniverseState | null>(null);
+
+const ROUTE_PATTERNS: UraiRouteId[] = [
+  '/home',
+  '/life-map',
+  '/life-map/star/[starId]',
+  '/focus',
+  '/focus/session/[sessionId]',
+  '/replay',
+  '/replay/[replayId]',
+  '/ochat',
+];
+
+function normalizePathname(pathname: string | null): UraiRouteId {
+  const current = pathname ?? '/home';
+  if (current === '/' || current === '/home') return '/home';
+  if (current === '/life-map') return '/life-map';
+  if (current.startsWith('/life-map/star/')) return '/life-map/star/[starId]';
+  if (current === '/focus') return '/focus';
+  if (current.startsWith('/focus/session/')) return '/focus/session/[sessionId]';
+  if (current === '/replay') return '/replay';
+  if (current.startsWith('/replay/')) return '/replay/[replayId]';
+  if (current === '/ochat') return '/ochat';
+  return '/home';
+}
+
+function detectQualityProfile(): UraiQualityProfile {
+  if (typeof window === 'undefined') return 'desktop-cinematic';
+  const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+  if (reduceMotion) return 'reduced-motion';
+  const coarsePointer = window.matchMedia?.('(pointer: coarse)').matches ?? false;
+  const narrow = window.innerWidth < 760;
+  return coarsePointer || narrow ? 'mobile-safe' : 'desktop-cinematic';
+}
+
+export function resolveSpatialUniverseState(pathname: string | null, qualityProfile: UraiQualityProfile = 'desktop-cinematic'): SpatialUniverseState {
+  const route = normalizePathname(pathname);
+  const runtime = getSpatialRuntimeContract(route);
+  const routeContract = URAI_ROUTE_CONTRACTS[route];
+
+  return {
+    route,
+    pathname: pathname ?? '/home',
+    mode: runtime.stableMode,
+    cameraPreset: runtime.cameraPreset,
+    canonicalScreen: runtime.canonicalScreen,
+    primaryObject: runtime.primaryObject,
+    qualityProfile,
+    loadingState: routeContract.loadingState,
+    emptyState: routeContract.emptyState,
+    errorState: routeContract.errorState,
+    directLoadSafe: routeContract.directLoad,
+    returnHomeHref: route === '/home' ? null : '/home',
+  };
+}
+
+export function SpatialUniverseProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const qualityProfile = detectQualityProfile();
+  const state = useMemo(() => resolveSpatialUniverseState(pathname, qualityProfile), [pathname, qualityProfile]);
+
+  return (
+    <SpatialUniverseContext.Provider value={state}>
+      <div
+        aria-hidden="true"
+        data-urai-spatial-universe="mounted"
+        data-urai-route={state.route}
+        data-urai-mode={state.mode}
+        data-urai-camera={state.cameraPreset}
+        data-urai-quality={state.qualityProfile}
+        style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 0 }}
+      />
+      {children}
+    </SpatialUniverseContext.Provider>
+  );
+}
+
+export function useSpatialUniverse(): SpatialUniverseState {
+  const value = useContext(SpatialUniverseContext);
+  if (!value) return resolveSpatialUniverseState('/home');
+  return value;
+}
+
+export const URAI_SPATIAL_ROUTE_PATTERNS = ROUTE_PATTERNS;

--- a/tests/unit/urai-canon/spatialUniverseProvider.test.ts
+++ b/tests/unit/urai-canon/spatialUniverseProvider.test.ts
@@ -1,0 +1,33 @@
+import { resolveSpatialUniverseState, URAI_SPATIAL_ROUTE_PATTERNS } from '@/components/urai/SpatialUniverseProvider';
+
+describe('SpatialUniverseProvider state resolver', () => {
+  test('normalizes direct routes into canonical spatial runtime state', () => {
+    expect(resolveSpatialUniverseState('/').route).toBe('/home');
+    expect(resolveSpatialUniverseState('/home').mode).toBe('home');
+    expect(resolveSpatialUniverseState('/life-map').mode).toBe('life-map');
+    expect(resolveSpatialUniverseState('/life-map/star/star-1').route).toBe('/life-map/star/[starId]');
+    expect(resolveSpatialUniverseState('/focus/session/session-1').route).toBe('/focus/session/[sessionId]');
+    expect(resolveSpatialUniverseState('/replay/replay-1').route).toBe('/replay/[replayId]');
+    expect(resolveSpatialUniverseState('/ochat').mode).toBe('ochat');
+  });
+
+  test('every spatial route exposes required recovery guarantees', () => {
+    for (const path of URAI_SPATIAL_ROUTE_PATTERNS) {
+      const state = resolveSpatialUniverseState(path);
+      expect(state.directLoadSafe).toBe(true);
+      expect(state.loadingState).toBe(true);
+      expect(state.emptyState).toBe(true);
+      expect(state.errorState).toBe(true);
+    }
+  });
+
+  test('uses mobile and reduced-motion quality profiles without changing route identity', () => {
+    const mobile = resolveSpatialUniverseState('/life-map/star/star-1', 'mobile-safe');
+    const reduced = resolveSpatialUniverseState('/replay/replay-1', 'reduced-motion');
+
+    expect(mobile.route).toBe('/life-map/star/[starId]');
+    expect(mobile.qualityProfile).toBe('mobile-safe');
+    expect(reduced.route).toBe('/replay/[replayId]');
+    expect(reduced.qualityProfile).toBe('reduced-motion');
+  });
+});


### PR DESCRIPTION
Adds the first persistent spatial runtime shell on top of the now-aligned route/cinematic/spatial contracts.

Changes:
- Adds `SpatialUniverseProvider` with route normalization for root, home, life-map, life-map star detail, focus, focus session, replay, replay detail, and ochat.
- Mounts the provider from `src/app/providers.tsx` so the spatial universe state persists around app children.
- Exposes mounted route/mode/camera/quality data attributes for smoke/QA visibility without blocking UI.
- Adds deterministic state resolver tests covering direct-load routes, mobile-safe quality, and reduced-motion quality.

This is intentionally a lightweight provider shell: it does not claim shader/R3F completion yet. It gives the app a single spatial route state owner before deeper canvas/camera/HUD work.