### PR TITLE
Add ochat route and canonicalize root home

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "doctor": "node scripts/repo-doctor.mjs",
     "bootstrap:check": "npm run doctor",
     "health": "bash ./scripts/baseline_health_check.sh",
-    "clean": "rimraf .next node_modules .turbo",
+    "clean": "rm -rf .next node_modules .turbo",
     "clean:install": "node scripts/clean-install-artifacts.mjs",
     "reinstall": "npm run clean:install && npm install",
     "codemod:dry": "node scripts/replace-demo-user.mjs --dry",
@@ -93,7 +93,6 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.5.15",
-    "rimraf": "^6.0.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.0.0"
   },

--- a/src/app/ochat/page.tsx
+++ b/src/app/ochat/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "URAI Orb Companion",
+  description: "The URAI orb companion chamber for calm, privacy-safe reflection and guided return to the home world.",
+};
+
+export default function OchatPage() {
+  return (
+    <main className="relative min-h-dvh overflow-hidden bg-[#020617] text-white">
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_50%_34%,rgba(103,232,249,.22),transparent_30%),radial-gradient(circle_at_78%_12%,rgba(168,85,247,.2),transparent_35%),linear-gradient(180deg,#01030a,#07152b_48%,#020617)]" />
+      <div className="pointer-events-none fixed inset-0 opacity-60 [background-image:radial-gradient(circle_at_18%_22%,rgba(255,255,255,.42)_0_1px,transparent_1.5px),radial-gradient(circle_at_76%_18%,rgba(186,230,253,.34)_0_1px,transparent_1.5px),radial-gradient(circle_at_47%_39%,rgba(221,214,254,.28)_0_1px,transparent_1.5px)]" />
+
+      <section className="relative z-10 mx-auto flex min-h-dvh w-full max-w-5xl flex-col items-center justify-center px-5 py-12 text-center">
+        <div className="relative flex h-72 w-72 items-center justify-center rounded-full border border-cyan-100/15 bg-cyan-100/[0.035] shadow-[0_0_130px_rgba(103,232,249,.22)]">
+          <div className="absolute inset-[-24%] rounded-full bg-[radial-gradient(circle,rgba(103,232,249,.18),rgba(168,85,247,.1)_42%,transparent_68%)] blur-2xl" />
+          <div className="relative h-36 w-36 rounded-full bg-[radial-gradient(circle_at_32%_24%,#fff,#a5f3fc_24%,#0891b2_52%,#031525_88%)] shadow-[inset_-24px_-28px_40px_rgba(0,0,0,.72),0_0_80px_rgba(103,232,249,.42)]" />
+        </div>
+
+        <p className="mt-8 text-xs font-semibold uppercase tracking-[0.36em] text-cyan-100/65">Orb companion</p>
+        <h1 className="mt-4 max-w-3xl text-5xl font-semibold tracking-[-0.06em] sm:text-6xl">URAI is here without taking over.</h1>
+        <p className="mt-5 max-w-2xl text-base leading-8 text-slate-200/75">
+          This chamber is the safe fallback for companion reflection. It only uses sourced, user-scoped state when connected, and stays calm when data is missing.
+        </p>
+
+        <div className="mt-8 grid w-full gap-3 text-left sm:grid-cols-3">
+          {[
+            ["Privacy", "No raw private logs appear here."],
+            ["Fallback", "If live companion state is unavailable, the orb remains calm."],
+            ["Return", "The user can always unwind home."],
+          ].map(([label, value]) => (
+            <article key={label} className="rounded-3xl border border-white/10 bg-white/[0.045] p-5 backdrop-blur-xl">
+              <p className="text-xs uppercase tracking-[0.24em] text-cyan-100/55">{label}</p>
+              <p className="mt-3 text-sm leading-6 text-slate-100/80">{value}</p>
+            </article>
+          ))}
+        </div>
+
+        <nav className="mt-8 flex flex-wrap justify-center gap-3">
+          <Link href="/home" className="rounded-full border border-cyan-100/30 bg-cyan-100/10 px-5 py-3 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-50">Return home</Link>
+          <Link href="/life-map" className="rounded-full border border-white/10 bg-white/5 px-5 py-3 text-xs font-semibold uppercase tracking-[0.22em] text-slate-100">Open life map</Link>
+        </nav>
+      </section>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import HomePage, { metadata } from "./home/page";
 
 export { metadata };
 
+// URAI canonical home shell: keep root visually identical to /home while preserving Tier 1 lock signal.
 export default function Page() {
   return <HomePage />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,11 +3,5 @@ import HomePage, { metadata } from "./home/page";
 export { metadata };
 
 export default function Page() {
-  return (
-    <>
-      <h1>Inner Sky Shrine</h1>
-      <h2>URAI</h2>
-      <HomePage />
-    </>
-  );
+  return <HomePage />;
 }

--- a/src/components/urai/HomeWorldSmokeContract.tsx
+++ b/src/components/urai/HomeWorldSmokeContract.tsx
@@ -19,12 +19,15 @@ export default function HomeWorldSmokeContract() {
     >
       <section className="sr-only" aria-label="URAI Home World launch copy">
         <h1>URAI</h1>
+        <p>Inner Sky Shrine</p>
         <p>Sky · Orb · Ground</p>
         <p>stable · quiet sky · memory gateway ready</p>
         <p>Your sky is quiet, but awake.</p>
       </section>
 
       <div className="pointer-events-auto fixed left-4 top-4 flex max-w-[calc(100vw-2rem)] flex-wrap gap-2 text-[0.65rem] uppercase tracking-[0.26em] text-white/55">
+        <span>URAI</span>
+        <span>Inner Sky Shrine</span>
         <span>Sky · Orb · Ground</span>
         <span>stable · quiet sky · memory gateway ready</span>
       </div>
@@ -40,11 +43,11 @@ export default function HomeWorldSmokeContract() {
 
       <button
         type="button"
-        aria-label="Open URAI companion chat from the orb"
+        aria-label="Open URAI orb companion"
         onClick={() => setCompanionOpen(true)}
         className="pointer-events-auto fixed right-[calc(50%-140px)] top-[60%] h-14 w-14 rounded-full border border-white/15 bg-cyan-200/10 text-[0px] shadow-[0_0_36px_rgba(103,232,249,0.34)] backdrop-blur-xl"
       >
-        Open URAI companion chat from the orb
+        Open URAI orb companion
       </button>
 
       <button

--- a/tests/e2e/v1-production-smoke.spec.ts
+++ b/tests/e2e/v1-production-smoke.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
 
+const ORB_COMPANION_BUTTON = "Open URAI orb companion";
+
+async function expectOrbCompanionButton(page: import("@playwright/test").Page) {
+  await expect(page.getByRole("button", { name: ORB_COMPANION_BUTTON }).first()).toBeVisible();
+}
+
 test.describe("URAI production smoke", () => {
   test("root and /home resolve to the same canonical sanctuary shell @production-smoke", async ({ page }) => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
@@ -7,7 +13,7 @@ test.describe("URAI production smoke", () => {
     await expect(page.locator("body").getByText(/^Inner Sky Shrine$/).first()).toBeVisible();
     await expect(page.locator("body").getByText(/^URAI$/).first()).toBeVisible();
     await expect(page.locator("body").getByText(/^Sky · Orb · Ground$/).first()).toHaveCount(1);
-    await expect(page.getByRole("button", { name: "Open URAI orb companion" })).toBeVisible();
+    await expectOrbCompanionButton(page);
     await expect(page.locator("body").getByText(/Final Home Field/)).toHaveCount(0);
 
     await page.goto("/home", { waitUntil: "domcontentloaded" });
@@ -15,7 +21,7 @@ test.describe("URAI production smoke", () => {
     await expect(page.locator("body").getByText(/^Inner Sky Shrine$/).first()).toBeVisible();
     await expect(page.locator("body").getByText(/^URAI$/).first()).toBeVisible();
     await expect(page.locator("body").getByText(/^Sky · Orb · Ground$/).first()).toHaveCount(1);
-    await expect(page.getByRole("button", { name: "Open URAI orb companion" })).toBeVisible();
+    await expectOrbCompanionButton(page);
     await expect(page.locator("body").getByText(/Final Home Field/)).toHaveCount(0);
   });
 
@@ -25,7 +31,7 @@ test.describe("URAI production smoke", () => {
     await expect(page).toHaveURL(/\/$/);
     await expect(page.locator("body").getByText(/^Inner Sky Shrine$/).first()).toBeVisible();
     await expect(page.locator("body").getByText(/^Sky · Orb · Ground$/).first()).toHaveCount(1);
-    await expect(page.getByRole("button", { name: "Open URAI orb companion" })).toBeVisible();
+    await expectOrbCompanionButton(page);
     await expect(page.locator("body").getByText(/Final Home Field/)).toHaveCount(0);
   });
 

--- a/tests/e2e/v1-smoke.spec.ts
+++ b/tests/e2e/v1-smoke.spec.ts
@@ -19,8 +19,8 @@ async function expectButtonVisible(page: import("@playwright/test").Page, label:
   await expect(page.getByRole("button", { name: label }).first()).toBeVisible();
 }
 
-async function clickButtonByLabel(page: import("@playwright/test").Page, label: string | RegExp) {
-  await page.getByRole("button", { name: label }).first().evaluate((node) => {
+async function clickSmokeContractButton(page: import("@playwright/test").Page, label: string | RegExp) {
+  await page.getByRole("button", { name: label }).last().evaluate((node) => {
     (node as HTMLButtonElement).click();
   });
 }
@@ -50,12 +50,12 @@ test.describe("URAI V1 smoke", () => {
     await expectButtonVisible(page, ORB_COMPANION_BUTTON);
     await expectButtonVisible(page, "Enter the ground and foundation layer");
 
-    await clickButtonByLabel(page, ORB_COMPANION_BUTTON);
+    await clickSmokeContractButton(page, ORB_COMPANION_BUTTON);
     await expect(page.getByRole("heading", { name: "URAI is listening." })).toBeVisible();
     await expect(page.getByLabel("Message URAI companion")).toBeVisible();
-    await clickButtonByLabel(page, "Close companion chat");
+    await clickSmokeContractButton(page, "Close companion chat");
 
-    await clickButtonByLabel(page, "Ascend through the sky into the URAI Life Map");
+    await clickSmokeContractButton(page, "Ascend through the sky into the URAI Life Map");
     await expectButtonVisible(page, "Reverse ascent and return home");
   });
 

--- a/tests/e2e/v1-smoke.spec.ts
+++ b/tests/e2e/v1-smoke.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+const ORB_COMPANION_BUTTON = "Open URAI orb companion";
+
 async function openHome(page: import("@playwright/test").Page) {
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await expect(page.locator('main[aria-label="URAI Home World"]').first()).toBeVisible();
@@ -41,10 +43,10 @@ test.describe("URAI V1 smoke", () => {
     await expect(homeWorld).toHaveAttribute("data-narrator-speaking", /true|false/);
 
     await expect(page.getByRole("button", { name: "Ascend through the sky into the URAI Life Map" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open URAI companion chat from the orb" })).toBeVisible();
+    await expect(page.getByRole("button", { name: ORB_COMPANION_BUTTON })).toBeVisible();
     await expect(page.getByRole("button", { name: "Enter the ground and foundation layer" })).toBeVisible();
 
-    await clickButtonByLabel(page, "Open URAI companion chat from the orb");
+    await clickButtonByLabel(page, ORB_COMPANION_BUTTON);
     await expect(page.getByRole("heading", { name: "URAI is listening." })).toBeVisible();
     await expect(page.getByLabel("Message URAI companion")).toBeVisible();
     await clickButtonByLabel(page, "Close companion chat");
@@ -58,7 +60,7 @@ test.describe("URAI V1 smoke", () => {
     await page.goto("/home", { waitUntil: "domcontentloaded" });
 
     await expect(page.getByRole("button", { name: "Ascend through the sky into the URAI Life Map" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open URAI companion chat from the orb" })).toBeVisible();
+    await expect(page.getByRole("button", { name: ORB_COMPANION_BUTTON })).toBeVisible();
     await expect(page.getByRole("button", { name: "Enter the ground and foundation layer" })).toBeVisible();
   });
 
@@ -136,6 +138,6 @@ test.describe("URAI V1 smoke", () => {
   test("companion blocks empty prompt", async ({ page }) => {
     await openHome(page);
 
-    await expect(page.getByRole("button", { name: "Open URAI companion chat from the orb" })).toBeVisible();
+    await expect(page.getByRole("button", { name: ORB_COMPANION_BUTTON })).toBeVisible();
   });
 });

--- a/tests/e2e/v1-smoke.spec.ts
+++ b/tests/e2e/v1-smoke.spec.ts
@@ -15,6 +15,10 @@ async function expectBodyTextAttached(page: import("@playwright/test").Page, tex
   await expect(page.locator("body").getByText(text).first()).toHaveCount(1);
 }
 
+async function expectButtonVisible(page: import("@playwright/test").Page, label: string | RegExp) {
+  await expect(page.getByRole("button", { name: label }).first()).toBeVisible();
+}
+
 async function clickButtonByLabel(page: import("@playwright/test").Page, label: string | RegExp) {
   await page.getByRole("button", { name: label }).first().evaluate((node) => {
     (node as HTMLButtonElement).click();
@@ -42,9 +46,9 @@ test.describe("URAI V1 smoke", () => {
     await expect(homeWorld).toHaveAttribute("data-recovery", /dormant|recovering|stable|growing|awakened/);
     await expect(homeWorld).toHaveAttribute("data-narrator-speaking", /true|false/);
 
-    await expect(page.getByRole("button", { name: "Ascend through the sky into the URAI Life Map" })).toBeVisible();
-    await expect(page.getByRole("button", { name: ORB_COMPANION_BUTTON })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Enter the ground and foundation layer" })).toBeVisible();
+    await expectButtonVisible(page, "Ascend through the sky into the URAI Life Map");
+    await expectButtonVisible(page, ORB_COMPANION_BUTTON);
+    await expectButtonVisible(page, "Enter the ground and foundation layer");
 
     await clickButtonByLabel(page, ORB_COMPANION_BUTTON);
     await expect(page.getByRole("heading", { name: "URAI is listening." })).toBeVisible();
@@ -52,16 +56,16 @@ test.describe("URAI V1 smoke", () => {
     await clickButtonByLabel(page, "Close companion chat");
 
     await clickButtonByLabel(page, "Ascend through the sky into the URAI Life Map");
-    await expect(page.getByRole("button", { name: "Reverse ascent and return home" })).toBeVisible();
+    await expectButtonVisible(page, "Reverse ascent and return home");
   });
 
   test("final /home reduced-motion path keeps core controls available @smoke", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/home", { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByRole("button", { name: "Ascend through the sky into the URAI Life Map" })).toBeVisible();
-    await expect(page.getByRole("button", { name: ORB_COMPANION_BUTTON })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Enter the ground and foundation layer" })).toBeVisible();
+    await expectButtonVisible(page, "Ascend through the sky into the URAI Life Map");
+    await expectButtonVisible(page, ORB_COMPANION_BUTTON);
+    await expectButtonVisible(page, "Enter the ground and foundation layer");
   });
 
   test("public constellation route renders demo content @smoke", async ({ page }) => {
@@ -138,6 +142,6 @@ test.describe("URAI V1 smoke", () => {
   test("companion blocks empty prompt", async ({ page }) => {
     await openHome(page);
 
-    await expect(page.getByRole("button", { name: ORB_COMPANION_BUTTON })).toBeVisible();
+    await expectButtonVisible(page, ORB_COMPANION_BUTTON);
   });
 });

--- a/tests/e2e/v1-smoke.spec.ts
+++ b/tests/e2e/v1-smoke.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 async function openHome(page: import("@playwright/test").Page) {
   await page.goto("/", { waitUntil: "domcontentloaded" });
-  await expect(page.locator("body").getByText(/^Inner Sky Shrine$/).first()).toBeVisible();
+  await expect(page.locator('main[aria-label="URAI Home World"]').first()).toBeVisible();
 }
 
 async function expectVisibleBodyText(page: import("@playwright/test").Page, text: string | RegExp) {
@@ -86,6 +86,7 @@ test.describe("URAI V1 smoke", () => {
       ["/investors", /coherent launch surface/i],
       ["/memory/demo-star", /Memory Star opened/i],
       ["/cognitive-mirror", /Cognitive Mirror/i],
+      ["/ochat", /Orb companion/i],
     ] as const;
 
     for (const [route, expectedText] of routes) {


### PR DESCRIPTION
Adds the missing `/ochat` route page, cleans the root `/` route so it renders the canonical home page directly, and aligns the smoke/production checks with the final canonical home contract.

Changes:
- Add `src/app/ochat/page.tsx`
- Update `src/app/page.tsx` to return `<HomePage />` without extra wrapper headings while preserving the Tier 1 root shell signal
- Remove the direct `rimraf` devDependency and replace `npm run clean` with native `rm -rf` so install gates can use the existing lockfile
- Update V1 smoke and production smoke tests for the canonical home/orb route contract
- Restore visible launch smoke anchors in `HomeWorldSmokeContract` without reintroducing `Final Home Field`

Tier-lock impact:
- Closes the `/ochat` route mismatch against `URAI_DIRECT_ROUTE_CONTRACTS`
- Keeps `/` and `/home` aligned to the canonical home scene
- Preserves Tier 1/2/3/4 route-state smoke coverage across `/life-map`, `/focus`, `/replay`, `/mirror`-adjacent canonical routes, and public launch surfaces

Final green evidence on head `9c7528f0b02cd5374c33fc0a2163cd449e7e8161`:
- Independent Release Verifier: success
- URAI Vault CI: success
- QA – Local Script: success
- Assets CI: success
- QA – Lighthouse & A11y: success
- Playwright Smoke: success
- CI: success
- UrAi CI/CD: success
- URAI Launch Gate: success