### PR TITLE
Add V1 public surface evidence docs

### DIFF
--- a/docs/URAI_CANONICAL_PUBLIC_SURFACE.md
+++ b/docs/URAI_CANONICAL_PUBLIC_SURFACE.md
@@ -1,0 +1,43 @@
+# URAI Canonical Public Launch Surface
+
+Status: canonical public-surface decision recorded
+Date: 2026-05-22
+Owner: Adam Clamp
+Related issue: #300
+
+## Decision
+
+URAI V1 launches as the memory-world public demo surface.
+
+- Canonical root surface: `/`
+- Existing world/deeper shrine surface: `/home`
+- Public demo constellation: `/u/adamclamp`
+- Companion API smoke surface: `/api/companion`
+- Waitlist API smoke surface: `/api/waitlist`
+- Spatial preview surface: `/spatial`
+- Spatial health surface: `/api/spatial/health`
+
+## Public routing rule
+
+The public root must not be a Spatial-only shell for V1. The root should introduce the memory-to-world product promise and route users into the home/world experience.
+
+Spatial remains visible as a preview layer at `/spatial`, but it is not the V1 production claim and must not be marketed as a complete AR/VR or production Spatial system until independent Spatial evidence exists.
+
+## Claim boundaries
+
+Public V1 copy must avoid claims that are not backed by deployed evidence:
+
+- no health or diagnosis claims
+- no passive sensing claims unless opt-in data collection is live and reviewed
+- no marketplace, data-sale, or revenue-share claims
+- no AR/VR production claims
+- no enterprise-live or B2B-production claims
+- no production-live claim until Issue #300 closure evidence is complete
+
+## Launch gating rule
+
+Do not broadly share the public demo until Issue #300 has a passing Production Evidence workflow comment with run URL and artifact URL, or equivalent attached deploy evidence.
+
+## Rationale
+
+The V1 repo evidence is strongest for the memory-world demo spine: root entry, `/home` shrine, public constellation, companion endpoint, waitlist endpoint, smoke tests, and release evidence workflow. Spatial is important, but it remains a preview surface unless and until `/spatial`, `/api/spatial/health`, consent/auth/rules, provider checks, and public-copy evidence are all attached.

--- a/docs/release-evidence/2026-05-22-v1-public-demo-smoke.md
+++ b/docs/release-evidence/2026-05-22-v1-public-demo-smoke.md
@@ -1,0 +1,99 @@
+# URAI V1 Public Demo Smoke Evidence
+
+Date: 2026-05-22
+Owner: Adam Clamp
+Repo: LifeLoggerAI/UrAi
+Related issue: #300
+
+## Current verdict
+
+Status: PRODUCTION BLOCKED
+
+Repo-side implementation and production-evidence workflow scaffolding exist. Closure still requires a completed Production Evidence workflow comment on Issue #300 with run URL and artifact URL.
+
+## Canonical public surface
+
+URAI V1 launches as the memory-world public demo surface.
+
+- `/` is the V1 public root.
+- `/home` is the deeper memory-world surface.
+- `/u/adamclamp` is the public demo constellation.
+- `/api/companion` is the companion smoke endpoint.
+- `/api/waitlist` is the waitlist smoke endpoint.
+- `/spatial` is a gated Spatial preview surface.
+- `/api/spatial/health` is the Spatial readiness endpoint.
+
+## Required route evidence
+
+- [ ] `/` deployed route loads.
+- [ ] `/home` deployed route follows the launch contract.
+- [ ] `/u/adamclamp` loads public-safe demo content.
+- [ ] `/api/companion` returns a safe response.
+- [ ] `/api/waitlist` handles invalid and valid submissions correctly.
+- [ ] `/spatial` loads as a preview surface.
+- [ ] `/api/spatial/health` returns readiness JSON.
+
+## Required command evidence
+
+- [ ] `npm install`
+- [ ] `npm run check:v1`
+- [ ] `npm run check:firestore-contract`
+- [ ] `npm run seed:demo`
+- [ ] `npm run test:unit`
+- [ ] `npm run check:types`
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm run preflight`
+- [ ] `npm run test:smoke`
+- [ ] `npm run test:e2e`
+- [ ] `npm run test:smoke:production`
+
+## Required deployment evidence
+
+- [ ] Firebase project confirmed.
+- [ ] Firebase Hosting URL confirmed.
+- [ ] Custom domain checked.
+- [ ] Public Firebase env values configured.
+- [ ] Admin Firebase env values configured without exposing secret material.
+- [ ] Firestore rules deployed.
+- [ ] Firestore indexes deployed.
+- [ ] Waitlist persistence verified in Firestore or dry-run mode recorded.
+
+## Required artifacts
+
+- [ ] Desktop root screenshot.
+- [ ] Mobile root screenshot.
+- [ ] Reduced-motion root screenshot.
+- [ ] Desktop public demo screenshot.
+- [ ] Mobile public demo screenshot.
+- [ ] Companion response evidence.
+- [ ] Waitlist success evidence.
+- [ ] Waitlist error evidence.
+- [ ] Production Evidence workflow artifact attached to Issue #300.
+
+## Public-copy lock
+
+- [ ] No unsupported public claims.
+- [ ] No Spatial production claim before Spatial evidence is complete.
+- [ ] No B2B production claim before B2B evidence is complete.
+- [ ] No production-live claim until Issue #300 is closed with evidence.
+
+## Privacy and operations
+
+- [ ] Privacy route or link is visible.
+- [ ] Waitlist removal path is documented.
+- [ ] Support/contact route or email is visible.
+- [ ] Error logging is available.
+- [ ] Uptime/status route is checked.
+- [ ] Rollback SHA and rollback plan are recorded.
+
+## Evidence references
+
+- Issue #300
+- `docs/URAI_POST_MERGE_DEPLOYMENT_EVIDENCE.md`
+- `docs/URAI_RELEASE_ROLLBACK_PR304.md`
+- `docs/URAI_CANONICAL_PUBLIC_SURFACE.md`
+
+## Closure rule
+
+Do not mark production complete from this file alone. Update this file only after workflow run URL, artifact URL, route smoke output, screenshots, Firebase rules/index evidence, and waitlist persistence evidence are attached.


### PR DESCRIPTION
## Summary

Adds documentation for the V1 public surface decision and a closeout evidence checklist for Issue #300.

## Notes

- Docs only.
- No app code changed.
- Issue #300 remains open until workflow and artifact evidence are attached.