### PR TITLE
Fix UrAi CI secret condition

### DIFF
--- a/.github/workflows/urai-ci.yml
+++ b/.github/workflows/urai-ci.yml
@@ -6,15 +6,18 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
 jobs:
   ci:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -25,5 +28,5 @@ jobs:
         run: npm test
 
       - name: Validate Firebase Secrets
+        if: ${{ env.FIREBASE_TOKEN != '' }}
         run: echo "FIREBASE_TOKEN secret is present"
-        if: ${{ secrets.FIREBASE_TOKEN != '' }}


### PR DESCRIPTION
## What changed
- move `FIREBASE_TOKEN` into workflow-level `env`
- change the step condition from direct `secrets.FIREBASE_TOKEN` usage to `env.FIREBASE_TOKEN`
- update `actions/checkout` and `actions/setup-node` from v3 to v4

## Why
Current `main` CI is being rejected before any jobs are created because GitHub no longer accepts direct secret references in this `if:` expression. The latest failed check suite has zero jobs, consistent with workflow validation failure.

## Validation
- YAML parses successfully
- no `if:` clause contains `secrets.*`
- existing secret-presence behavior is preserved

This is intentionally a one-file CI-only fix.