### PR TITLE
Superseded: launch-validation ping before current-main quarantine

### DIFF
--- a/docs/LEGACY_PRODUCTION_DEPLOY_DISABLED.md
+++ b/docs/LEGACY_PRODUCTION_DEPLOY_DISABLED.md
@@ -4,7 +4,7 @@ Date: 2026-07-10
 
 `LifeLoggerAI/UrAi` is not authorized to deploy `https://urai.app` or the shared Firebase project `urai-4dc1d`.
 
-The canonical production authority is:
+The canonical and sole production authority is:
 
 - repository: `LifeLoggerAI/urai-spatial`
 - runtime root: `urai-tier1`

--- a/docs/launch/verification-ping.md
+++ b/docs/launch/verification-ping.md
@@ -1,0 +1,14 @@
+# URAI Launch Validation Ping
+
+This file exists to trigger the URAI Launch Verify GitHub Actions workflow after PR #367 was merged.
+
+Expected workflow: `.github/workflows/urai-launch-verify.yml`
+
+Expected checks:
+
+- `npm run check:types`
+- `npm run lint`
+- `npm run test:rules`
+- `npm run build`
+
+If the workflow does not appear on the pull request, repository Actions or GitHub App workflow permissions may need to be enabled.


### PR DESCRIPTION
## Superseded authority record

This pull request is closed unmerged.

Its only purpose was to trigger the old `URAI Launch Verify` workflow after PR #367 merged. It predates the current-main legacy quarantine and no longer provides useful or authoritative source evidence.

PR #370 now contains the materialized current-main quarantine at exact head `1f9e53088cbb81ef1c56e560cdbed514170de472` with 14/14 exact-head workflows green, including Launch Verify, Launch Gate, Production Verify, QA, CI, Vault, permanent authority denial, and WebXR/browser regressions.

No unique approved source or authority remains in this validation-ping branch. Do not reopen or merge it.