### PR TITLE
Simplify URAI public entry

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,41 @@
-import HomePage, { metadata } from "./home/page";
+import Link from "next/link";
 
-export { metadata };
+export const metadata = {
+  title: "URAI | Give it one memory",
+  description: "Give URAI one memory and watch it become a living world."
+};
 
 export default function Page() {
   return (
-    <>
-      <h1>Inner Sky Shrine</h1>
-      <h2>URAI</h2>
-      <HomePage />
-    </>
+    <main className="urai-entry-shell">
+      <section className="entry-card" aria-labelledby="urai-entry-title">
+        <p className="eyebrow">URAI</p>
+        <h1 id="urai-entry-title">Give URAI one memory. Watch it become a world.</h1>
+        <p className="lede">
+          Start with a thought, moment, dream, voice-note transcript, or scene from your life.
+          URAI turns it into the first piece of a living cinematic world.
+        </p>
+        <div className="actions" aria-label="Start URAI">
+          <Link className="primary" href="/start">Start</Link>
+          <Link className="secondary" href="/home">Enter existing world</Link>
+        </div>
+        <p className="note">No giant setup. No explanation wall. Add one piece of life and let the world reveal itself.</p>
+      </section>
+      <div className="ambient ambient-one" aria-hidden="true" />
+      <div className="ambient ambient-two" aria-hidden="true" />
+      <style>{styles}</style>
+    </main>
   );
 }
+
+const styles = `
+  .urai-entry-shell{min-height:100dvh;display:grid;place-items:center;overflow:hidden;position:relative;background:radial-gradient(circle at 50% 20%,rgba(103,232,249,.18),transparent 34%),radial-gradient(circle at 15% 70%,rgba(168,85,247,.16),transparent 34%),linear-gradient(180deg,#020617,#030712 58%,#000);color:white;padding:24px;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+  .entry-card{position:relative;z-index:2;width:min(720px,100%);border:1px solid rgba(255,255,255,.13);border-radius:32px;background:rgba(2,6,23,.62);box-shadow:0 28px 120px rgba(0,0,0,.42),inset 0 1px 0 rgba(255,255,255,.08);backdrop-filter:blur(24px);padding:clamp(28px,7vw,72px);text-align:left}
+  .eyebrow{margin:0 0 16px;color:rgba(125,211,252,.9);font-size:.78rem;font-weight:800;letter-spacing:.28em;text-transform:uppercase}
+  h1{margin:0;max-width:680px;font-size:clamp(2.55rem,8.5vw,5.8rem);line-height:.9;letter-spacing:-.075em;text-wrap:balance}
+  .lede{margin:24px 0 0;max-width:590px;color:rgba(226,232,240,.78);font-size:clamp(1.02rem,2vw,1.24rem);line-height:1.6}
+  .actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:34px}.actions a{display:inline-flex;align-items:center;justify-content:center;min-height:52px;border-radius:999px;padding:0 22px;text-decoration:none;font-weight:800;transition:transform .18s ease,border-color .18s ease,background .18s ease}.actions a:hover{transform:translateY(-1px)}
+  .primary{background:white;color:#020617;box-shadow:0 16px 50px rgba(255,255,255,.16)}.secondary{border:1px solid rgba(255,255,255,.16);color:rgba(255,255,255,.9);background:rgba(255,255,255,.05)}
+  .note{margin:22px 0 0;max-width:520px;color:rgba(148,163,184,.8);font-size:.95rem;line-height:1.55}.ambient{position:absolute;border-radius:999px;filter:blur(80px);opacity:.38;pointer-events:none}.ambient-one{width:360px;height:360px;right:-110px;top:12%;background:rgba(56,189,248,.38)}.ambient-two{width:420px;height:420px;left:-130px;bottom:2%;background:rgba(192,132,252,.26)}
+  @media(max-width:640px){.entry-card{border-radius:24px}.actions{display:grid}.actions a{width:100%}}
+`;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,32 @@
 import Link from "next/link";
