### PR TITLE
Strengthen package lockfile drift check

### DIFF
--- a/docs/LOCKFILE_REFRESH.md
+++ b/docs/LOCKFILE_REFRESH.md
@@ -1,13 +1,19 @@
 # Lockfile Refresh Requirement
 
-`package.json` has changed to add production/build dependencies:
+`package.json` has changed and the checked-in `package-lock.json` must be regenerated before CI should return to deterministic `npm ci` installs.
 
-- `firebase-admin`
-- `tailwindcss`
-- `postcss`
-- `autoprefixer`
+## Current validation behavior
 
-The checked-in `package-lock.json` must be regenerated before CI should return to `npm ci`.
+`npm run check:lockfile` now performs two checks:
+
+1. Confirms every root `dependencies` and `devDependencies` entry from `package.json` exists in the lockfile root package.
+2. Runs:
+
+```bash
+npm ci --dry-run --ignore-scripts --no-audit --no-fund
+```
+
+The dry run catches version and nested dependency drift that a root-name-only check can miss.
 
 ## Refresh steps
 
@@ -15,6 +21,7 @@ Run locally from the repo root:
 
 ```bash
 npm install
+npm run check:lockfile
 npm run seed:demo
 npm run test:unit
 npm run check:types
@@ -31,7 +38,7 @@ git commit -m "Refresh package lockfile"
 
 ## CI note
 
-`.github/workflows/ci.yml` temporarily uses `npm install` so dependency changes do not fail only because the lockfile is stale.
+CI workflows temporarily use `npm install` so dependency changes do not fail only because the lockfile is stale.
 
 After `package-lock.json` is refreshed and committed, update CI back to:
 
@@ -39,4 +46,4 @@ After `package-lock.json` is refreshed and committed, update CI back to:
 - run: npm ci
 ```
 
-This restores deterministic dependency installs for CI.
+Only restore `npm ci` after `npm run check:lockfile` passes from a clean checkout. This restores deterministic dependency installs for CI.

--- a/scripts/check-lockfile.mjs
+++ b/scripts/check-lockfile.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { spawnSync } from "node:child_process";
 
 const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
 const lockJson = JSON.parse(fs.readFileSync("package-lock.json", "utf8"));
@@ -22,4 +23,30 @@ if (missing.length) {
   process.exit(1);
 }
 
-console.log("package-lock.json matches package.json root dependencies.");
+const npmCi = spawnSync("npm", ["ci", "--dry-run", "--ignore-scripts", "--no-audit", "--no-fund"], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+if (npmCi.error) {
+  console.error("Unable to run `npm ci --dry-run` for lockfile validation.");
+  console.error(npmCi.error.message);
+  process.exit(1);
+}
+
+if (npmCi.status !== 0) {
+  console.error("package-lock.json is stale or incompatible with package.json.");
+  console.error("`npm ci --dry-run --ignore-scripts --no-audit --no-fund` failed.");
+  const details = [npmCi.stdout, npmCi.stderr]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  if (details) {
+    console.error("\n--- npm ci dry-run output ---");
+    console.error(details);
+  }
+  console.error("\nRun `npm install` and commit the refreshed package-lock.json.");
+  process.exit(npmCi.status || 1);
+}
+
+console.log("package-lock.json matches package.json root dependencies and passes npm ci dry-run.");


### PR DESCRIPTION
## Summary

Strengthens `npm run check:lockfile` so it catches the real stale-lockfile class that caused `npm ci` failures during launch-gate validation.

## Changes

- Keeps the existing root dependency/devDependency presence check.
- Adds `npm ci --dry-run --ignore-scripts --no-audit --no-fund` to catch version and nested dependency drift.
- Updates `docs/LOCKFILE_REFRESH.md` with the stronger validation behavior and refresh sequence.

## Validation

This PR is expected to make stale-lockfile detection more accurate. If `npm run check:lockfile` fails before the lockfile refresh lands, that is the desired signal: `package-lock.json` still needs regeneration before workflows can return to `npm ci`.