### PR TITLE
fix: unify root life-map, focus, and replay routes with SpatialLifeMap runtime

### DIFF
--- a/src/app/focus/page.tsx
+++ b/src/app/focus/page.tsx
@@ -1,9 +1,10 @@
-import LifeMapUniverse from "@/components/life-map/LifeMapUniverse";
+import SpatialLifeMap from "@/components/spatial-life-map/SpatialLifeMap";
 
 export const metadata = {
-  title: "URAI Focus Chamber",
+  title: "URAI Focus",
+  description: "Focus mode inside the URAI life-map field.",
 };
 
 export default function FocusPage() {
-  return <LifeMapUniverse initialView="focus" />;
+  return <SpatialLifeMap initialMode="focus" />;
 }

--- a/src/app/life-map/page.tsx
+++ b/src/app/life-map/page.tsx
@@ -1,11 +1,11 @@
-import LifeMapUniverse from "@/components/life-map/LifeMapUniverse";
+import SpatialLifeMap from "@/components/spatial-life-map/SpatialLifeMap";
 
 export const metadata = {
-  title: "Life Map | UrAi",
+  title: "Life Map | URAI",
   description:
-    "The UrAi Life Map is a cinematic memory galaxy for reflection, recovery, purpose, emotional weather, and legacy.",
+    "The URAI Life Map is a cinematic memory galaxy for reflection, recovery, purpose, emotional weather, and legacy.",
 };
 
-export default function Page() {
-  return <LifeMapUniverse initialView="lifeMap" />;
+export default function LifeMapPage() {
+  return <SpatialLifeMap />;
 }

--- a/src/app/replay/page.tsx
+++ b/src/app/replay/page.tsx
@@ -1,9 +1,10 @@
-import LifeMapUniverse from "@/components/life-map/LifeMapUniverse";
+import SpatialLifeMap from "@/components/spatial-life-map/SpatialLifeMap";
 
 export const metadata = {
   title: "URAI Replay",
+  description: "Replay mode inside the URAI life-map field.",
 };
 
 export default function ReplayPage() {
-  return <LifeMapUniverse initialView="replay" />;
+  return <SpatialLifeMap initialMode="replay" />;
 }


### PR DESCRIPTION
## Summary
- Route `/life-map` through the same `SpatialLifeMap` runtime used by `/app/life-map`
- Route `/focus` through `SpatialLifeMap initialMode="focus"`
- Route `/replay` through `SpatialLifeMap initialMode="replay"`

## Why
- Removes split behavior between root and app route trees
- Keeps the user journey coherent from home -> ascent -> life-map -> focus -> replay in the same 3D spatial system
- Reduces risk of route-level UX divergence and duplicate interaction models

## Files changed
- `src/app/life-map/page.tsx`
- `src/app/focus/page.tsx`
- `src/app/replay/page.tsx`