### PR TITLE
Add spatial universe shell HUD

### DIFF
--- a/src/components/urai/SpatialUniverseProvider.tsx
+++ b/src/components/urai/SpatialUniverseProvider.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { getSpatialRuntimeContract, type UraiSpatialMode } from '@/lib/urai-canon/spatial-runtime';
 import { URAI_ROUTE_CONTRACTS, type UraiRouteId } from '@/lib/urai-canon/system';
+import SpatialUniverseShell from './SpatialUniverseShell';
 
 export type UraiQualityProfile = 'mobile-safe' | 'reduced-motion' | 'desktop-cinematic';
 
@@ -94,6 +95,7 @@ export function SpatialUniverseProvider({ children }: { children: ReactNode }) {
         data-urai-quality={state.qualityProfile}
         style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 0 }}
       />
+      <SpatialUniverseShell />
       {children}
     </SpatialUniverseContext.Provider>
   );

--- a/src/components/urai/SpatialUniverseShell.tsx
+++ b/src/components/urai/SpatialUniverseShell.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useSpatialUniverse, type SpatialUniverseState } from './SpatialUniverseProvider';
+
+export type SpatialUniverseShellModel = {
+  label: string;
+  ariaLabel: string;
+  route: SpatialUniverseState['route'];
+  mode: SpatialUniverseState['mode'];
+  qualityProfile: SpatialUniverseState['qualityProfile'];
+  cameraPreset: string;
+  primaryObject: string;
+  reducedMotion: boolean;
+  mobileSafe: boolean;
+  returnHomeHref: '/home' | null;
+};
+
+export function resolveSpatialUniverseShellModel(state: SpatialUniverseState): SpatialUniverseShellModel {
+  const reducedMotion = state.qualityProfile === 'reduced-motion';
+  const mobileSafe = state.qualityProfile === 'mobile-safe' || reducedMotion;
+  return {
+    label: `${state.canonicalScreen} · ${state.mode} · ${state.primaryObject}`,
+    ariaLabel: `URAI spatial universe shell: ${state.canonicalScreen} in ${state.qualityProfile} mode`,
+    route: state.route,
+    mode: state.mode,
+    qualityProfile: state.qualityProfile,
+    cameraPreset: state.cameraPreset,
+    primaryObject: state.primaryObject,
+    reducedMotion,
+    mobileSafe,
+    returnHomeHref: state.returnHomeHref,
+  };
+}
+
+export default function SpatialUniverseShell() {
+  const state = useSpatialUniverse();
+  const model = resolveSpatialUniverseShellModel(state);
+
+  return (
+    <aside
+      aria-label={model.ariaLabel}
+      data-urai-spatial-shell="mounted"
+      data-urai-shell-route={model.route}
+      data-urai-shell-mode={model.mode}
+      data-urai-shell-quality={model.qualityProfile}
+      data-urai-shell-camera={model.cameraPreset}
+      data-urai-shell-primary-object={model.primaryObject}
+      data-urai-shell-reduced-motion={String(model.reducedMotion)}
+      data-urai-shell-mobile-safe={String(model.mobileSafe)}
+      style={{
+        position: 'fixed',
+        right: 12,
+        bottom: 12,
+        zIndex: 2147483000,
+        maxWidth: 280,
+        border: '1px solid rgba(255,255,255,.16)',
+        borderRadius: 16,
+        padding: '10px 12px',
+        color: 'rgba(255,255,255,.82)',
+        background: 'rgba(4,8,18,.58)',
+        backdropFilter: 'blur(10px)',
+        pointerEvents: 'none',
+        fontSize: 12,
+        lineHeight: 1.35,
+      }}
+    >
+      <div>Spatial Universe</div>
+      <div>{model.label}</div>
+      {model.returnHomeHref ? <div>Return: {model.returnHomeHref}</div> : null}
+    </aside>
+  );
+}

--- a/tests/unit/urai-canon/spatialUniverseShell.test.ts
+++ b/tests/unit/urai-canon/spatialUniverseShell.test.ts
@@ -1,0 +1,29 @@
+import { resolveSpatialUniverseShellModel } from '@/components/urai/SpatialUniverseShell';
+import { resolveSpatialUniverseState } from '@/components/urai/SpatialUniverseProvider';
+
+describe('SpatialUniverseShell model', () => {
+  test('describes home as a persistent spatial shell without return link', () => {
+    const model = resolveSpatialUniverseShellModel(resolveSpatialUniverseState('/home'));
+    expect(model.label).toContain('home');
+    expect(model.primaryObject).toBe('world-orb');
+    expect(model.returnHomeHref).toBeNull();
+    expect(model.mobileSafe).toBe(false);
+    expect(model.reducedMotion).toBe(false);
+  });
+
+  test('exposes return-home and quality guarantees for child routes', () => {
+    const model = resolveSpatialUniverseShellModel(resolveSpatialUniverseState('/ochat', 'mobile-safe'));
+    expect(model.route).toBe('/ochat');
+    expect(model.mode).toBe('ochat');
+    expect(model.primaryObject).toBe('companion-orb');
+    expect(model.returnHomeHref).toBe('/home');
+    expect(model.mobileSafe).toBe(true);
+  });
+
+  test('marks reduced-motion as mobile-safe equivalent', () => {
+    const model = resolveSpatialUniverseShellModel(resolveSpatialUniverseState('/replay/replay-1', 'reduced-motion'));
+    expect(model.reducedMotion).toBe(true);
+    expect(model.mobileSafe).toBe(true);
+    expect(model.ariaLabel).toContain('reduced-motion');
+  });
+});


### PR DESCRIPTION
Adds a lightweight spatial shell on top of the persistent SpatialUniverseProvider.

Changes:
- Adds `SpatialUniverseShell` with route/mode/camera/quality data attributes for QA and smoke visibility.
- Renders the shell from the provider without blocking app UI.
- Adds deterministic shell model tests for home, ochat, mobile-safe, and reduced-motion states.

This is still not the full shader/R3F canvas. It is the next safe runtime slice: one persistent shell/HUD state surface before deeper visual canvas implementation.