+import { encodeScene, generateScene, type SceneVibe } from "@/lib/scene-generator";
 
 export const metadata = {
   title: "URAI | Give it one memory",
   description: "Give URAI one memory and watch it become a living world."
 };
 
-export default function Page() {
+type PageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseVibe(value: string | undefined): SceneVibe {
+  if (value === "calm" || value === "strange" || value === "dark" || value === "hopeful") return value;
+  return "cinematic";
+}
+
+export default async function Page({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const memory = firstParam(params?.memory) ?? "";
+  const vibe = parseVibe(firstParam(params?.vibe));
+  const hasScene = memory.trim().length > 0;
+  const scene = generateScene(memory, vibe);
+  const shareId = encodeScene({ ...scene, id: "share" });
+
   return (
     <main className="urai-entry-shell">
       <section className="entry-card" aria-labelledby="urai-entry-title">
@@ -15,12 +36,32 @@ export default function Page() {
           Start with a thought, moment, dream, voice-note transcript, or scene from your life.
           URAI turns it into the first piece of a living cinematic world.
         </p>
-        <div className="actions" aria-label="Start URAI">
-          <Link className="primary" href="/start">Start</Link>
+        <form className="memory-form" action="/" aria-label="Create a URAI scene">
+          <label htmlFor="memory">One memory</label>
+          <textarea id="memory" name="memory" rows={5} maxLength={900} placeholder="Example: I moved to a new city and started rebuilding my life." defaultValue={memory} />
+          <label htmlFor="vibe">Vibe</label>
+          <select id="vibe" name="vibe" defaultValue={vibe}>
+            <option value="cinematic">cinematic</option>
+            <option value="calm">calm</option>
+            <option value="strange">strange</option>
+            <option value="dark">dark</option>
+            <option value="hopeful">hopeful</option>
+          </select>
+          <button className="primary" type="submit">Create scene</button>
+        </form>
+        <div className="actions" aria-label="URAI links">
           <Link className="secondary" href="/home">Enter existing world</Link>
         </div>
-        <p className="note">No giant setup. No explanation wall. Add one piece of life and let the world reveal itself.</p>
+        <p className="note">No giant setup. Add one piece of life and let the world reveal itself.</p>
       </section>
+      <aside className={`scene-card ${hasScene ? "is-ready" : ""}`} aria-live="polite">
+        <p className="eyebrow">{hasScene ? "Your first scene" : "Preview"}</p>
+        <h2>{scene.title}</h2>
+        <p>{scene.atmosphere}</p>
+        <p>{scene.world}</p>
+        <blockquote>{scene.narratorLine}</blockquote>
+        {hasScene ? <Link className="primary" href={`/share/${shareId}`}>Open share scene</Link> : <span className="disabled-link">Add a memory to create the scene.</span>}
+      </aside>
       <div className="ambient ambient-one" aria-hidden="true" />
       <div className="ambient ambient-two" aria-hidden="true" />
       <style>{styles}</style>
@@ -29,13 +70,12 @@ export default function Page() {
 }
 
 const styles = `
-  .urai-entry-shell{min-height:100dvh;display:grid;place-items:center;overflow:hidden;position:relative;background:radial-gradient(circle at 50% 20%,rgba(103,232,249,.18),transparent 34%),radial-gradient(circle at 15% 70%,rgba(168,85,247,.16),transparent 34%),linear-gradient(180deg,#020617,#030712 58%,#000);color:white;padding:24px;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
-  .entry-card{position:relative;z-index:2;width:min(720px,100%);border:1px solid rgba(255,255,255,.13);border-radius:32px;background:rgba(2,6,23,.62);box-shadow:0 28px 120px rgba(0,0,0,.42),inset 0 1px 0 rgba(255,255,255,.08);backdrop-filter:blur(24px);padding:clamp(28px,7vw,72px);text-align:left}
+  .urai-entry-shell{min-height:100dvh;display:grid;grid-template-columns:minmax(320px,720px) minmax(300px,520px);gap:20px;align-items:center;justify-content:center;overflow:hidden;position:relative;background:radial-gradient(circle at 50% 20%,rgba(103,232,249,.18),transparent 34%),radial-gradient(circle at 15% 70%,rgba(168,85,247,.16),transparent 34%),linear-gradient(180deg,#020617,#030712 58%,#000);color:white;padding:24px;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+  .entry-card,.scene-card{position:relative;z-index:2;border:1px solid rgba(255,255,255,.13);border-radius:32px;background:rgba(2,6,23,.62);box-shadow:0 28px 120px rgba(0,0,0,.42),inset 0 1px 0 rgba(255,255,255,.08);backdrop-filter:blur(24px);padding:clamp(28px,6vw,58px);text-align:left}.scene-card{display:flex;flex-direction:column;gap:16px;min-height:420px;justify-content:center}.scene-card.is-ready{border-color:rgba(125,211,252,.32)}
   .eyebrow{margin:0 0 16px;color:rgba(125,211,252,.9);font-size:.78rem;font-weight:800;letter-spacing:.28em;text-transform:uppercase}
-  h1{margin:0;max-width:680px;font-size:clamp(2.55rem,8.5vw,5.8rem);line-height:.9;letter-spacing:-.075em;text-wrap:balance}
-  .lede{margin:24px 0 0;max-width:590px;color:rgba(226,232,240,.78);font-size:clamp(1.02rem,2vw,1.24rem);line-height:1.6}
-  .actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:34px}.actions a{display:inline-flex;align-items:center;justify-content:center;min-height:52px;border-radius:999px;padding:0 22px;text-decoration:none;font-weight:800;transition:transform .18s ease,border-color .18s ease,background .18s ease}.actions a:hover{transform:translateY(-1px)}
-  .primary{background:white;color:#020617;box-shadow:0 16px 50px rgba(255,255,255,.16)}.secondary{border:1px solid rgba(255,255,255,.16);color:rgba(255,255,255,.9);background:rgba(255,255,255,.05)}
-  .note{margin:22px 0 0;max-width:520px;color:rgba(148,163,184,.8);font-size:.95rem;line-height:1.55}.ambient{position:absolute;border-radius:999px;filter:blur(80px);opacity:.38;pointer-events:none}.ambient-one{width:360px;height:360px;right:-110px;top:12%;background:rgba(56,189,248,.38)}.ambient-two{width:420px;height:420px;left:-130px;bottom:2%;background:rgba(192,132,252,.26)}
-  @media(max-width:640px){.entry-card{border-radius:24px}.actions{display:grid}.actions a{width:100%}}
+  h1{margin:0;max-width:680px;font-size:clamp(2.55rem,8vw,5.35rem);line-height:.9;letter-spacing:-.075em;text-wrap:balance}h2{margin:0;font-size:clamp(1.7rem,3vw,2.7rem);line-height:1;letter-spacing:-.05em}.lede{margin:24px 0 0;max-width:590px;color:rgba(226,232,240,.78);font-size:clamp(1.02rem,2vw,1.18rem);line-height:1.6}.scene-card p{margin:0;color:rgba(226,232,240,.75);line-height:1.6}.scene-card blockquote{margin:4px 0 0;border-left:3px solid rgba(125,211,252,.72);padding-left:16px;color:white;line-height:1.55}
+  .memory-form{display:grid;gap:12px;margin-top:28px}.memory-form label{color:rgba(226,232,240,.88);font-size:.82rem;font-weight:850;letter-spacing:.05em}.memory-form textarea,.memory-form select{border:1px solid rgba(255,255,255,.14);border-radius:18px;background:rgba(15,23,42,.72);color:white;padding:14px 16px;font:inherit;line-height:1.5;outline:none}.memory-form textarea:focus,.memory-form select:focus{border-color:rgba(125,211,252,.58);box-shadow:0 0 0 4px rgba(125,211,252,.08)}
+  .actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:18px}.primary,.secondary,.disabled-link{display:inline-flex;align-items:center;justify-content:center;min-height:52px;border-radius:999px;padding:0 22px;text-decoration:none;font-weight:800;transition:transform .18s ease,border-color .18s ease,background .18s ease;border:0}.primary{background:white;color:#020617;box-shadow:0 16px 50px rgba(255,255,255,.16);cursor:pointer}.secondary{border:1px solid rgba(255,255,255,.16);color:rgba(255,255,255,.9);background:rgba(255,255,255,.05)}.disabled-link{background:rgba(255,255,255,.08);color:rgba(226,232,240,.62)}.primary:hover,.secondary:hover{transform:translateY(-1px)}
+  .note{margin:20px 0 0;max-width:520px;color:rgba(148,163,184,.8);font-size:.95rem;line-height:1.55}.ambient{position:absolute;border-radius:999px;filter:blur(80px);opacity:.38;pointer-events:none}.ambient-one{width:360px;height:360px;right:-110px;top:12%;background:rgba(56,189,248,.38)}.ambient-two{width:420px;height:420px;left:-130px;bottom:2%;background:rgba(192,132,252,.26)}
+  @media(max-width:980px){.urai-entry-shell{grid-template-columns:1fr}.entry-card,.scene-card{border-radius:24px}.actions{display:grid}.actions a,.primary{width:100%}}
 `;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { encodeScene, generateScene, type SceneVibe } from "@/lib/scene-generator";
+import { generateScene, type SceneVibe } from "@/lib/scene-generator";
 
 export const metadata = {
   title: "URAI | Give it one memory",
@@ -25,7 +25,7 @@ export default async function Page({ searchParams }: PageProps) {
   const vibe = parseVibe(firstParam(params?.vibe));
   const hasScene = memory.trim().length > 0;
   const scene = generateScene(memory, vibe);
-  const shareId = encodeScene({ ...scene, id: "share" });
+  const shareHref = `/?memory=${encodeURIComponent(scene.memory)}&vibe=${scene.vibe}`;
 
   return (
     <main className="urai-entry-shell">
@@ -60,7 +60,7 @@ export default async function Page({ searchParams }: PageProps) {
         <p>{scene.atmosphere}</p>
         <p>{scene.world}</p>
         <blockquote>{scene.narratorLine}</blockquote>
-        {hasScene ? <Link className="primary" href={`/share/${shareId}`}>Open share scene</Link> : <span className="disabled-link">Add a memory to create the scene.</span>}
+        {hasScene ? <Link className="primary" href={shareHref}>Share this scene</Link> : <span className="disabled-link">Add a memory to create the scene.</span>}
       </aside>
       <div className="ambient ambient-one" aria-hidden="true" />
       <div className="ambient ambient-two" aria-hidden="true" />

--- a/src/lib/scene-generator.ts
+++ b/src/lib/scene-generator.ts
@@ -1,0 +1,112 @@
+export type SceneVibe = "cinematic" | "calm" | "strange" | "dark" | "hopeful";
+
+export type GeneratedScene = {
+  id: string;
+  memory: string;
+  vibe: SceneVibe;
+  title: string;
+  atmosphere: string;
+  world: string;
+  narratorLine: string;
+  nextPrompt: string;
+  posterPrompt: string;
+};
+
+const VIBE_COPY: Record<SceneVibe, { atmosphere: string; lens: string; light: string }> = {
+  cinematic: {
+    atmosphere: "wide, luminous, and cinematic",
+    lens: "a slow tracking shot with emotional scale",
+    light: "blue-gold light cutting through soft haze"
+  },
+  calm: {
+    atmosphere: "quiet, grounded, and breathable",
+    lens: "a still frame that lets the moment settle",
+    light: "warm window light and slow moving shadows"
+  },
+  strange: {
+    atmosphere: "surreal, symbolic, and half-dreamed",
+    lens: "a drifting camera moving through impossible architecture",
+    light: "violet reflections, floating dust, and bent neon"
+  },
+  dark: {
+    atmosphere: "heavy, intimate, and storm-lit",
+    lens: "a close handheld scene with pressure under the surface",
+    light: "low contrast light, rain shine, and a distant amber glow"
+  },
+  hopeful: {
+    atmosphere: "open, rebuilding, and quietly triumphant",
+    lens: "a rising shot from ground level into a wider world",
+    light: "sunrise color, clean air, and reflective glass"
+  }
+};
+
+function normalizeMemory(memory: string) {
+  return memory.replace(/\s+/g, " ").trim().slice(0, 900);
+}
+
+function titleFromMemory(memory: string, vibe: SceneVibe) {
+  const clean = normalizeMemory(memory);
+  const firstClause = clean.split(/[.!?;:]/)[0]?.trim() || "A memory becomes visible";
+  const short = firstClause.length > 58 ? `${firstClause.slice(0, 55).trim()}...` : firstClause;
+  const prefixes: Record<SceneVibe, string> = {
+    cinematic: "The Scene Where",
+    calm: "The Quiet Place Where",
+    strange: "The Door That Remembered",
+    dark: "The Room Beneath",
+    hopeful: "The World After"
+  };
+  return `${prefixes[vibe]} ${short.charAt(0).toLowerCase()}${short.slice(1)}`;
+}
+
+function base64UrlEncode(value: string) {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "utf8").toString("base64url");
+  }
+  if (typeof window !== "undefined") {
+    return window.btoa(unescape(encodeURIComponent(value))).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  }
+  return encodeURIComponent(value);
+}
+
+export function decodeSceneId(id: string): GeneratedScene | null {
+  try {
+    const normalized = id.replace(/-/g, "+").replace(/_/g, "/");
+    const json = typeof Buffer !== "undefined"
+      ? Buffer.from(normalized, "base64").toString("utf8")
+      : decodeURIComponent(escape(window.atob(normalized)));
+    const parsed = JSON.parse(json) as GeneratedScene;
+    if (!parsed?.memory || !parsed?.title) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function encodeScene(scene: GeneratedScene) {
+  return base64UrlEncode(JSON.stringify(scene));
+}
+
+export function generateScene(memoryInput: string, vibe: SceneVibe = "cinematic"): GeneratedScene {
+  const memory = normalizeMemory(memoryInput) || "A person gives URAI one small piece of their life and watches it become visible.";
+  const copy = VIBE_COPY[vibe];
+  const title = titleFromMemory(memory, vibe);
+  const atmosphere = `The scene feels ${copy.atmosphere}: ${copy.light}.`;
+  const world = `URAI treats this memory like the first room of an autonomous world. The environment forms around the emotional center of the moment, then leaves space for the next memory to expand the place, the characters, and the story.`;
+  const narratorLine = `This is where your life stops being a note and starts becoming a world.`;
+  const nextPrompt = "Add another memory to grow the world.";
+  const posterPrompt = `Poster still for a personal cinematic world: ${memory}. ${copy.lens}, ${copy.light}, intimate scale, atmospheric detail, no text.`;
+
+  return {
+    id: "draft",
+    memory,
+    vibe,
+    title,
+    atmosphere,
+    world,
+    narratorLine,
+    nextPrompt,
+    posterPrompt
+  };
+}
+
+export const SCENE_VIBES: SceneVibe[] = ["cinematic", "calm", "strange", "dark", "hopeful"];


### PR DESCRIPTION
## Summary

- Replace root page with a simple memory-to-world entry flow.
- Add deterministic scene generation.
- Keep `/home` as the deeper existing world view.
- Use the root URL query params as the lightweight share link for now.

## QA

- Open `/`.
- Enter a memory.
- Submit the form.
- Confirm a scene appears.
- Click the share button.
- Confirm the scene reloads from the URL.
- Confirm `/home` still opens.